### PR TITLE
Start implementing the top-level Honey Badger algorithm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.1.0"
 authors = ["Vladimir Komendantskiy <komendantsky@gmail.com>"]
 
 [dependencies]
+bincode = "1.0.0"
 env_logger = "0.5.10"
 itertools = "0.7"
 log = "0.4.1"
-reed-solomon-erasure = "3.0"
 merkle = { git = "https://github.com/vkomenda/merkle.rs", branch = "public-proof" }
 protobuf = "1.4.4"
+reed-solomon-erasure = "3.0"
 ring = "^0.12"
+serde = "1.0.54"
 
 [build-dependencies]
 protoc-rust = "1.4.4"

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -41,7 +41,7 @@ use std::marker::{Send, Sync};
 use std::net::SocketAddr;
 use std::{io, iter, process, thread, time};
 
-use hbbft::broadcast::{Broadcast, BroadcastMessage, TargetedBroadcastMessage};
+use hbbft::broadcast::{Broadcast, BroadcastMessage};
 use hbbft::messaging::SourcedMessage;
 use hbbft::proto::message::BroadcastProto;
 use network::commst;
@@ -130,8 +130,6 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                     for msg in broadcast
                         .propose_value(v.clone().into())
                         .expect("propose value")
-                        .into_iter()
-                        .map(TargetedBroadcastMessage::into)
                     {
                         tx_from_algo.send(msg).expect("send from algo");
                     }
@@ -148,7 +146,7 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                     for msg in &msgs {
                         debug!("{} sending to {:?}: {:?}", our_id, msg.target, msg.message);
                     }
