### PR TITLE
Simplify the message types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ authors = ["Vladimir Komendantskiy <komendantsky@gmail.com>"]
 
 [dependencies]
 env_logger = "0.5.10"
+itertools = "0.7"
 log = "0.4.1"
 reed-solomon-erasure = "3.0"
 merkle = { git = "https://github.com/vkomenda/merkle.rs", branch = "public-proof" }
-ring = "^0.12"
 protobuf = "1.4.4"
-crossbeam = "0.3.2"
-crossbeam-channel = "0.1"
-itertools = "0.7"
+ring = "^0.12"
 
 [build-dependencies]
 protoc-rust = "1.4.4"
 
 [dev-dependencies]
+crossbeam = "0.3.2"
+crossbeam-channel = "0.1"
 docopt = "0.8"
 rand = "0.3"

--- a/examples/consensus-node.rs
+++ b/examples/consensus-node.rs
@@ -8,6 +8,7 @@ extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
+extern crate protobuf;
 
 mod network;
 

--- a/examples/run-consensus-nodes.sh
+++ b/examples/run-consensus-nodes.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-export RUST_LOG=hbbft=debug
+export RUST_LOG=hbbft=debug,consensus_node=debug
 
 cargo build --example consensus-node
 cargo run --example consensus-node -- --bind-address=127.0.0.1:5000 --remote-address=127.0.0.1:5001 --remote-address=127.0.0.1:5002 --remote-address=127.0.0.1:5003 --remote-address=127.0.0.1:5004 --value=Foo &

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -4,8 +4,6 @@ use itertools::Itertools;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::hash::Hash;
 
-use proto::message;
-
 /// Type of output from the Agreement message handler. The first component is
 /// the value on which the Agreement has decided, also called "output" in the
 /// HoneyadgerBFT paper. The second component is a queue of messages to be sent
@@ -19,36 +17,6 @@ pub enum AgreementMessage {
     BVal((u32, bool)),
     /// AUX message with an epoch.
     Aux((u32, bool)),
-}
-
-impl AgreementMessage {
-    pub fn into_proto(self) -> message::AgreementProto {
-        let mut p = message::AgreementProto::new();
-        match self {
-            AgreementMessage::BVal((e, b)) => {
-                p.set_epoch(e);
-                p.set_bval(b);
-            }
-            AgreementMessage::Aux((e, b)) => {
-                p.set_epoch(e);
-                p.set_aux(b);
-            }
-        }
-        p
-    }
-
-    // TODO: Re-enable lint once implemented.
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-    pub fn from_proto(mp: message::AgreementProto) -> Option<Self> {
-        let epoch = mp.get_epoch();
-        if mp.has_bval() {
-            Some(AgreementMessage::BVal((epoch, mp.get_bval())))
-        } else if mp.has_aux() {
-            Some(AgreementMessage::Aux((epoch, mp.get_aux())))
-        } else {
-            None
-        }
-    }
 }
 
 /// Binary Agreement instance.

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -114,7 +114,7 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
         &mut self,
         sender_id: &NodeUid,
         proposer_id: &NodeUid,
-        bmessage: BroadcastMessage<ProposedValue>,
+        bmessage: BroadcastMessage,
     ) -> Result<CommonSubsetOutput<NodeUid>, Error> {
         let mut instance_result = None;
         let input_result: Result<VecDeque<Output<NodeUid>>, Error> = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 #![feature(optin_builtin_traits)]
 #[macro_use]
 extern crate log;
-extern crate crossbeam;
-extern crate crossbeam_channel;
 extern crate itertools;
 extern crate merkle;
 extern crate protobuf;

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,16 +1,8 @@
-//! The local message delivery system.
-use proto::Message;
-use std::fmt::Debug;
-
-/// Message sent by a given source. The sources are consensus nodes indexed 1
-/// through N where N is the total number of nodes. Sourced messages are
-/// required when it is essential to know the message origin but the set of
-/// recepients is unknown without further computation which is irrelevant to the
-/// message delivery task.
+/// Message sent by a given source.
 #[derive(Clone, Debug)]
-pub struct SourcedMessage<T: Clone + Debug + Send + Sync + AsRef<[u8]>> {
-    pub source: usize,
-    pub message: Message<T>,
+pub struct SourcedMessage<M, N> {
+    pub source: N,
+    pub message: M,
 }
 
 /// Message destination can be either of the two:
@@ -20,21 +12,14 @@ pub struct SourcedMessage<T: Clone + Debug + Send + Sync + AsRef<[u8]>> {
 ///
 /// 2) `Node(i)`: node i or local algorithm instances with the node index i.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Target {
+pub enum Target<N> {
     All,
-    Node(usize),
+    Node(N),
 }
 
 /// Message with a designated target.
 #[derive(Clone, Debug, PartialEq)]
-pub struct TargetedMessage<T: Clone + Debug + Send + Sync + AsRef<[u8]>> {
-    pub target: Target,
-    pub message: Message<T>,
-}
-
-impl<T: Clone + Debug + Send + Sync + AsRef<[u8]>> TargetedMessage<T> {
-    /// Initialises a message while checking parameter preconditions.
-    pub fn new(target: Target, message: Message<T>) -> Self {
-        TargetedMessage { target, message }
-    }
+pub struct TargetedMessage<M, N> {
+    pub target: Target<N>,
+    pub message: M,
 }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -13,7 +13,8 @@ use rand::Rng;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
-use hbbft::broadcast::{Broadcast, BroadcastMessage, BroadcastTarget, TargetedBroadcastMessage};
+use hbbft::broadcast::{Broadcast, BroadcastMessage, TargetedBroadcastMessage};
+use hbbft::messaging::Target;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
 struct NodeId(usize);
@@ -29,7 +30,7 @@ struct TestNode {
     /// The instance of the broadcast algorithm.
     broadcast: Broadcast<NodeId>,
     /// Incoming messages from other nodes that this node has not yet handled.
-    queue: VecDeque<(NodeId, BroadcastMessage<ProposedValue>)>,
+    queue: VecDeque<(NodeId, BroadcastMessage)>,
     /// The values this node has output so far.
     outputs: Vec<ProposedValue>,
 }
@@ -216,7 +217,7 @@ impl<A: Adversary> TestNetwork<A> {
         for msg in msgs {
             match msg {
                 TargetedBroadcastMessage {
-                    target: BroadcastTarget::All,
+                    target: Target::All,
                     ref message,
                 } => {
                     for node in self.nodes.values_mut() {
@@ -227,7 +228,7 @@ impl<A: Adversary> TestNetwork<A> {
                     self.adversary.push_message(sender_id, msg.clone());
                 }
                 TargetedBroadcastMessage {
-                    target: BroadcastTarget::Node(to_id),
+                    target: Target::Node(to_id),
                     ref message,
                 } => {
                     if self.adv_nodes.contains(&to_id) {


### PR DESCRIPTION
This moves the remaining channel/crossbeam logic to the examples and reorganizes the message types.