### PR TITLE
The ACS and BA algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ log = "0.4.1"
 reed-solomon-erasure = "3.0"
 merkle = { git = "https://github.com/vkomenda/merkle.rs", branch = "public-proof" }
 ring = "^0.12"
-rand = "*"
 protobuf = "1.4.4"
 crossbeam = "0.3.2"
 crossbeam-channel = "0.1"
+rand = "0.3"
 
 [build-dependencies]
 protoc-rust = "1.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ ring = "^0.12"
 protobuf = "1.4.4"
 crossbeam = "0.3.2"
 crossbeam-channel = "0.1"
-rand = "0.3"
 
 [build-dependencies]
 protoc-rust = "1.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ring = "^0.12"
 protobuf = "1.4.4"
 crossbeam = "0.3.2"
 crossbeam-channel = "0.1"
+itertools = "0.7"
 
 [build-dependencies]
 protoc-rust = "1.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ protoc-rust = "1.4.4"
 
 [dev-dependencies]
 docopt = "0.8"
+rand = "0.3"

--- a/TODO
+++ b/TODO
@@ -1,0 +1,12 @@
+TODO
+====
+
+* Fix the inappropriate use of Common Coin in the Byzantine Agreement protocol
+
+   This bug is explained in https://github.com/amiller/HoneyBadgerBFT/issues/59
+   where a solution is suggested introducing an additional type of message,
+   CONF.
+
+   There may be alternative solutions, such as using a different Byzantine
+   Agreement protocol altogether, for example,
+   https://people.csail.mit.edu/silvio/Selected%20Scientific%20Papers/Distributed%20Computation/BYZANTYNE%20AGREEMENT%20MADE%20TRIVIAL.pdf

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -45,8 +45,9 @@ message LemmaProto {
 }
 
 message AgreementProto {
+  uint32 epoch = 1;
   oneof payload {
-    bool bval = 1;
-    bool aux = 2;
+    bool bval = 2;
+    bool aux = 3;
   }
 }

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -1,53 +1,52 @@
 syntax = "proto3";
 
 message MessageProto {
-  oneof payload {
-    BroadcastProto broadcast = 1;
-    AgreementProto agreement = 2;
-  }
+    oneof payload {
+        BroadcastProto broadcast = 1;
+        AgreementProto agreement = 2;
+    }
 }
 
 message BroadcastProto {
-  oneof payload {
-    ValueProto value = 1;
-    EchoProto echo = 2;
-    ReadyProto ready = 3;
-  }
+    oneof payload {
+        ValueProto value = 1;
+        EchoProto echo = 2;
+        ReadyProto ready = 3;
+    }
 }
 
 message ValueProto {
-  ProofProto proof = 1;
+    ProofProto proof = 1;
 }
 
 message EchoProto {
-  ProofProto proof = 1;
+    ProofProto proof = 1;
 }
 
 message ReadyProto {
-  bytes root_hash = 1;
+    bytes root_hash = 1;
 }
 
 message ProofProto {
-  bytes root_hash = 1;
-  LemmaProto lemma = 2;
-  bytes value = 3;
+    bytes root_hash = 1;
+    LemmaProto lemma = 2;
+    bytes value = 3;
 }
 
 message LemmaProto {
-  bytes node_hash = 1;
-  LemmaProto sub_lemma = 2;
+    bytes node_hash = 1;
+    LemmaProto sub_lemma = 2;
 
-  oneof sibling_hash {
-    bytes left_sibling_hash = 3;
-    bytes right_sibling_hash = 4;
-  }
-
+    oneof sibling_hash {
+        bytes left_sibling_hash = 3;
+        bytes right_sibling_hash = 4;
+    }
 }
 
 message AgreementProto {
-  uint32 epoch = 1;
-  oneof payload {
-    bool bval = 2;
-    bool aux = 3;
-  }
+    uint32 epoch = 1;
+    oneof payload {
+        bool bval = 2;
+        bool aux = 3;
+    }
 }

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -1,52 +1,52 @@
 syntax = "proto3";
 
 message MessageProto {
-    oneof payload {
-        BroadcastProto broadcast = 1;
-        AgreementProto agreement = 2;
-    }
+  oneof payload {
+    BroadcastProto broadcast = 1;
+    AgreementProto agreement = 2;
+  }
 }
 
 message BroadcastProto {
-    oneof payload {
-        ValueProto value = 1;
-        EchoProto echo = 2;
-        ReadyProto ready = 3;
-    }
+  oneof payload {
+    ValueProto value = 1;
+    EchoProto echo = 2;
+    ReadyProto ready = 3;
+  }
 }
 
 message ValueProto {
-    ProofProto proof = 1;
+  ProofProto proof = 1;
 }
 
 message EchoProto {
-    ProofProto proof = 1;
+  ProofProto proof = 1;
 }
 
 message ReadyProto {
-    bytes root_hash = 1;
+  bytes root_hash = 1;
 }
 
 message ProofProto {
-    bytes root_hash = 1;
-    LemmaProto lemma = 2;
-    bytes value = 3;
+  bytes root_hash = 1;
+  LemmaProto lemma = 2;
+  bytes value = 3;
 }
 
 message LemmaProto {
-    bytes node_hash = 1;
-    LemmaProto sub_lemma = 2;
+  bytes node_hash = 1;
+  LemmaProto sub_lemma = 2;
 
-    oneof sibling_hash {
-        bytes left_sibling_hash = 3;
-        bytes right_sibling_hash = 4;
-    }
+  oneof sibling_hash {
+    bytes left_sibling_hash = 3;
+    bytes right_sibling_hash = 4;
+  }
 }
 
 message AgreementProto {
-    uint32 epoch = 1;
-    oneof payload {
-        bool bval = 2;
-        bool aux = 3;
-    }
+  uint32 epoch = 1;
+  oneof payload {
+    bool bval = 2;
+    bool aux = 3;
+  }
 }

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -1,5 +1,6 @@
 //! Binary Byzantine agreement protocol from a common coin protocol.
 
