### PR TITLE
Fix broadcast and example, enable more tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ env:
   global:
     - RUST_BACKTRACE=1
     - RUSTFLAGS="-D warnings"
-  script:
-    - cargo fmt -- --write-mode=diff
-    - cargo clippy -- -D clippy
-    - cargo clippy --tests -- -D clippy
-    - cargo check --tests
-    - cargo test
+script:
+  # TODO: This currently fails, claiming that `src/proto/message.rs` does not
+  #       exist. Re-enable once the problem is resolved.
+  # - cargo fmt -- --write-mode=diff
+  - cargo clippy -- -D clippy
+  - cargo clippy --tests -- -D clippy
+  - cargo check --tests
+  - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Vladimir Komendantskiy <komendantsky@gmail.com>"]
 
 [dependencies]
+env_logger = "0.5.10"
 log = "0.4.1"
-simple_logger = "0.5"
 reed-solomon-erasure = "3.0"
 merkle = { git = "https://github.com/vkomenda/merkle.rs", branch = "public-proof" }
 ring = "^0.12"

--- a/examples/consensus-node.rs
+++ b/examples/consensus-node.rs
@@ -4,10 +4,10 @@ extern crate crossbeam;
 #[macro_use]
 extern crate crossbeam_channel;
 extern crate docopt;
+extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
-extern crate simple_logger;
 
 mod network;
 