-                    for msg in msgs.into_iter().map(TargetedBroadcastMessage::into) {
+                    for msg in msgs {
                         tx_from_algo.send(msg).expect("send from algo");
                     }
                     if let Some(output) = opt_output {

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -1,0 +1,168 @@
+use std::collections::{HashSet, VecDeque};
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+
+use bincode;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use common_subset::{self, CommonSubset};
+use messaging::TargetedMessage;
+
+/// An instance of the Honey Badger Byzantine fault tolerant consensus algorithm.
+pub struct HoneyBadger<T, N: Eq + Hash + Ord + Clone + Display> {
+    /// The buffer of transactions that have not yet been included in any batch.
+    buffer: VecDeque<T>,
+    /// The current epoch, i.e. the number of batches that have been output so far.
+    epoch: u64,
+    /// The Asynchronous Common Subset instance that decides which nodes' transactions to include.
+    // TODO: Common subset could be optimized to output before it is allowed to terminate. In that
+    // case, we would need to keep track of one or two previous instances, too.
+    common_subset: CommonSubset<N>,
+    /// This node's ID.
+    id: N,
+    /// The set of all node IDs of the participants (including ourselves).
+    all_ids: HashSet<N>,
+    /// The target number of transactions to be included in each batch.
+    // TODO: Do experiments and recommend a batch size. It should be proportional to
+    // `num_nodes * num_nodes * log(num_nodes)`.
+    batch_size: usize,
+}
+
+// TODO: Use a threshold encryption scheme to encrypt the proposed transactions.
+// TODO: We only contribute a proposal to the next round once we have `batch_size` buffered
+// transactions. This should be more configurable: `min_batch_size`, `max_batch_size` and maybe a
+// timeout? The paper assumes that all nodes will often have more or less the same set of
+// transactions in the buffer; if the sets are disjoint on average, we can just send our whole
+// buffer instead of 1/n of it.
+impl<T, N> HoneyBadger<T, N>
+where
+    T: Ord + AsRef<[u8]> + Serialize + DeserializeOwned,
+    N: Eq + Hash + Ord + Clone + Display + Debug,
+{
+    /// Returns a new Honey Badger instance with the given parameters, starting at epoch `0`.
+    pub fn new<I>(id: N, all_ids_iter: I, batch_size: usize) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = N>,
+    {
+        let all_ids: HashSet<N> = all_ids_iter.into_iter().collect();
+        if !all_ids.contains(&id) {
+            return Err(Error::OwnIdMissing);
+        }
+        Ok(HoneyBadger {
+            buffer: VecDeque::new(),
+            epoch: 0,
+            common_subset: CommonSubset::new(id.clone(), &all_ids)?,
+            id,
+            batch_size,
+            all_ids,
+        })
+    }
+
+    /// Adds transactions into the buffer.
+    pub fn add_transactions<I>(&mut self, txs: I) -> Result<HoneyBadgerOutput<T, N>, Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.buffer.extend(txs);
+        if self.buffer.len() < self.batch_size {
+            return Ok((None, Vec::new()));
+        }
+        // TODO: Handle the case `all_ids.len() == 1`.
+        let share = bincode::serialize(&self.buffer)?;
+        let msgs = self.common_subset
+            .send_proposed_value(share)?
+            .into_iter()
+            .map(|targeted_msg| {
+                targeted_msg.map(|cs_msg| Message::CommonSubset(self.epoch, cs_msg))
+            })
+            .collect();
+        Ok((None, msgs))
+    }
+
+    /// Handles a message from another node, and returns the next batch, if any, and the messages
+    /// to be sent out.
+    pub fn handle_message(
+        &mut self,
+        sender_id: &N,
+        message: Message<N>,
+    ) -> Result<HoneyBadgerOutput<T, N>, Error> {
+        match message {
+            Message::CommonSubset(epoch, cs_msg) => {
+                self.handle_common_subset_message(sender_id, epoch, cs_msg)
+            }
+        }
+    }
+
+    fn handle_common_subset_message(
+        &mut self,
+        sender_id: &N,
+        epoch: u64,
+        message: common_subset::Message<N>,
+    ) -> Result<HoneyBadgerOutput<T, N>, Error> {
+        if epoch != self.epoch {
+            // TODO: Do we need to cache messages for future epochs?
+            return Ok((None, Vec::new()));
+        }
+        let (cs_out, cs_msgs) = self.common_subset.handle_message(sender_id, message)?;
+        let mut msgs: Vec<TargetedMessage<Message<N>, N>> = cs_msgs
+            .into_iter()
+            .map(|targeted_msg| targeted_msg.map(|cs_msg| Message::CommonSubset(epoch, cs_msg)))
+            .collect();
+        let output = if let Some(ser_batches) = cs_out {
+            let mut transactions: Vec<T> = ser_batches
+                .into_iter()
+                .map(|ser_batch| bincode::deserialize::<Vec<T>>(&ser_batch))
+                .collect::<Result<Vec<_>, Box<bincode::ErrorKind>>>()?
+                .into_iter()
+                .flat_map(|txs| txs)
+                .collect();
+            transactions.sort();
+            self.epoch += 1;
+            self.common_subset = CommonSubset::new(self.id.clone(), &self.all_ids)?;
+            let (_, new_epoch_msgs) = self.add_transactions(None)?;
+            msgs.extend(new_epoch_msgs);
+            Some(Batch {
+                epoch,
+                transactions,
+            })
+        } else {
+            None
+        };
+        Ok((output, msgs))
+    }
+}
+
+type HoneyBadgerOutput<T, N> = (Option<Batch<T>>, Vec<TargetedMessage<Message<N>, N>>);
+
+/// A batch of transactions the algorithm has output.
+pub struct Batch<T> {
+    pub epoch: u64,
+    pub transactions: Vec<T>,
+}
+
+/// A message sent to or received from another node's Honey Badger instance.
+pub enum Message<N> {
+    /// A message belonging to the common subset algorithm in the given epoch.
+    CommonSubset(u64, common_subset::Message<N>),
+    // TODO: Decryption share.
+}
+
+/// A Honey Badger error.
+pub enum Error {
+    OwnIdMissing,
+    CommonSubset(common_subset::Error),
+    Bincode(Box<bincode::ErrorKind>),
+}
+
+impl From<common_subset::Error> for Error {
+    fn from(err: common_subset::Error) -> Error {
+        Error::CommonSubset(err)
+    }
+}
+
+impl From<Box<bincode::ErrorKind>> for Error {
+    fn from(err: Box<bincode::ErrorKind>) -> Error {
+        Error::Bincode(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! honey badger of BFT protocols" after a paper with the same title.
 
 #![feature(optin_builtin_traits)]
+
+extern crate bincode;
 #[macro_use]
 extern crate log;
 extern crate itertools;
@@ -11,10 +13,12 @@ extern crate merkle;
 extern crate protobuf;
 extern crate reed_solomon_erasure;
 extern crate ring;
+extern crate serde;
 
 pub mod agreement;
 pub mod broadcast;
 pub mod common_subset;
+pub mod honey_badger;
 pub mod messaging;
 pub mod proto;
 pub mod proto_io;

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -17,9 +17,29 @@ pub enum Target<N> {
     Node(N),
 }
 
+impl<N> Target<N> {
+    /// Returns a `TargetedMessage` with this target, and the given message.
+    pub fn message<M>(self, message: M) -> TargetedMessage<M, N> {
+        TargetedMessage {
+            target: self,
+            message,
+        }
+    }
+}
+
 /// Message with a designated target.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TargetedMessage<M, N> {
     pub target: Target<N>,
     pub message: M,
+}
+
+impl<M, N> TargetedMessage<M, N> {
+    /// Applies the given transformation of messages, preserving the target.
+    pub fn map<T, F: Fn(M) -> T>(self, f: F) -> TargetedMessage<T, N> {
+        TargetedMessage {
+            target: self.target,
+            message: f(self.message),
+        }
+    }
 }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -13,15 +13,15 @@ use rand::Rng;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
-use hbbft::broadcast::{Broadcast, BroadcastMessage, TargetedBroadcastMessage};
-use hbbft::messaging::Target;
+use hbbft::broadcast::{Broadcast, BroadcastMessage};
+use hbbft::messaging::{Target, TargetedMessage};
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
 struct NodeId(usize);
 
 type ProposedValue = Vec<u8>;
 
-type MessageQueue = VecDeque<TargetedBroadcastMessage<NodeId>>;
+type MessageQueue = VecDeque<TargetedMessage<BroadcastMessage, NodeId>>;
 
 /// A "node" running a broadcast instance.
 struct TestNode {
@@ -97,10 +97,10 @@ trait Adversary {
     fn pick_node(&self, nodes: &BTreeMap<NodeId, TestNode>) -> NodeId;
 
     /// Adds a message sent to one of the adversary's nodes.
-    fn push_message(&mut self, sender_id: NodeId, msg: TargetedBroadcastMessage<NodeId>);
+    fn push_message(&mut self, sender_id: NodeId, msg: TargetedMessage<BroadcastMessage, NodeId>);
 
     /// Produces a list of messages to be sent from the adversary's nodes.
-    fn step(&mut self) -> Vec<(NodeId, TargetedBroadcastMessage<NodeId>)>;
+    fn step(&mut self) -> Vec<(NodeId, TargetedMessage<BroadcastMessage, NodeId>)>;
 }
 
 /// An adversary whose nodes never send any messages.
@@ -120,11 +120,11 @@ impl Adversary for SilentAdversary {
         self.scheduler.pick_node(nodes)
     }
 
-    fn push_message(&mut self, _: NodeId, _: TargetedBroadcastMessage<NodeId>) {
+    fn push_message(&mut self, _: NodeId, _: TargetedMessage<BroadcastMessage, NodeId>) {
         // All messages are ignored.
     }
 
-    fn step(&mut self) -> Vec<(NodeId, TargetedBroadcastMessage<NodeId>)> {
+    fn step(&mut self) -> Vec<(NodeId, TargetedMessage<BroadcastMessage, NodeId>)> {
         vec![] // No messages are sent.
     }
 }
@@ -158,11 +158,11 @@ impl Adversary for ProposeAdversary {
         self.scheduler.pick_node(nodes)
     }
 
-    fn push_message(&mut self, _: NodeId, _: TargetedBroadcastMessage<NodeId>) {
+    fn push_message(&mut self, _: NodeId, _: TargetedMessage<BroadcastMessage, NodeId>) {
         // All messages are ignored.
     }
 
-    fn step(&mut self) -> Vec<(NodeId, TargetedBroadcastMessage<NodeId>)> {
+    fn step(&mut self) -> Vec<(NodeId, TargetedMessage<BroadcastMessage, NodeId>)> {
         if self.has_sent {
             return vec![];
         }
@@ -212,11 +212,11 @@ impl<A: Adversary> TestNetwork<A> {
     /// Pushes the messages into the queues of the corresponding recipients.
     fn dispatch_messages<Q>(&mut self, sender_id: NodeId, msgs: Q)
     where
-        Q: IntoIterator<Item = TargetedBroadcastMessage<NodeId>> + fmt::Debug,
+        Q: IntoIterator<Item = TargetedMessage<BroadcastMessage, NodeId>> + fmt::Debug,
     {
         for msg in msgs {
             match msg {
-                TargetedBroadcastMessage {
+                TargetedMessage {
                     target: Target::All,
                     ref message,
                 } => {
@@ -227,7 +227,7 @@ impl<A: Adversary> TestNetwork<A> {
                     }
                     self.adversary.push_message(sender_id, msg.clone());
                 }
-                TargetedBroadcastMessage {
+                TargetedMessage {
                     target: Target::Node(to_id),
                     ref message,
                 } => {


### PR DESCRIPTION
This also contains a few fixes for the `common_subset` module:
* Rename `common_subset::Output` to `Message` to avoid confusing it
  with the value that the algorithm outputs as a result.
* Implement dispatch of messages to the right instance within
  `CommonSubset`, in a way that is transparent to the user.

And it generalizes `TargetedMessage`, so that it can replace e.g. `TargetedBroadcastMessage`.