+use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::hash::Hash;
 
@@ -210,17 +211,12 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
     /// can, however, expect every good node to send an AUX value that will
     /// eventually end up in our bin_values.
     fn count_aux(&self) -> (usize, BTreeSet<bool>) {
-        let mut count = 0;
-        let vals: BTreeSet<bool> = self.received_aux
+        let (vals_cnt, vals) = self.received_aux
             .values()
-            .filter(|b| {
-                count += 1;
-                self.bin_values.contains(b)
-            })
-            .cloned()
-            .collect();
+            .filter(|b| self.bin_values.contains(b))
+            .tee();
 
-        (count, vals)
+        (vals_cnt.count(), vals.cloned().collect())
     }
 
     /// Waits until at least (N − f) AUX_r messages have been received, such that

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -1,9 +1,51 @@
 //! Binary Byzantine agreement protocol from a common coin protocol.
 
+use rand::random;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::hash::Hash;
 
-use proto::AgreementMessage;
+use proto::message;
+
+type AgreementOutput = (Option<bool>, VecDeque<AgreementMessage>);
+
+/// Messages sent during the binary Byzantine agreement stage.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AgreementMessage {
+    /// BVAL message with an epoch.
+    BVal((u32, bool)),
+    /// AUX message with an epoch.
+    Aux((u32, bool)),
+}
+
+impl AgreementMessage {
+    pub fn into_proto(self) -> message::AgreementProto {
+        let mut p = message::AgreementProto::new();
+        match self {
+            AgreementMessage::BVal((e, b)) => {
+                p.set_epoch(e);
+                p.set_bval(b);
+            }
+            AgreementMessage::Aux((e, b)) => {
+                p.set_epoch(e);
+                p.set_aux(b);
+            }
+        }
+        p
+    }
+
+    // TODO: Re-enable lint once implemented.
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+    pub fn from_proto(mp: message::AgreementProto) -> Option<Self> {
+        let epoch = mp.get_epoch();
+        if mp.has_bval() {
+            Some(AgreementMessage::BVal((epoch, mp.get_bval())))
+        } else if mp.has_aux() {
+            Some(AgreementMessage::Aux((epoch, mp.get_aux())))
+        } else {
+            None
+        }
+    }
+}
 
 pub struct Agreement<NodeUid> {
     /// The UID of the corresponding node.
@@ -21,7 +63,7 @@ pub struct Agreement<NodeUid> {
     /// Values received in AUX messages. Reset on every epoch update.
     received_aux: HashMap<NodeUid, BTreeSet<bool>>,
     /// All the output values in all epochs.
-    outputs: BTreeMap<u32, bool>,
+    estimated: BTreeMap<u32, bool>,
     /// Termination flag.
     terminated: bool,
 }
@@ -40,7 +82,7 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
             received_bval: HashMap::new(),
             sent_bval: BTreeSet::new(),
             received_aux: HashMap::new(),
-            outputs: BTreeMap::new(),
+            estimated: BTreeMap::new(),
             terminated: false,
         }
     }
@@ -53,7 +95,10 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
     pub fn set_input(&mut self, input: bool) -> AgreementMessage {
         self.input = Some(input);
         // Receive the BVAL message locally.
-        update_map_of_sets(&mut self.received_bval, self.uid.clone(), input);
+        self.received_bval
+            .entry(self.uid.clone())
+            .or_insert_with(BTreeSet::new)
+            .insert(input);
         // Multicast BVAL
         AgreementMessage::BVal((self.epoch, input))
     }
@@ -70,71 +115,85 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
         &mut self,
         uid: NodeUid,
         message: &AgreementMessage,
