### PR TITLE
Make tests compile, fix value encoding, shorten debug messages.

### DIFF
--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -87,10 +87,10 @@ impl<T: Clone + Debug + Send + Sync> Messaging<T> {
             .map(|_| unbounded())
             .collect();
         let to_comms_txs = to_comms.iter()
-            .map(|(tx, _)| tx.to_owned())
+            .map(|&(ref tx, _)| tx.to_owned())
             .collect();
         let to_comms_rxs: Vec<Receiver<Message<T>>> = to_comms.iter()
-            .map(|(_, rx)| rx.to_owned())
+            .map(|&(_, ref rx)| rx.to_owned())
             .collect();
         let (from_comms_tx, from_comms_rx) = unbounded();
         let to_algo: Vec<(Sender<SourcedMessage<T>>,
@@ -99,10 +99,10 @@ impl<T: Clone + Debug + Send + Sync> Messaging<T> {
             .map(|_| unbounded())
             .collect();
         let to_algo_txs = to_algo.iter()
-            .map(|(tx, _)| tx.to_owned())
+            .map(|&(ref tx, _)| tx.to_owned())
             .collect();
         let to_algo_rxs: Vec<Receiver<SourcedMessage<T>>> = to_algo.iter()
-            .map(|(_, rx)| rx.to_owned())
+            .map(|&(_, ref rx)| rx.to_owned())
             .collect();
         let (from_algo_tx, from_algo_rx) = unbounded();
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -57,7 +57,7 @@ impl<T: Clone + Debug + Hashable + PartialEq + Send + Sync
         let num_nodes = connections.len() + 1;
 
         // Initialise the message delivery system and obtain TX and RX handles.
-        let messaging: Messaging<T> = Messaging::new(num_nodes);
+        let messaging: Messaging<Vec<u8>> = Messaging::new(num_nodes);
         let to_comms_rxs = messaging.to_comms_rxs();
         let from_comms_tx = messaging.from_comms_tx();
         let to_algo_rxs = messaging.to_algo_rxs();

--- a/tests/netsim.rs
+++ b/tests/netsim.rs
@@ -18,16 +18,16 @@ pub struct NetSim<Message: Clone + Send + Sync> {
 impl<Message: Clone + Send + Sync> NetSim<Message> {
     pub fn new(num_nodes: usize) -> Self {
         assert!(num_nodes > 1);
-        // All channels of a totally conected network of size `num_nodes`.
+        // All channels of a totally connected network of size `num_nodes`.
         let channels: Vec<(Sender<Message>, Receiver<Message>)> =
             (0 .. num_nodes * num_nodes)
             .map(|_| unbounded())
             .collect();
         let txs = channels.iter()
-            .map(|(tx, _)| tx.to_owned())
+            .map(|&(ref tx, _)| tx.to_owned())
             .collect();
         let rxs = channels.iter()
-            .map(|(_, rx)| rx.to_owned())
+            .map(|&(_, ref rx)| rx.to_owned())
             .collect();
         NetSim {
             num_nodes: num_nodes,

--- a/tests/node_comms/mod.rs
+++ b/tests/node_comms/mod.rs
@@ -2,10 +2,6 @@
 //! simulated remote node through a channel. Local communication with
 //! coordinating threads is also made via a channel.
 
-extern crate hbbft;
-extern crate crossbeam;
-extern crate crossbeam_channel;
-
 use std::io;
 use std::fmt::Debug;
 use std::sync::Arc;


### PR DESCRIPTION
This adds a length byte to the values before padding with 0, so that we
can omit the padding at the end again. Shards are not converted to the
type parameter `T` anymore, because they are not necessarily valid
representations of a `T` value, e.g. valid UTF-8, as in the tests.

It also shortens some debug messages by printing byte arrays as
hexadecimal, and eliding some bytes.

One of the files in `tests` is moved to a subdirectory, so it's not considered a test target itself by cargo.