### PR TITLE
Define a common DistAlgorithm trait.

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -113,14 +113,16 @@ pub struct Broadcast<N> {
 
 impl<N: Eq + Debug + Clone + Ord> DistAlgorithm for Broadcast<N> {
     type NodeUid = N;
-    type Input = Vec<u8>; // TODO: Allow anything serializable.
+    // TODO: Allow anything serializable and deserializable, i.e. make this a type parameter
+    // T: Serialize + DeserializeOwned
+    type Input = Vec<u8>;
     type Output = Self::Input;
     type Message = BroadcastMessage;
     type Error = Error;
 
     fn input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
         if self.our_id != self.proposer_id {
-            return Err(Error::UnexpectedMessage);
+            return Err(Error::InstanceCannotPropose);
         }
         // Split the value into chunks/shards, encode them with erasure codes.
         // Assemble a Merkle tree from data and parity shards. Take all proofs
@@ -432,7 +434,7 @@ pub enum Error {
     Threading,
     ProofConstructionFailed,
     ReedSolomon(rse::Error),
-    UnexpectedMessage,
+    InstanceCannotPropose,
     NotImplemented,
     UnknownSender,
 }

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -1,13 +1,14 @@
 use std::collections::{HashSet, VecDeque};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::iter;
 
 use bincode;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use common_subset::{self, CommonSubset};
-use messaging::TargetedMessage;
+use messaging::{DistAlgorithm, TargetedMessage};
 
 /// An instance of the Honey Badger Byzantine fault tolerant consensus algorithm.
 pub struct HoneyBadger<T, N: Eq + Hash + Ord + Clone + Display> {
@@ -22,11 +23,58 @@ pub struct HoneyBadger<T, N: Eq + Hash + Ord + Clone + Display> {
     /// This node's ID.
     id: N,
     /// The set of all node IDs of the participants (including ourselves).
-    all_ids: HashSet<N>,
+    all_uids: HashSet<N>,
     /// The target number of transactions to be included in each batch.
     // TODO: Do experiments and recommend a batch size. It should be proportional to
     // `num_nodes * num_nodes * log(num_nodes)`.
     batch_size: usize,
+    /// The messages that need to be sent to other nodes.
+    messages: VecDeque<TargetedMessage<Message<N>, N>>,
+    /// The outputs from completed epochs.
+    output: VecDeque<Batch<T>>,
+}
+
+impl<T, N> DistAlgorithm for HoneyBadger<T, N>
+where
+    T: Ord + Serialize + DeserializeOwned,
+    N: Eq + Hash + Ord + Clone + Display + Debug,
+{
+    type NodeUid = N;
+    type Input = T;
+    type Output = Batch<T>;
+    type Message = Message<N>;
+    type Error = Error;
+
+    fn input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        self.add_transactions(iter::once(input))
+    }
+
+    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<(), Self::Error> {
+        if !self.all_uids.contains(sender_id) {
+            return Err(Error::UnknownSender);
+        }
+        match message {
+            Message::CommonSubset(epoch, cs_msg) => {
+                self.handle_common_subset_message(sender_id, epoch, cs_msg)
+            }
+        }
+    }
+
+    fn next_message(&mut self) -> Option<TargetedMessage<Self::Message, N>> {
+        self.messages.pop_front()
+    }
+
+    fn next_output(&mut self) -> Option<Self::Output> {
+        self.output.pop_front()
+    }
+
+    fn terminated(&self) -> bool {
+        false
+    }
+
+    fn our_id(&self) -> &N {
+        &self.id
+    }
 }
 
 // TODO: Use a threshold encryption scheme to encrypt the proposed transactions.
@@ -37,103 +85,83 @@ pub struct HoneyBadger<T, N: Eq + Hash + Ord + Clone + Display> {
 // buffer instead of 1/n of it.
 impl<T, N> HoneyBadger<T, N>
 where
-    T: Ord + AsRef<[u8]> + Serialize + DeserializeOwned,
+    T: Ord + Serialize + DeserializeOwned,
     N: Eq + Hash + Ord + Clone + Display + Debug,
 {
     /// Returns a new Honey Badger instance with the given parameters, starting at epoch `0`.
-    pub fn new<I>(id: N, all_ids_iter: I, batch_size: usize) -> Result<Self, Error>
+    pub fn new<I>(id: N, all_uids_iter: I, batch_size: usize) -> Result<Self, Error>
     where
         I: IntoIterator<Item = N>,
     {
-        let all_ids: HashSet<N> = all_ids_iter.into_iter().collect();
-        if !all_ids.contains(&id) {
+        let all_uids: HashSet<N> = all_uids_iter.into_iter().collect();
+        if !all_uids.contains(&id) {
             return Err(Error::OwnIdMissing);
         }
         Ok(HoneyBadger {
             buffer: VecDeque::new(),
             epoch: 0,
-            common_subset: CommonSubset::new(id.clone(), &all_ids)?,
+            common_subset: CommonSubset::new(id.clone(), &all_uids)?,
             id,
             batch_size,
-            all_ids,
+            all_uids,
+            messages: VecDeque::new(),
+            output: VecDeque::new(),
         })
     }
 
     /// Adds transactions into the buffer.
-    pub fn add_transactions<I>(&mut self, txs: I) -> Result<HoneyBadgerOutput<T, N>, Error>
+    pub fn add_transactions<I>(&mut self, txs: I) -> Result<(), Error>
     where
         I: IntoIterator<Item = T>,
     {
         self.buffer.extend(txs);
         if self.buffer.len() < self.batch_size {
-            return Ok((None, Vec::new()));
+            return Ok(());
         }
-        // TODO: Handle the case `all_ids.len() == 1`.
         let share = bincode::serialize(&self.buffer)?;
-        let msgs = self.common_subset
-            .send_proposed_value(share)?
-            .into_iter()
-            .map(|targeted_msg| {
-                targeted_msg.map(|cs_msg| Message::CommonSubset(self.epoch, cs_msg))
-            })
-            .collect();
-        Ok((None, msgs))
-    }
-
-    /// Handles a message from another node, and returns the next batch, if any, and the messages
-    /// to be sent out.
-    pub fn handle_message(
-        &mut self,
-        sender_id: &N,
-        message: Message<N>,
-    ) -> Result<HoneyBadgerOutput<T, N>, Error> {
-        match message {
-            Message::CommonSubset(epoch, cs_msg) => {
-                self.handle_common_subset_message(sender_id, epoch, cs_msg)
-            }
+        for targeted_msg in self.common_subset.send_proposed_value(share)? {
+            let msg = targeted_msg.map(|cs_msg| Message::CommonSubset(self.epoch, cs_msg));
+            self.messages.push_back(msg);
         }
+        Ok(())
     }
 
+    /// Handles a message for the common subset sub-algorithm.
     fn handle_common_subset_message(
         &mut self,
         sender_id: &N,
         epoch: u64,
         message: common_subset::Message<N>,
-    ) -> Result<HoneyBadgerOutput<T, N>, Error> {
+    ) -> Result<(), Error> {
         if epoch != self.epoch {
             // TODO: Do we need to cache messages for future epochs?
-            return Ok((None, Vec::new()));
+            return Ok(());
         }
         let (cs_out, cs_msgs) = self.common_subset.handle_message(sender_id, message)?;
-        let mut msgs: Vec<TargetedMessage<Message<N>, N>> = cs_msgs
-            .into_iter()
-            .map(|targeted_msg| targeted_msg.map(|cs_msg| Message::CommonSubset(epoch, cs_msg)))
-            .collect();
-        let output = if let Some(ser_batches) = cs_out {
-            let mut transactions: Vec<T> = ser_batches
+        for targeted_msg in cs_msgs {
+            let msg = targeted_msg.map(|cs_msg| Message::CommonSubset(epoch, cs_msg));
+            self.messages.push_back(msg);
+        }
+        let batches: Vec<Vec<T>> = if let Some(ser_batches) = cs_out {
+            ser_batches
                 .into_iter()
-                .map(|ser_batch| bincode::deserialize::<Vec<T>>(&ser_batch))
-                .collect::<Result<Vec<_>, Box<bincode::ErrorKind>>>()?
-                .into_iter()
-                .flat_map(|txs| txs)
-                .collect();
-            transactions.sort();
-            self.epoch += 1;
-            self.common_subset = CommonSubset::new(self.id.clone(), &self.all_ids)?;
-            let (_, new_epoch_msgs) = self.add_transactions(None)?;
-            msgs.extend(new_epoch_msgs);
-            Some(Batch {
-                epoch,
-                transactions,
-            })
+                .map(|ser_batch| bincode::deserialize(&ser_batch))
+                .collect::<Result<_, _>>()?
         } else {
-            None
+            return Ok(());
         };
-        Ok((output, msgs))
+        let mut transactions: Vec<T> = batches.into_iter().flat_map(|txs| txs).collect();
+        transactions.sort();
+        self.epoch += 1;
+        self.common_subset = CommonSubset::new(self.id.clone(), &self.all_uids)?;
+        self.add_transactions(None)?;
+        self.output.push_back(Batch {
+            epoch,
+            transactions,
+        });
+        Ok(())
     }
 }
-
-type HoneyBadgerOutput<T, N> = (Option<Batch<T>>, Vec<TargetedMessage<Message<N>, N>>);
 
 /// A batch of transactions the algorithm has output.
 pub struct Batch<T> {
@@ -143,6 +171,7 @@ pub struct Batch<T> {
 
 /// A message sent to or received from another node's Honey Badger instance.
 #[cfg_attr(feature = "serialization-serde", derive(Serialize))]
+#[derive(Debug)]
 pub enum Message<N> {
     /// A message belonging to the common subset algorithm in the given epoch.
     CommonSubset(u64, common_subset::Message<N>),
@@ -150,8 +179,10 @@ pub enum Message<N> {
 }
 
 /// A Honey Badger error.
+#[derive(Debug)]
 pub enum Error {
     OwnIdMissing,
+    UnknownSender,
     CommonSubset(common_subset::Error),
     Bincode(Box<bincode::ErrorKind>),
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -89,6 +89,14 @@ pub trait DistAlgorithm {
     {
         MessageIter { algorithm: self }
     }
+
+    /// Returns an iterator over the algorithm's outputs.
+    fn output_iter(&mut self) -> OutputIter<Self>
+    where
+        Self: Sized,
+    {
+        OutputIter { algorithm: self }
+    }
 }
 
 /// An iterator over a distributed algorithm's outgoing messages.
@@ -101,5 +109,18 @@ impl<'a, D: DistAlgorithm + 'a> Iterator for MessageIter<'a, D> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.algorithm.next_message()
+    }
+}
+
+/// An iterator over a distributed algorithm's pending outputs.
+pub struct OutputIter<'a, D: DistAlgorithm + 'a> {
+    algorithm: &'a mut D,
+}
+
+impl<'a, D: DistAlgorithm + 'a> Iterator for OutputIter<'a, D> {
+    type Item = D::Output;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.algorithm.next_output()
     }
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 /// Message sent by a given source.
 #[derive(Clone, Debug)]
 pub struct SourcedMessage<M, N> {
@@ -41,5 +43,63 @@ impl<M, N> TargetedMessage<M, N> {
             target: self.target,
             message: f(self.message),
         }
+    }
+}
+
+/// A distributed algorithm that defines a message flow.
+pub trait DistAlgorithm {
+    /// Unique node identifier.
+    type NodeUid: Debug + Clone + Ord + Eq;
+    /// The input provided by the user.
+    type Input;
+    /// The output type. Some algorithms return an output exactly once, others return multiple
+    /// times.
+    type Output;
+    /// The messages that need to be exchanged between the instances in the participating nodes.
+    type Message: Debug;
+    /// The errors that can occur during execution.
+    type Error: Debug;
+
+    /// Handles an input provided by the user, and returns
+    fn input(&mut self, input: Self::Input) -> Result<(), Self::Error>;
+
+    /// Handles a message received from node `sender_id`.
+    fn handle_message(
+        &mut self,
+        sender_id: &Self::NodeUid,
+        message: Self::Message,
+    ) -> Result<(), Self::Error>;
+
+    /// Returns a message that needs to be sent to another node.
+    fn next_message(&mut self) -> Option<TargetedMessage<Self::Message, Self::NodeUid>>;
+
+    /// Returns the algorithm's output.
+    fn next_output(&mut self) -> Option<Self::Output>;
+
+    /// Returns `true` if execution has completed and this instance can be dropped.
+    fn terminated(&self) -> bool;
+
+    /// Returns this node's own ID.
+    fn our_id(&self) -> &Self::NodeUid;
+
+    /// Returns an iterator over the outgoing messages.
+    fn message_iter(&mut self) -> MessageIter<Self>
+    where
+        Self: Sized,
+    {
+        MessageIter { algorithm: self }
+    }
+}
+
+/// An iterator over a distributed algorithm's outgoing messages.
+pub struct MessageIter<'a, D: DistAlgorithm + 'a> {
+    algorithm: &'a mut D,
+}
+
+impl<'a, D: DistAlgorithm + 'a> Iterator for MessageIter<'a, D> {
+    type Item = TargetedMessage<D::Message, D::NodeUid>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.algorithm.next_message()
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -67,11 +67,11 @@ impl AgreementMessage {
     pub fn into_proto(self) -> message::AgreementProto {
         let mut p = message::AgreementProto::new();
         match self {
-            AgreementMessage::BVal((e, b)) => {
+            AgreementMessage::BVal(e, b) => {
                 p.set_epoch(e);
                 p.set_bval(b);
             }
-            AgreementMessage::Aux((e, b)) => {
+            AgreementMessage::Aux(e, b) => {
                 p.set_epoch(e);
                 p.set_aux(b);
             }
@@ -84,9 +84,9 @@ impl AgreementMessage {
     pub fn from_proto(mp: message::AgreementProto) -> Option<Self> {
         let epoch = mp.get_epoch();
         if mp.has_bval() {
-            Some(AgreementMessage::BVal((epoch, mp.get_bval())))
+            Some(AgreementMessage::BVal(epoch, mp.get_bval()))
         } else if mp.has_aux() {
-            Some(AgreementMessage::Aux((epoch, mp.get_aux())))
+            Some(AgreementMessage::Aux(epoch, mp.get_aux()))
         } else {
             None
         }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -49,13 +49,13 @@ impl<D: DistAlgorithm> TestNode<D> {
         self.algo
             .handle_message(&from_id, msg)
             .expect("handling message");
-        self.outputs.extend(self.algo.next_output());
+        self.outputs.extend(self.algo.output_iter());
     }
 
     /// Inputs a value into the instance.
     fn input(&mut self, input: D::Input) {
         self.algo.input(input).expect("input");
-        self.outputs.extend(self.algo.next_output());
+        self.outputs.extend(self.algo.output_iter());
     }
 }
 


### PR DESCRIPTION
This will allow us to deduplicate network simulations in tests for the
different algorithms. More generally, it facilitates writing general
tools and applying them to all distributed algorithms.