-    ) -> Result<(Option<bool>, VecDeque<AgreementMessage>), Error> {
+    ) -> Result<AgreementOutput, Error> {
+        match *message {
+            // The algorithm instance has already terminated.
+            _ if self.terminated => Err(Error::Terminated),
+
+            AgreementMessage::BVal((epoch, b)) if epoch == self.epoch => self.on_bval(uid, b),
+
+            AgreementMessage::Aux((epoch, b)) if epoch == self.epoch => self.on_aux(uid, b),
+
+            // Epoch does not match. Ignore the message.
+            _ => Ok((None, VecDeque::new())),
+        }
+    }
+
+    fn on_bval(&mut self, uid: NodeUid, b: bool) -> Result<AgreementOutput, Error> {
         let mut outgoing = VecDeque::new();
 
-        match *message {
-            _ if self.terminated => {
-                // The algorithm instance has already terminated.
-                Err(Error::Terminated)
+        self.received_bval
+            .entry(uid)
+            .or_insert_with(BTreeSet::new)
+            .insert(b);
+        let count_bval = self.received_bval
+            .values()
+            .filter(|values| values.contains(&b))
+            .count();
+
+        // upon receiving BVAL_r(b) messages from 2f + 1 nodes,
+        // bin_values_r := bin_values_r ∪ {b}
+        if count_bval == 2 * self.num_faulty_nodes + 1 {
+            self.bin_values.insert(b);
+
+            // wait until bin_values_r != 0, then multicast AUX_r(w)
+            // where w ∈ bin_values_r
+            if self.bin_values.len() == 1 {
+                // Send an AUX message at most once per epoch.
+                outgoing.push_back(AgreementMessage::Aux((self.epoch, b)));
+                // Receive the AUX message locally.
+                self.received_aux
+                    .entry(self.uid.clone())
+                    .or_insert_with(BTreeSet::new)
+                    .insert(b);
             }
 
-            AgreementMessage::BVal((epoch, b)) if epoch == self.epoch => {
-                update_map_of_sets(&mut self.received_bval, uid, b);
-                let count_bval = self.received_bval.iter().fold(0, |count, (_, values)| {
-                    if values.contains(&b) {
-                        count + 1
-                    } else {
-                        count
-                    }
-                });
-
-                // upon receiving BVAL_r(b) messages from 2f + 1 nodes,
-                // bin_values_r := bin_values_r ∪ {b}
-                if count_bval == 2 * self.num_faulty_nodes + 1 {
-                    self.bin_values.insert(b);
-
-                    // wait until bin_values_r /= 0, then multicast AUX_r(w)
-                    // where w ∈ bin_values_r
-                    outgoing.push_back(AgreementMessage::Aux((self.epoch, b)));
-                    // Receive the AUX message locally.
-                    update_map_of_sets(&mut self.received_aux, self.uid.clone(), b);
-
-                    let coin_result = self.try_coin();
-                    if let Some(output_message) = coin_result.1 {
-                        outgoing.push_back(output_message);
-                    }
-                    Ok((coin_result.0, outgoing))
-                }
-                // upon receiving BVAL_r(b) messages from f + 1 nodes, if
-                // BVAL_r(b) has not been sent, multicast BVAL_r(b)
-                else if count_bval == self.num_faulty_nodes + 1 && !self.sent_bval.contains(&b) {
-                    outgoing.push_back(AgreementMessage::BVal((self.epoch, b)));
-                    // Receive the BVAL message locally.
-                    update_map_of_sets(&mut self.received_bval, self.uid.clone(), b);
-                    Ok((None, outgoing))
-                } else {
-                    Ok((None, outgoing))
-                }
+            let coin_result = self.try_coin();
+            if let Some(output_message) = coin_result.1 {
+                outgoing.push_back(output_message);
             }
+            Ok((coin_result.0, outgoing))
+        }
+        // upon receiving BVAL_r(b) messages from f + 1 nodes, if
+        // BVAL_r(b) has not been sent, multicast BVAL_r(b)
+        else if count_bval == self.num_faulty_nodes + 1 && !self.sent_bval.contains(&b) {
+            outgoing.push_back(AgreementMessage::BVal((self.epoch, b)));
+            // Receive the BVAL message locally.
+            self.received_bval
+                .entry(self.uid.clone())
+                .or_insert_with(BTreeSet::new)
+                .insert(b);
+            Ok((None, outgoing))
+        } else {
+            Ok((None, outgoing))
+        }
+    }
 
-            AgreementMessage::Aux((epoch, b)) if epoch == self.epoch => {
-                update_map_of_sets(&mut self.received_aux, uid, b);
-                if !self.bin_values.is_empty() {
-                    let coin_result = self.try_coin();
-                    if let Some(output_message) = coin_result.1 {
-                        outgoing.push_back(output_message);
-                    }
-                    Ok((coin_result.0, outgoing))
-                } else {
-                    Ok((None, outgoing))
-                }
-            }
+    fn on_aux(&mut self, uid: NodeUid, b: bool) -> Result<AgreementOutput, Error> {
+        let mut outgoing = VecDeque::new();
 
-            _ => {
-                // Epoch does not match. Ignore the message.
-                Ok((None, outgoing))
+        self.received_aux
+            .entry(uid)
+            .or_insert_with(BTreeSet::new)
+            .insert(b);
+        if !self.bin_values.is_empty() {
+            let coin_result = self.try_coin();
+            if let Some(output_message) = coin_result.1 {
+                outgoing.push_back(output_message);
             }
+            Ok((coin_result.0, outgoing))
+        } else {
+            Ok((None, outgoing))
         }
     }
 
@@ -143,47 +202,54 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
     ///
     /// FIXME: Clarify whether the values of AUX messages should be the same or
     /// not. It is assumed in `count_aux` that they can differ.
+    ///
+    /// In general, we can't expect every good node to send the same AUX value,
+    /// so waiting for N - f agreeing messages would not always terminate. We
+    /// can, however, expect every good node to send an AUX value that will
+    /// eventually end up in our bin_values.
     fn count_aux(&self) -> (usize, BTreeSet<bool>) {
         let vals = BTreeSet::new();
         (
-            self.received_aux.iter().fold(0, |count, (_, values)| {
-                if values.is_subset(&self.bin_values) {
-                    vals.union(values);
-                    count + 1
-                } else {
-                    count
-                }
-            }),
+            self.received_aux
+                .values()
+                .filter(|values| values.is_subset(&self.bin_values))
+                .map(|values| vals.union(values))
+                .count(),
             vals,
         )
     }
 
-    /// Wait until at least (N − f) AUX_r messages have been received, such that
+    /// Waits until at least (N − f) AUX_r messages have been received, such that
     /// the set of values carried by these messages, vals, are a subset of
     /// bin_values_r (note that bin_values_r may continue to change as BVAL_r
     /// messages are received, thus this condition may be triggered upon arrival
     /// of either an AUX_r or a BVAL_r message).
     ///
-    /// `try_coin` output an optional combination of the agreement value and the
-    /// agreement broadcast message.
+    /// `try_coin` outputs an optional combination of the agreement value and
+    /// the agreement broadcast message.
     fn try_coin(&mut self) -> (Option<bool>, Option<AgreementMessage>) {
         let (count_aux, vals) = self.count_aux();
-        if count_aux >= self.num_nodes - self.num_faulty_nodes {
+        if count_aux < self.num_nodes - self.num_faulty_nodes {
+            // Continue waiting for the (N - f) AUX messages.
+            (None, None)
+        } else {
             // FIXME: Implement the Common Coin algorithm. At the moment the
-            // coin value is constant `true`.
-            let coin: u64 = 1;
-
-            let coin2 = coin % 2 != 0;
+            // coin value is random and local to each instance of Agreement.
+            let coin2 = random::<bool>();
 
             // Check the termination condition: "continue looping until both a
             // value b is output in some round r, and the value Coin_r' = b for
             // some round r' > r."
-            self.terminated = self.terminated || self.outputs.values().any(|b| *b == coin2);
+            self.terminated = self.terminated || self.estimated.values().any(|b| *b == coin2);
 
             // Prepare to start the next epoch.
             self.bin_values.clear();
 
-            if vals.len() == 1 {
+            if vals.len() != 1 {
+                // Start the next epoch.
+                self.epoch += 1;
+                (None, Some(self.set_input(coin2)))
+            } else {
                 let mut message = None;
                 // NOTE: `vals` has exactly one element due to `vals.len() == 1`
                 let output: Vec<Option<bool>> = vals.into_iter()
@@ -193,7 +259,7 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
 
                         if b == coin2 {
                             // Record the output to perform a termination check later.
-                            self.outputs.insert(self.epoch, b);
+                            self.estimated.insert(self.epoch, b);
                             // Output the agreement value.
                             Some(b)
                         } else {
@@ -205,33 +271,9 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
                 // Start the next epoch.
                 self.epoch += 1;
                 (output[0], message)
-            } else {
-                // Start the next epoch.
-                self.epoch += 1;
-                (None, Some(self.set_input(coin2)))
             }
-        } else {
-            // Continue waiting for the (N - f) AUX messages.
-            (None, None)
         }
     }
-}
-
-// Insert an element into a hash map of sets of values of type `Elt`.
-fn update_map_of_sets<Key, Elt>(map: &mut HashMap<Key, BTreeSet<Elt>>, key: Key, elt: Elt)
-where
-    Key: Eq + Hash,
-    Elt: Copy + Ord,
-{
-    map.entry(key)
-        .and_modify(|values| {
-            values.insert(elt);
-        })
-        .or_insert({
-            let mut values = BTreeSet::new();
-            values.insert(elt);
-            values
-        });
 }
 
 #[derive(Clone, Debug)]

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -74,6 +74,11 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
         let mut outgoing = VecDeque::new();
 
         match *message {
+            _ if self.terminated => {
+                // The algorithm instance has already terminated.
+                Err(Error::Terminated)
+            }
+
             AgreementMessage::BVal((epoch, b)) if epoch == self.epoch => {
                 update_map_of_sets(&mut self.received_bval, uid, b);
                 let count_bval = self.received_bval.iter().fold(0, |count, (_, values)| {
@@ -113,7 +118,7 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
                 }
             }
 
-            AgreementMessage::Aux((_epoch, b)) => {
+            AgreementMessage::Aux((epoch, b)) if epoch == self.epoch => {
                 update_map_of_sets(&mut self.received_aux, uid, b);
                 if !self.bin_values.is_empty() {
                     let coin_result = self.try_coin();
@@ -231,5 +236,6 @@ where
 
 #[derive(Clone, Debug)]
 pub enum Error {
+    Terminated,
     NotImplemented,
 }

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -210,15 +210,17 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
     /// can, however, expect every good node to send an AUX value that will
     /// eventually end up in our bin_values.
     fn count_aux(&self) -> (usize, BTreeSet<bool>) {
-        let mut vals: BTreeSet<bool> = BTreeSet::new();
+        let mut count = 0;
+        let vals: BTreeSet<bool> = self.received_aux
+            .values()
+            .filter(|b| {
+                count += 1;
+                self.bin_values.contains(b)
+            })
+            .cloned()
+            .collect();
 
-        for b in self.received_aux.values() {
-            if self.bin_values.contains(b) {
-                vals.insert(b.clone());
-            }
-        }
-
-        (vals.len(), vals)
+        (count, vals)
     }
 
     /// Waits until at least (N − f) AUX_r messages have been received, such that

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -1,26 +1,61 @@
 //! Binary Byzantine agreement protocol from a common coin protocol.
 
-use proto::AgreementMessage;
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::hash::Hash;
 
-#[derive(Default)]
-pub struct Agreement {
+use proto::AgreementMessage;
+
+pub struct Agreement<NodeUid> {
+    /// The UID of the corresponding node.
+    uid: NodeUid,
+    num_nodes: usize,
+    num_faulty_nodes: usize,
+    epoch: u32,
     input: Option<bool>,
-    _bin_values: BTreeSet<bool>,
+    /// Bin values. Reset on every epoch update.
+    bin_values: BTreeSet<bool>,
+    /// Values received in BVAL messages. Reset on every epoch update.
+    received_bval: HashMap<NodeUid, BTreeSet<bool>>,
+    /// Sent BVAL values. Reset on every epoch update.
+    sent_bval: BTreeSet<bool>,
+    /// Values received in AUX messages. Reset on every epoch update.
+    received_aux: HashMap<NodeUid, BTreeSet<bool>>,
+    /// All the output values in all epochs.
+    outputs: BTreeMap<u32, bool>,
+    /// Termination flag.
+    terminated: bool,
 }
 
-impl Agreement {
-    pub fn new() -> Self {
+impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
+    pub fn new(uid: NodeUid, num_nodes: usize) -> Self {
+        let num_faulty_nodes = (num_nodes - 1) / 3;
+
         Agreement {
+            uid,
+            num_nodes,
+            num_faulty_nodes,
+            epoch: 0,
             input: None,
-            _bin_values: BTreeSet::new(),
+            bin_values: BTreeSet::new(),
+            received_bval: HashMap::new(),
+            sent_bval: BTreeSet::new(),
+            received_aux: HashMap::new(),
+            outputs: BTreeMap::new(),
+            terminated: false,
         }
+    }
+
+    /// Algorithm has terminated.
+    pub fn terminated(&self) -> bool {
+        self.terminated
     }
 
     pub fn set_input(&mut self, input: bool) -> AgreementMessage {
         self.input = Some(input);
+        // Receive the BVAL message locally.
+        update_map_of_sets(&mut self.received_bval, self.uid.clone(), input);
         // Multicast BVAL
-        AgreementMessage::BVal(input)
+        AgreementMessage::BVal((self.epoch, input))
     }
 
     pub fn has_input(&self) -> bool {
@@ -28,12 +63,170 @@ impl Agreement {
     }
 
     /// Receive input from a remote node.
+    ///
+    /// Outputs an optional agreement result and a queue of agreement messages
+    /// to remote nodes. There can be up to 2 messages.
     pub fn on_input(
-        &self,
-        _message: &AgreementMessage,
-    ) -> Result<VecDeque<AgreementMessage>, Error> {
-        Err(Error::NotImplemented)
+        &mut self,
+        uid: NodeUid,
+        message: &AgreementMessage,
+    ) -> Result<(Option<bool>, VecDeque<AgreementMessage>), Error> {
+        let mut outgoing = VecDeque::new();
+
+        match *message {
+            AgreementMessage::BVal((epoch, b)) if epoch == self.epoch => {
+                update_map_of_sets(&mut self.received_bval, uid, b);
+                let count_bval = self.received_bval.iter().fold(0, |count, (_, values)| {
+                    if values.contains(&b) {
+                        count + 1
+                    } else {
+                        count
+                    }
+                });
+
+                // upon receiving BVAL_r(b) messages from 2f + 1 nodes,
+                // bin_values_r := bin_values_r ∪ {b}
+                if count_bval == 2 * self.num_faulty_nodes + 1 {
+                    self.bin_values.insert(b);
+
+                    // wait until bin_values_r /= 0, then multicast AUX_r(w)
+                    // where w ∈ bin_values_r
+                    outgoing.push_back(AgreementMessage::Aux((self.epoch, b)));
+                    // Receive the AUX message locally.
+                    update_map_of_sets(&mut self.received_aux, self.uid.clone(), b);
+
+                    let coin_result = self.try_coin();
+                    if let Some(output_message) = coin_result.1 {
+                        outgoing.push_back(output_message);
+                    }
+                    Ok((coin_result.0, outgoing))
+                }
+                // upon receiving BVAL_r(b) messages from f + 1 nodes, if
+                // BVAL_r(b) has not been sent, multicast BVAL_r(b)
+                else if count_bval == self.num_faulty_nodes + 1 && !self.sent_bval.contains(&b) {
+                    outgoing.push_back(AgreementMessage::BVal((self.epoch, b)));
+                    // Receive the BVAL message locally.
+                    update_map_of_sets(&mut self.received_bval, self.uid.clone(), b);
+                    Ok((None, outgoing))
+                } else {
+                    Ok((None, outgoing))
+                }
+            }
+
+            AgreementMessage::Aux((_epoch, b)) => {
+                update_map_of_sets(&mut self.received_aux, uid, b);
+                if !self.bin_values.is_empty() {
+                    let coin_result = self.try_coin();
+                    if let Some(output_message) = coin_result.1 {
+                        outgoing.push_back(output_message);
+                    }
+                    Ok((coin_result.0, outgoing))
+                } else {
+                    Ok((None, outgoing))
+                }
+            }
+
+            _ => {
+                // Epoch does not match. Ignore the message.
+                Ok((None, outgoing))
+            }
+        }
     }
+
+    /// AUX_r messages such that the set of values carried by those messages is
+    /// a subset of bin_values_r. Outputs this subset.
+    ///
+    /// FIXME: Clarify whether the values of AUX messages should be the same or
+    /// not. It is assumed in `count_aux` that they can differ.
+    fn count_aux(&self) -> (usize, BTreeSet<bool>) {
+        let vals = BTreeSet::new();
+        (
+            self.received_aux.iter().fold(0, |count, (_, values)| {
+                if values.is_subset(&self.bin_values) {
+                    vals.union(values);
+                    count + 1
+                } else {
+                    count
+                }
+            }),
+            vals,
+        )
+    }
+
+    /// Wait until at least (N − f) AUX_r messages have been received, such that
+    /// the set of values carried by these messages, vals, are a subset of
+    /// bin_values_r (note that bin_values_r may continue to change as BVAL_r
+    /// messages are received, thus this condition may be triggered upon arrival
+    /// of either an AUX_r or a BVAL_r message).
+    ///
+    /// `try_coin` output an optional combination of the agreement value and the
+    /// agreement broadcast message.
+    fn try_coin(&mut self) -> (Option<bool>, Option<AgreementMessage>) {
+        let (count_aux, vals) = self.count_aux();
+        if count_aux >= self.num_nodes - self.num_faulty_nodes {
+            // FIXME: Implement the Common Coin algorithm. At the moment the
+            // coin value is constant `true`.
+            let coin: u64 = 1;
+
+            let coin2 = coin % 2 != 0;
+
+            // Check the termination condition: "continue looping until both a
+            // value b is output in some round r, and the value Coin_r' = b for
+            // some round r' > r."
+            self.terminated = self.terminated || self.outputs.values().any(|b| *b == coin2);
+
+            // Prepare to start the next epoch.
+            self.bin_values.clear();
+
+            if vals.len() == 1 {
+                let mut message = None;
+                // NOTE: `vals` has exactly one element due to `vals.len() == 1`
+                let output: Vec<Option<bool>> = vals.into_iter()
+                    .take(1)
+                    .map(|b| {
+                        message = Some(self.set_input(b));
+
+                        if b == coin2 {
+                            // Record the output to perform a termination check later.
+                            self.outputs.insert(self.epoch, b);
+                            // Output the agreement value.
+                            Some(b)
+                        } else {
+                            // Don't output a value.
+                            None
+                        }
+                    })
+                    .collect();
+                // Start the next epoch.
+                self.epoch += 1;
+                (output[0], message)
+            } else {
+                // Start the next epoch.
+                self.epoch += 1;
+                (None, Some(self.set_input(coin2)))
+            }
+        } else {
+            // Continue waiting for the (N - f) AUX messages.
+            (None, None)
+        }
+    }
+}
+
+// Insert an element into a hash map of sets of values of type `Elt`.
+fn update_map_of_sets<Key, Elt>(map: &mut HashMap<Key, BTreeSet<Elt>>, key: Key, elt: Elt)
+where
+    Key: Eq + Hash,
+    Elt: Copy + Ord,
+{
+    map.entry(key)
+        .and_modify(|values| {
+            values.insert(elt);
+        })
+        .or_insert({
+            let mut values = BTreeSet::new();
+            values.insert(elt);
+            values
+        });
 }
 
 #[derive(Clone, Debug)]

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -95,7 +95,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
     /// BA_j, then provide input 1 to BA_j. See Figure 11.
     fn on_broadcast_result(&mut self, uid: &NodeUid) -> Result<Option<AgreementMessage>, Error> {
         if let Some(agreement_instance) = self.agreement_instances.get_mut(&uid) {
-            if !agreement_instance.has_input() {
+            if agreement_instance.accepts_input() {
                 Ok(Some(agreement_instance.set_input(true)?))
             } else {
                 Ok(None)
@@ -168,7 +168,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
             } else {
                 // Send the message to the agreement instance.
                 agreement_instance
-                    .handle_agreement_message(sender_id.clone(), &amessage)
+                    .handle_agreement_message(sender_id, &amessage)
                     .map_err(Error::from)
             }
         }
@@ -209,7 +209,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
 
             if results1 >= self.num_nodes - self.num_faulty_nodes {
                 for instance in self.agreement_instances.values_mut() {
-                    if !instance.has_input() {
+                    if instance.accepts_input() {
                         outgoing.push_back(instance.set_input(false)?);
                     }
                 }

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -17,6 +17,8 @@ use proto::AgreementMessage;
 
 // TODO: Make this a generic argument of `Broadcast`.
 type ProposedValue = Vec<u8>;
+// Type of output from the Common Subset message handler.
+type CommonSubsetOutput<NodeUid> = (Option<HashSet<ProposedValue>>, VecDeque<Output<NodeUid>>);
 
 /// Input from a remote node to Common Subset.
 pub enum Input<NodeUid> {
@@ -27,9 +29,6 @@ pub enum Input<NodeUid> {
 }
 
 /// Output from Common Subset to remote nodes.
-///
-/// FIXME: We can do an interface that doesn't need this type and instead works
-/// directly with the `TargetBroadcastMessage` and `AgreementMessage`.
 pub enum Output<NodeUid> {
     /// A broadcast message to be sent to the destination set in the
     /// `TargetedBroadcastMessage`.
@@ -46,6 +45,8 @@ pub struct CommonSubset<NodeUid: Eq + Hash + Ord> {
     broadcast_instances: HashMap<NodeUid, Broadcast<NodeUid>>,
     agreement_instances: HashMap<NodeUid, Agreement<NodeUid>>,
     broadcast_results: HashMap<NodeUid, ProposedValue>,
+    /// FIXME: The result may be a set of bool rather than a single bool due to
+    /// the ability of Agreement to output multiple values.
     agreement_results: HashMap<NodeUid, bool>,
 }
 
@@ -104,10 +105,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
 
     /// Upon delivery of v_j from RBC_j, if input has not yet been provided to
     /// BA_j, then provide input 1 to BA_j. See Figure 11.
-    pub fn on_broadcast_result(
-        &mut self,
-        uid: &NodeUid,
-    ) -> Result<Option<AgreementMessage>, Error> {
+    fn on_broadcast_result(&mut self, uid: &NodeUid) -> Result<Option<AgreementMessage>, Error> {
         if let Some(agreement_instance) = self.agreement_instances.get_mut(&uid) {
             if !agreement_instance.has_input() {
                 Ok(Some(agreement_instance.set_input(true)))
@@ -119,20 +117,22 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
         }
     }
 
-    /// Receive input from a remote node.
+    /// Receive input from a remote node. The output contains an optional result
+    /// of the Common Subset algorithm - a set of proposed values - and a queue
+    /// of messages to be sent to remote nodes, or an error.
     pub fn on_input(
         &mut self,
         message: Input<NodeUid>,
-    ) -> Result<VecDeque<Output<NodeUid>>, Error> {
+    ) -> Result<CommonSubsetOutput<NodeUid>, Error> {
         match message {
             Input::Broadcast(uid, bmessage) => {
                 let mut instance_result = None;
-                let input_result = {
+                let input_result: Result<VecDeque<Output<NodeUid>>, Error> = {
                     if let Some(broadcast_instance) = self.broadcast_instances.get(&uid) {
                         broadcast_instance
                             .handle_broadcast_message(&uid, bmessage)
-                            .map(|(value, queue)| {
-                                instance_result = value;
+                            .map(|(opt_value, queue)| {
+                                instance_result = opt_value;
                                 queue.into_iter().map(Output::Broadcast).collect()
                             })
                             .map_err(Error::from)
@@ -140,17 +140,24 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
                         Err(Error::NoSuchBroadcastInstance)
                     }
                 };
-                if instance_result.is_some() {
-                    self.on_broadcast_result(&uid)?;
+                let mut opt_message: Option<AgreementMessage> = None;
+                if let Some(value) = instance_result {
+                    self.broadcast_results.insert(uid.clone(), value);
+                    opt_message = self.on_broadcast_result(&uid)?;
                 }
-                input_result
+                input_result.map(|mut queue| {
+                    if let Some(agreement_message) = opt_message {
+                        // Append the message to agreement nodes to the common output queue.
+                        queue.push_back(Output::Agreement(agreement_message))
+                    }
+                    (None, queue)
+                })
             }
 
             Input::Agreement(uid, amessage) => {
                 // The result defaults to error.
                 let mut result = Err(Error::NoSuchAgreementInstance);
 
-                // FIXME: send the message to the Agreement instance and
                 if let Some(mut agreement_instance) = self.agreement_instances.get_mut(&uid) {
                     // Optional output of agreement and outgoing agreement
                     // messages to remote nodes.
@@ -158,6 +165,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
                         // This instance has terminated and does not accept input.
                         Ok((None, VecDeque::new()))
                     } else {
+                        // Send the message to the agreement instance.
                         agreement_instance
                             .on_input(uid.clone(), &amessage)
                             .map_err(Error::from)
@@ -168,11 +176,15 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
                     if let Some(b) = output {
                         outgoing.append(&mut self.on_agreement_result(uid, b));
                     }
-                    Ok(outgoing.into_iter().map(Output::Agreement).collect())
+                    Ok((
+                        self.try_agreement_completion(),
+                        outgoing.into_iter().map(Output::Agreement).collect(),
+                    ))
                 } else {
                     // error
-                    result
-                        .map(|(_, messages)| messages.into_iter().map(Output::Agreement).collect())
+                    result.map(|(_, messages)| {
+                        (None, messages.into_iter().map(Output::Agreement).collect())
+                    })
                 }
             }
         }
@@ -180,25 +192,20 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
 
     /// Callback to be invoked on receipt of a returned value of the Agreement
     /// instance `uid`.
-    ///
-    /// FIXME: It is likely that only one `AgreementMessage` is required because
-    /// Figure 11 does not count the number of messages but the number of nodes
-    /// that sent messages.
     fn on_agreement_result(&mut self, uid: NodeUid, result: bool) -> VecDeque<AgreementMessage> {
         let mut outgoing = VecDeque::new();
         // Upon delivery of value 1 from at least N − f instances of BA, provide
         // input 0 to each instance of BA that has not yet been provided input.
         if result {
             self.agreement_results.insert(uid, result);
-            let results1: Vec<bool> = self.agreement_results
-                .iter()
-                .map(|(_, v)| *v)
-                .filter(|b| *b)
-                .collect();
+            // The number of instances of BA that output 1.
+            let results1: usize =
+                self.agreement_results
+                    .iter()
+                    .fold(0, |count, (_, v)| if *v { count + 1 } else { count });
 
-            if results1.len() >= self.num_nodes - self.num_faulty_nodes {
-                let instances = &mut self.agreement_instances;
-                for (_uid0, instance) in instances.iter_mut() {
+            if results1 >= self.num_nodes - self.num_faulty_nodes {
+                for instance in self.agreement_instances.values_mut() {
                     if !instance.has_input() {
                         outgoing.push_back(instance.set_input(false));
                     }
@@ -208,24 +215,19 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
         outgoing
     }
 
-    pub fn on_agreement_completion(&self) -> Option<HashSet<ProposedValue>> {
+    fn try_agreement_completion(&self) -> Option<HashSet<ProposedValue>> {
         // Once all instances of BA have completed, let C ⊂ [1..N] be
         // the indexes of each BA that delivered 1. Wait for the output
         // v_j for each RBC_j such that j∈C. Finally output ∪ j∈C v_j.
-        let instance_uids: HashSet<NodeUid> = self.agreement_instances
+        if self.agreement_instances
             .iter()
-            .map(|(k, _)| k.clone())
-            .collect();
-        let completed_uids: HashSet<NodeUid> = self.agreement_results
-            .iter()
-            .map(|(k, _)| k.clone())
-            .collect();
-        if instance_uids == completed_uids {
-            // All instances of Agreement that delivered `true`.
-            let delivered_1: HashSet<NodeUid> = self.agreement_results
+            .all(|(_, instance)| instance.terminated())
+        {
+            // All instances of Agreement that delivered `true` (or "1" in the paper).
+            let delivered_1: HashSet<&NodeUid> = self.agreement_results
                 .iter()
                 .filter(|(_, v)| **v)
-                .map(|(k, _)| k.clone())
+                .map(|(k, _)| k)
                 .collect();
             // Results of Broadcast instances in `delivered_1`
             let broadcast_results: HashSet<ProposedValue> = self.broadcast_results

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -179,8 +179,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
         let mut result = Err(Error::NoSuchAgreementInstance);
 
         // Send the message to the local instance of Agreement
-        if let Some(mut agreement_instance) = self.agreement_instances.get_mut(&element_proposer_id)
-        {
+        if let Some(agreement_instance) = self.agreement_instances.get_mut(&element_proposer_id) {
             // Optional output of agreement and outgoing agreement
             // messages to remote nodes.
             result = if agreement_instance.terminated() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate log;
 extern crate crossbeam;
 extern crate crossbeam_channel;
+extern crate itertools;
 extern crate merkle;
 extern crate protobuf;
 extern crate reed_solomon_erasure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ extern crate crossbeam;
 extern crate crossbeam_channel;
 extern crate merkle;
 extern crate protobuf;
-extern crate rand;
 extern crate reed_solomon_erasure;
 extern crate ring;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate crossbeam;
 extern crate crossbeam_channel;
 extern crate merkle;
 extern crate protobuf;
+extern crate rand;
 extern crate reed_solomon_erasure;
 extern crate ring;
 


### PR DESCRIPTION
I've defined the ACS algorithm and an interface to it consisting of 3 functions: new, send_proposed_value and on_input. The latter is a message handler for RB and BA messages. These two types of message are therefore joined in the types of message inputs and outputs.

Note about BA: A common coin implementation is not provided in this pull request. The coin value is constant 1 at https://github.com/poanetwork/hbbft/blob/15353e8d27398fa745a99a148f74276c62ec1d11/src/agreement.rs#L174.