@@ -55,7 +55,7 @@ fn parse_args() -> Args {
 }
 
 pub fn main() {
-    simple_logger::init_with_level(log::Level::Debug).unwrap();
+    env_logger::init();
     let args: Args = parse_args();
     println!("{:?}", args);
     let node = Node::new(args.bind_address, args.remote_addresses, args.value);

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -37,9 +37,9 @@
 use crossbeam;
 use std::collections::HashSet;
 use std::fmt::Debug;
-use std::io;
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
+use std::{io, iter, process};
 
 use hbbft::broadcast;
 use network::commst;
@@ -50,7 +50,6 @@ use network::messaging::Messaging;
 pub enum Error {
     IoError(io::Error),
     CommsError(commst::Error),
-    NotImplemented,
 }
 
 impl From<io::Error> for Error {
@@ -90,54 +89,64 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
     /// Consensus node procedure implementing HoneyBadgerBFT.
     pub fn run(&self) -> Result<T, Error> {
         let value = &self.value;
-        let connections = connection::make(&self.addr, &self.remotes);
+        let (our_str, connections) = connection::make(&self.addr, &self.remotes);
+        let mut node_strs: Vec<String> = iter::once(our_str.clone())
+            .chain(connections.iter().map(|c| c.node_str.clone()))
+            .collect();
+        node_strs.sort();
+        debug!("Nodes:  {:?}", node_strs);
+        let proposer_id = 0;
+        let our_id = node_strs.binary_search(&our_str).unwrap();
         let num_nodes = connections.len() + 1;
+
+        if value.is_some() != (our_id == proposer_id) {
+            panic!("Exactly the first node must propose a value.");
+        }
 
         // Initialise the message delivery system and obtain TX and RX handles.
         let messaging: Messaging<Vec<u8>> = Messaging::new(num_nodes);
         let rxs_to_comms = messaging.rxs_to_comms();
         let tx_from_comms = messaging.tx_from_comms();
-        let rxs_to_algo = messaging.rxs_to_algo();
+        let rx_to_algo = messaging.rx_to_algo();
         let tx_from_algo = messaging.tx_from_algo();
         let stop_tx = messaging.stop_tx();
 
         // All spawned threads will have exited by the end of the scope.
         crossbeam::scope(|scope| {
             // Start the centralised message delivery system.
-            let msg_handle = messaging.spawn(scope);
-            let mut broadcast_handles = Vec::new();
+            let _msg_handle = messaging.spawn(scope);
 
             // Associate a broadcast instance with this node. This instance will
             // broadcast the proposed value. There is no remote node
             // corresponding to this instance, and no dedicated comms task. The
             // node index is 0.
-            let rx_to_algo0 = &rxs_to_algo[0];
-            broadcast_handles.push(scope.spawn(move || {
+            let broadcast_handle = scope.spawn(move || {
                 match broadcast::Instance::new(
                     tx_from_algo,
-                    rx_to_algo0,
+                    rx_to_algo,
                     value.to_owned(),
-                    num_nodes,
-                    0,
+                    (0..num_nodes).collect(),
+                    our_id,
+                    proposer_id,
                 ).run()
                 {
                     Ok(t) => {
                         debug!(
-                            "Broadcast instance 0 succeeded: {}",
+                            "Broadcast succeeded: {}",
                             String::from_utf8(T::into(t)).unwrap()
                         );
                     }
-                    Err(e) => error!("Broadcast instance 0: {:?}", e),
+                    Err(e) => error!("Broadcast instance: {:?}", e),
                 }
-            }));
+            });
 
             // Start a comms task for each connection. Node indices of those
             // tasks are 1 through N where N is the number of connections.
             for (i, c) in connections.iter().enumerate() {
                 // Receive side of a single-consumer channel from algorithm
                 // actor tasks to the comms task.
-                let rx_to_comms = &rxs_to_comms[i];
-                let node_index = i + 1;
+                let node_index = if c.node_str < our_str { i } else { i + 1 };
+                let rx_to_comms = &rxs_to_comms[node_index];
 
                 scope.spawn(move || {
                     match commst::CommsTask::new(
@@ -152,35 +161,11 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                         Err(e) => error!("Comms task {}: {:?}", node_index, e),
                     }
                 });
-
-                // Associate a broadcast instance to the above comms task.
-                let rx_to_algo = &rxs_to_algo[node_index];
-                broadcast_handles.push(scope.spawn(move || {
-                    match broadcast::Instance::new(
-                        tx_from_algo,
-                        rx_to_algo,
-                        None,
-                        num_nodes,
-                        node_index,
-                    ).run()
-                    {
-                        Ok(t) => {
-                            debug!(
-                                "Broadcast instance {} succeeded: {}",
-                                node_index,
-                                String::from_utf8(T::into(t)).unwrap()
-                            );
-                        }
-                        Err(e) => error!("Broadcast instance {}: {:?}", node_index, e),
-                    }
-                }));
             }
 
             // Wait for the broadcast instances to finish before stopping the
             // messaging task.
-            for h in broadcast_handles {
-                h.join();
-            }
+            broadcast_handle.join();
 
             // Stop the messaging task.
             stop_tx
@@ -190,30 +175,14 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                 })
                 .unwrap();
 
-            match msg_handle.join() {
-                Ok(()) => debug!("Messaging stopped OK"),
-                Err(e) => debug!("Messaging error: {:?}", e),
-            }
-            // TODO: continue the implementation of the asynchronous common
-            // subset algorithm.
-            Err(Error::NotImplemented)
+            process::exit(0);
+
+            // TODO: Exit cleanly.
+            // match msg_handle.join() {
+            //     Ok(()) => debug!("Messaging stopped OK"),
+            //     Err(e) => debug!("Messaging error: {:?}", e),
+            // }
+            // Err(Error::NotImplemented)
         }) // end of thread scope
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use std::collections::HashSet;
-//     use node;
-
-//     /// Test that the node works to completion.
-//     #[test]
-//     fn test_node_0() {
-//         let node = node::Node::new("127.0.0.1:10000".parse().unwrap(),
-//                                    HashSet::new(),
-//                                    Some("abc".as_bytes().to_vec()));
-//         let result = node.run();
-//         assert!(match result { Err(node::Error::NotImplemented) => true,
-//                                _ => false });
-//     }
-// }

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -39,7 +39,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
-use std::{io, iter, process};
+use std::{io, iter, process, thread, time};
 
 use hbbft::broadcast;
 use network::commst;
@@ -131,8 +131,9 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                 ).run()
                 {
                     Ok(t) => {
-                        debug!(
-                            "Broadcast succeeded: {}",
+                        println!(
+                            "Broadcast succeeded! Node {} output: {}",
+                            our_id,
                             String::from_utf8(T::into(t)).unwrap()
                         );
                     }
@@ -166,6 +167,9 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
             // Wait for the broadcast instances to finish before stopping the
             // messaging task.
             broadcast_handle.join();
+
+            // Wait another second so that pending messages get sent out.
+            thread::sleep(time::Duration::from_secs(1));
 
             // Stop the messaging task.
             stop_tx

--- a/examples/run-consensus-nodes.sh
+++ b/examples/run-consensus-nodes.sh
@@ -3,11 +3,13 @@
 export RUST_LOG=hbbft=debug
 
 cargo build --example consensus-node
-cargo run --example consensus-node -- --bind-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 --value=Foo &
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 --remote-address=127.0.0.1:5004 --value=Foo &
 sleep 1
-cargo run --example consensus-node -- --bind-address=127.0.0.1:5001 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 &
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5001 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 --remote-address=127.0.0.1:5004 &
 sleep 1
-cargo run --example consensus-node -- --bind-address=127.0.0.1:5002 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5003 &
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5002 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5003 --remote-address=127.0.0.1:5004 &
 sleep 1
-cargo run --example consensus-node -- --bind-address=127.0.0.1:5003 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 &
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5003 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5004 &
+sleep 1
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5004 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 &
 wait

--- a/examples/run-consensus-nodes.sh
+++ b/examples/run-consensus-nodes.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+cargo build --example consensus-node
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 --value=Foo &
+sleep 1
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5001 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 &
+sleep 1
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5002 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5003 &
+sleep 1
+cargo run --example consensus-node -- --bind-address=127.0.0.1:5003 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 &

--- a/examples/run-consensus-nodes.sh
+++ b/examples/run-consensus-nodes.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+export RUST_LOG=hbbft=debug
+
 cargo build --example consensus-node
 cargo run --example consensus-node -- --bind-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 --value=Foo &
 sleep 1
@@ -8,3 +10,4 @@ sleep 1
 cargo run --example consensus-node -- --bind-address=127.0.0.1:5002 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5003 &
 sleep 1
 cargo run --example consensus-node -- --bind-address=127.0.0.1:5003 --remote-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 &
+wait

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -11,9 +11,9 @@ use agreement;
 use agreement::Agreement;
 
 use broadcast;
-use broadcast::{Broadcast, TargetedBroadcastMessage};
+use broadcast::{Broadcast, BroadcastMessage, TargetedBroadcastMessage};
 
-use proto::{AgreementMessage, BroadcastMessage};
+use proto::AgreementMessage;
 
 // TODO: Make this a generic argument of `Broadcast`.
 type ProposedValue = Vec<u8>;
@@ -39,7 +39,7 @@ pub enum Output<NodeUid> {
     Agreement(AgreementMessage),
 }
 
-pub struct CommonSubset<NodeUid: Eq + Hash> {
+pub struct CommonSubset<NodeUid: Eq + Hash + Ord> {
     uid: NodeUid,
     num_nodes: usize,
     num_faulty_nodes: usize,
@@ -59,7 +59,11 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
         for uid0 in all_uids {
             broadcast_instances.insert(
                 uid0.clone(),
-                Broadcast::new(uid.clone(), uid0.clone(), all_uids.clone())?,
+                Broadcast::new(
+                    uid.clone(),
+                    uid0.clone(),
+                    all_uids.iter().cloned().collect(),
+                )?,
             );
         }
 

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 /// recepients is unknown without further computation which is irrelevant to the
 /// message delivery task.
 #[derive(Clone, Debug)]
-pub struct SourcedMessage<T: Clone + Debug + Send + Sync> {
+pub struct SourcedMessage<T: Clone + Debug + Send + Sync + AsRef<[u8]>> {
     pub source: usize,
     pub message: Message<T>,
 }
@@ -27,20 +27,14 @@ pub enum Target {
 
 /// Message with a designated target.
 #[derive(Clone, Debug, PartialEq)]
-pub struct TargetedMessage<T: Clone + Debug + Send + Sync> {
+pub struct TargetedMessage<T: Clone + Debug + Send + Sync + AsRef<[u8]>> {
     pub target: Target,
     pub message: Message<T>,
 }
 
-impl<T: Clone + Debug + Send + Sync> TargetedMessage<T> {
+impl<T: Clone + Debug + Send + Sync + AsRef<[u8]>> TargetedMessage<T> {
     /// Initialises a message while checking parameter preconditions.
-    pub fn new(target: Target, message: Message<T>) -> Option<Self> {
-        match target {
-            Target::Node(i) if i == 0 => {
-                // Remote node indices start from 1.
-                None
-            }
-            _ => Some(TargetedMessage { target, message }),
-        }
+    pub fn new(target: Target, message: Message<T>) -> Self {
+        TargetedMessage { target, message }
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -299,18 +299,34 @@ impl LemmaProto {
     }
 }
 
+/// The path of a lemma in a Merkle tree
+struct BinaryPath(Vec<bool>);
+
 /// The path of the lemma, as a binary string
-fn path_of_lemma(mut lemma: &Lemma) -> String {
-    let mut result = String::new();
+fn path_of_lemma(mut lemma: &Lemma) -> BinaryPath {
+    let mut result = Vec::new();
     loop {
         match lemma.sibling_hash {
             None => (),
-            Some(Positioned::Left(_)) => result.push('1'),
-            Some(Positioned::Right(_)) => result.push('0'),
+            Some(Positioned::Left(_)) => result.push(true),
+            Some(Positioned::Right(_)) => result.push(false),
         }
         lemma = match lemma.sub_lemma.as_ref() {
             Some(lemma) => lemma,
-            None => return result,
+            None => return BinaryPath(result),
         }
+    }
+}
+
+impl fmt::Display for BinaryPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for b in &self.0 {
+            if *b {
+                write!(f, "1")?;
+            } else {
+                write!(f, "0")?;
+            }
+        }
+        Ok(())
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,6 +1,7 @@
 //! Construction of messages from protobuf buffers.
 pub mod message;
 
+use broadcast::BroadcastMessage;
 use merkle::proof::{Lemma, Positioned, Proof};
 use proto::message::*;
 use protobuf::core::parse_from_bytes;
@@ -12,18 +13,9 @@ use std::marker::{Send, Sync};
 
 /// Kinds of message sent by nodes participating in consensus.
 #[derive(Clone, Debug, PartialEq)]
-pub enum Message<T: Send + Sync> {
+pub enum Message<T: Send + Sync + AsRef<[u8]>> {
     Broadcast(BroadcastMessage<T>),
     Agreement(AgreementMessage),
-}
-
-/// The three kinds of message sent during the reliable broadcast stage of the
-/// consensus algorithm.
-#[derive(Clone, PartialEq)]
-pub enum BroadcastMessage<T: Send + Sync> {
-    Value(Proof<T>),
-    Echo(Proof<T>),
-    Ready(Vec<u8>),
 }
 
 /// Wrapper for a byte array, whose `Debug` implementation outputs shortened hexadecimal strings.
@@ -33,43 +25,44 @@ impl<'a> fmt::Debug for HexBytes<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.0.len() > 6 {
             for byte in &self.0[..3] {
-                write!(f, "{:0x}", byte)?;
+                write!(f, "{:02x}", byte)?;
             }
             write!(f, "..")?;
             for byte in &self.0[(self.0.len() - 3)..] {
-                write!(f, "{:0x}", byte)?;
+                write!(f, "{:02x}", byte)?;
             }
         } else {
             for byte in self.0 {
-                write!(f, "{:0x}", byte)?;
+                write!(f, "{:02x}", byte)?;
             }
         }
         Ok(())
     }
 }
 
-struct HexProof<'a, T: 'a>(&'a Proof<T>);
+/// Wrapper for a list of byte arrays, whose `Debug` implementation outputs shortened hexadecimal
+/// strings.
+pub struct HexList<'a, T: 'a>(pub &'a [T]);
 
-impl<'a, T: Send + Sync + fmt::Debug> fmt::Debug for HexProof<'a, T> {
+impl<'a, T: AsRef<[u8]>> fmt::Debug for HexList<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let v: Vec<_> = self.0.iter().map(|t| HexBytes(t.as_ref())).collect();
+        write!(f, "{:?}", v)
+    }
+}
+
+pub struct HexProof<'a, T: 'a>(pub &'a Proof<T>);
+
+impl<'a, T: AsRef<[u8]>> fmt::Debug for HexProof<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "Proof {{ algorithm: {:?}, root_hash: {:?}, lemma for leaf #{}, value: {:?} }}",
             self.0.algorithm,
             HexBytes(&self.0.root_hash),
-            ::broadcast::index_of_proof(self.0),
-            self.0.value
+            path_of_lemma(&self.0.lemma),
+            HexBytes(&self.0.value.as_ref())
         )
-    }
-}
-
-impl<T: Send + Sync + fmt::Debug> fmt::Debug for BroadcastMessage<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            BroadcastMessage::Value(ref v) => write!(f, "Value({:?})", HexProof(&v)),
-            BroadcastMessage::Echo(ref v) => write!(f, "Echo({:?})", HexProof(&v)),
-            BroadcastMessage::Ready(ref bytes) => write!(f, "Ready({:?})", HexBytes(bytes)),
-        }
     }
 }
 
@@ -80,17 +73,14 @@ pub enum AgreementMessage {
     Aux(bool),
 }
 
-impl<T: Send + Sync> Message<T> {
+impl<T: Send + Sync + AsRef<[u8]> + From<Vec<u8>>> Message<T> {
     /// Translation from protobuf to the regular type.
     ///
     /// TODO: add an `Algorithm` field to `MessageProto`. Either `Algorithm` has
     /// to be fully serialised and sent as a whole, or it can be passed over
     /// using an ID and the `Eq` instance to discriminate the finite set of
     /// algorithms in `ring::digest`.
-    pub fn from_proto(mut proto: message::MessageProto) -> Option<Self>
-    where
-        T: From<Vec<u8>>,
-    {
+    pub fn from_proto(mut proto: message::MessageProto) -> Option<Self> {
         if proto.has_broadcast() {
             BroadcastMessage::from_proto(
                 proto.take_broadcast(),
@@ -105,10 +95,7 @@ impl<T: Send + Sync> Message<T> {
         }
     }
 
-    pub fn into_proto(self) -> MessageProto
-    where
-        T: Into<Vec<u8>>,
-    {
+    pub fn into_proto(self) -> MessageProto {
         let mut m = MessageProto::new();
         match self {
             Message::Broadcast(b) => {
@@ -125,10 +112,7 @@ impl<T: Send + Sync> Message<T> {
     ///
     /// TODO: pass custom errors from down the chain of nested parsers as
     /// opposed to returning `WireError::Other`.
-    pub fn parse_from_bytes(bytes: &[u8]) -> ProtobufResult<Self>
-    where
-        T: From<Vec<u8>>,
-    {
+    pub fn parse_from_bytes(bytes: &[u8]) -> ProtobufResult<Self> {
         let r = parse_from_bytes::<MessageProto>(bytes).map(Self::from_proto);
 
         match r {
@@ -139,19 +123,13 @@ impl<T: Send + Sync> Message<T> {
     }
 
     /// Produce a protobuf representation of this `Message`.
-    pub fn write_to_bytes(self) -> ProtobufResult<Vec<u8>>
-    where
-        T: Into<Vec<u8>>,
-    {
+    pub fn write_to_bytes(self) -> ProtobufResult<Vec<u8>> {
         self.into_proto().write_to_bytes()
     }
 }
 
-impl<T: Send + Sync> BroadcastMessage<T> {
-    pub fn into_proto(self) -> BroadcastProto
-    where
-        T: Into<Vec<u8>>,
-    {
+impl<T: Send + Sync + AsRef<[u8]> + From<Vec<u8>>> BroadcastMessage<T> {
+    pub fn into_proto(self) -> BroadcastProto {
         let mut b = BroadcastProto::new();
         match self {
             BroadcastMessage::Value(p) => {
@@ -173,10 +151,7 @@ impl<T: Send + Sync> BroadcastMessage<T> {
         b
     }
 
-    pub fn from_proto(mut mp: BroadcastProto, algorithm: &'static Algorithm) -> Option<Self>
-    where
-        T: From<Vec<u8>>,
-    {
+    pub fn from_proto(mut mp: BroadcastProto, algorithm: &'static Algorithm) -> Option<Self> {
         if mp.has_value() {
             mp.take_value()
                 .take_proof()
@@ -223,10 +198,7 @@ impl AgreementMessage {
 /// around the restriction of not being allowed to extend the implementation of
 /// `Proof` outside its crate.
 impl ProofProto {
-    pub fn from_proof<T>(proof: Proof<T>) -> Self
-    where
-        T: Into<Vec<u8>>,
-    {
+    pub fn from_proof<T: AsRef<[u8]>>(proof: Proof<T>) -> Self {
         let mut proto = Self::new();
 
         match proof {
@@ -239,17 +211,17 @@ impl ProofProto {
             } => {
                 proto.set_root_hash(root_hash);
                 proto.set_lemma(LemmaProto::from_lemma(lemma));
-                proto.set_value(value.into());
+                proto.set_value(value.as_ref().to_vec());
             }
         }
 
         proto
     }
 
-    pub fn into_proof<T>(mut self, algorithm: &'static Algorithm) -> Option<Proof<T>>
-    where
-        T: From<Vec<u8>>,
-    {
+    pub fn into_proof<T: From<Vec<u8>>>(
+        mut self,
+        algorithm: &'static Algorithm,
+    ) -> Option<Proof<T>> {
         if !self.has_lemma() {
             return None;
         }
@@ -323,6 +295,22 @@ impl LemmaProto {
                 sibling_hash,
                 sub_lemma: None,
             })
+        }
+    }
+}
+
+/// The path of the lemma, as a binary string
+fn path_of_lemma(mut lemma: &Lemma) -> String {
+    let mut result = String::new();
+    loop {
+        match lemma.sibling_hash {
+            None => (),
+            Some(Positioned::Left(_)) => result.push('1'),
+            Some(Positioned::Right(_)) => result.push('0'),
+        }
+        lemma = match lemma.sub_lemma.as_ref() {
+            Some(lemma) => lemma,
+            None => return result,
         }
     }
 }

--- a/src/proto_io.rs
+++ b/src/proto_io.rs
@@ -3,9 +3,9 @@
 use proto::*;
 use protobuf;
 use protobuf::Message as ProtobufMessage;
-use std::io;
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::{cmp, io};
 
 /// A magic key to put right before each message. An atavism of primitive serial
 /// protocols.
@@ -35,14 +35,42 @@ impl From<protobuf::ProtobufError> for Error {
     }
 }
 
+fn encode_u32_to_be(value: u32, buffer: &mut [u8]) -> Result<(), Error> {
+    if buffer.len() < 4 {
+        return Err(Error::EncodeError);
+    }
+    let value = value.to_le();
+    buffer[0] = ((value & 0xFF00_0000) >> 24) as u8;
+    buffer[1] = ((value & 0x00FF_0000) >> 16) as u8;
+    buffer[2] = ((value & 0x0000_FF00) >> 8) as u8;
+    buffer[3] = (value & 0x0000_00FF) as u8;
+    Ok(())
+}
+
+fn decode_u32_from_be(buffer: &[u8]) -> Result<u32, Error> {
+    if buffer.len() < 4 {
+        return Err(Error::DecodeError);
+    }
+    let mut result = u32::from(buffer[0]);
+    result <<= 8;
+    result += u32::from(buffer[1]);
+    result <<= 8;
+    result += u32::from(buffer[2]);
+    result <<= 8;
+    result += u32::from(buffer[3]);
+    Ok(result)
+}
+
 pub struct ProtoIo<S: Read + Write> {
     stream: S,
+    buffer: [u8; 1024 * 4],
 }
 
 impl ProtoIo<TcpStream> {
     pub fn try_clone(&self) -> Result<ProtoIo<TcpStream>, ::std::io::Error> {
         Ok(ProtoIo {
             stream: self.stream.try_clone()?,
+            buffer: [0; 1024 * 4],
         })
     }
 }
@@ -52,31 +80,52 @@ impl<S: Read + Write> ProtoIo<S>
 //where T: Clone + Send + Sync + From<Vec<u8>> + Into<Vec<u8>>
 {
     pub fn from_stream(stream: S) -> Self {
-        ProtoIo { stream }
+        ProtoIo {
+            stream,
+            buffer: [0; 1024 * 4],
+        }
     }
 
     pub fn recv<T>(&mut self) -> Result<Message<T>, Error>
     where
         T: Clone + Send + Sync + AsRef<[u8]> + From<Vec<u8>>,
     {
-        let mut stream = protobuf::CodedInputStream::new(&mut self.stream);
-        // Read magic number
-        if stream.read_raw_varint32()? != FRAME_START {
+        self.stream.read_exact(&mut self.buffer[0..4])?;
+        let frame_start = decode_u32_from_be(&self.buffer[0..4])?;
+        if frame_start != FRAME_START {
             return Err(Error::FrameStartMismatch);
+        };
+        self.stream.read_exact(&mut self.buffer[0..4])?;
+        let size = decode_u32_from_be(&self.buffer[0..4])? as usize;
+
+        let mut message_v: Vec<u8> = Vec::new();
+        message_v.reserve(size);
+        while message_v.len() < size {
+            let num_to_read = cmp::min(self.buffer.len(), size - message_v.len());
+            let (slice, _) = self.buffer.split_at_mut(num_to_read);
+            self.stream.read_exact(slice)?;
+            message_v.extend_from_slice(slice);
         }
-        Message::from_proto(stream.read_message()?).ok_or(Error::DecodeError)
+
+        Message::parse_from_bytes(&message_v).map_err(Error::ProtobufError)
     }
 
     pub fn send<T>(&mut self, message: Message<T>) -> Result<(), Error>
     where
         T: Clone + Send + Sync + AsRef<[u8]> + From<Vec<u8>>,
     {
+        let mut buffer: [u8; 4] = [0; 4];
+        // Wrap stream
         let mut stream = protobuf::CodedOutputStream::new(&mut self.stream);
         // Write magic number
-        stream.write_raw_varint32(FRAME_START)?;
+        encode_u32_to_be(FRAME_START, &mut buffer[0..4])?;
+        stream.write_raw_bytes(&buffer)?;
         let message_p = message.into_proto();
+        // Write message size
+        encode_u32_to_be(message_p.compute_size(), &mut buffer[0..4])?;
+        stream.write_raw_bytes(&buffer)?;
         // Write message
-        message_p.write_length_delimited_to(&mut stream)?;
+        message_p.write_to(&mut stream)?;
         // Flush
         stream.flush()?;
         Ok(())
@@ -101,9 +150,6 @@ mod tests {
         println!("{:?}", pio.stream.get_ref());
         pio.stream.set_position(0);
         assert_eq!(msg0, pio.recv().expect("recv msg0"));
-        // TODO: Figure out why the cursor is wrong here.
-        let len = pio.stream.get_ref().len() as u64;
-        pio.stream.set_position(len / 2);
         assert_eq!(msg1, pio.recv().expect("recv msg1"));
     }
 }

--- a/src/proto_io.rs
+++ b/src/proto_io.rs
@@ -57,7 +57,7 @@ impl<S: Read + Write> ProtoIo<S>
 
     pub fn recv<T>(&mut self) -> Result<Message<T>, Error>
     where
-        T: Clone + Send + Sync + From<Vec<u8>>, // + Into<Vec<u8>>
+        T: Clone + Send + Sync + AsRef<[u8]> + From<Vec<u8>>,
     {
         let mut stream = protobuf::CodedInputStream::new(&mut self.stream);
         // Read magic number
@@ -69,7 +69,7 @@ impl<S: Read + Write> ProtoIo<S>
 
     pub fn send<T>(&mut self, message: Message<T>) -> Result<(), Error>
     where
-        T: Clone + Send + Sync + Into<Vec<u8>>,
+        T: Clone + Send + Sync + AsRef<[u8]> + From<Vec<u8>>,
     {
         let mut stream = protobuf::CodedOutputStream::new(&mut self.stream);
         // Write magic number
@@ -85,6 +85,7 @@ impl<S: Read + Write> ProtoIo<S>
 
 #[cfg(test)]
 mod tests {
+    use broadcast::BroadcastMessage;
     use proto_io::*;
     use std::io::Cursor;
 


### PR DESCRIPTION
This fixes several issues with the broadcast algorithm and enables the
previously ignored tests that now pass:
* Don't decide on a root hash based on anyone's `Echo` message.
* Work around the `merkle` crate's inability to produce the proof of the
  `i`-th leaf for a given index `i`.
* Ignore messages from unknown nodes.
* Avoid decoding multiple times.
* Document the full algorithm.
* Don't count multiple `Echo` or `Ready` messages coming from the same
  node.
* Fix index computation for a given proof.
* Move `BroadcastMessage` into `broadcast` to make the module more
  self-contained.

The example now only executes a single broadcast instance, expecting the
first node (the one with the lexicographically lowest address) to
propose a value. A shell script is added that runs for example nodes.

Use env_logger instead of simple_logger, so the log level can be controlled
with an environment variable. You can e.g. log all output from the broadcast
test and the crate itself in debug mode with:
RUST_LOG=hbbft=debug,broadcast=debug

Some debugging messages are more concise now and use hexadecimal
notation instead of printing arrays of decimal values.

An indentation error in the Travis script is also fixed.