### PR TITLE
Cleaned up imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,28 @@ Once you have verified that the `protoc` binary is in your `$PATH`, you can
 build `hbbft` using cargo:
 
     $ cargo build [--release]
+
+# Contributing
+
+Before submitting PRs to `hbbft`, check that your code is properly
+formatted using `rustfmt`.
+
+You can check to see whether or not you have `rustfmt` installed by running
+the following:
+
+    $ cargo fmt --help
+
+If you see an error message similiar to the following, you will need to
+install `rustfmt`:
+
+    error: toolchain '<you rust target archetecture>' does not have the binary `cargo-fmt`
+
+To install `rustfmt` run the following:
+
+    $ rustup component add rustfmt-preview
+
+To run `rustfmt` on `hbbft` run the following:
+
+    $ cargo fmt
+
+Commit and push your changes, then submit your PR!

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -1,8 +1,9 @@
 //! Binary Byzantine agreement protocol from a common coin protocol.
 
-use itertools::Itertools;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::hash::Hash;
+
+use itertools::Itertools;
 
 /// Type of output from the Agreement message handler. The first component is
 /// the value on which the Agreement has decided, also called "output" in the

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -503,12 +503,16 @@ pub fn index_of_lemma(lemma: &Lemma, n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use merkle::MerkleTree;
+    use ring::digest::SHA256;
+
+    use super::index_of_lemma;
+
     #[test]
     fn test_index_of_lemma() {
         for &n in &[3, 4, 13, 16, 127, 128, 129, 255] {
             let shards: Vec<[u8; 1]> = (0..n).map(|i| [i as u8]).collect();
-            let mtree = MerkleTree::from_vec(&::ring::digest::SHA256, shards);
+            let mtree = MerkleTree::from_vec(&SHA256, shards);
             for (i, val) in mtree.iter().enumerate() {
                 let p = mtree.gen_proof(val.clone()).expect("generate proof");
                 let idx = index_of_lemma(&p.lemma, n);

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -3,8 +3,8 @@ use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 use std::iter;
 
-use merkle::MerkleTree;
 use merkle::proof::{Lemma, Positioned, Proof};
+use merkle::MerkleTree;
 use reed_solomon_erasure::{self as rse, ReedSolomon};
 
 use messaging::{Target, TargetedMessage};

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,14 +1,14 @@
-use merkle::proof::{Lemma, Positioned, Proof};
-use merkle::MerkleTree;
-use proto::*;
-use reed_solomon_erasure as rse;
-use reed_solomon_erasure::ReedSolomon;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 use std::iter;
 
+use merkle::MerkleTree;
+use merkle::proof::{Lemma, Positioned, Proof};
+use reed_solomon_erasure::{self as rse, ReedSolomon};
+
 use messaging::{Target, TargetedMessage};
+use proto::{HexBytes, HexList, HexProof};
 
 type MessageQueue<NodeUid> = VecDeque<TargetedMessage<BroadcastMessage, NodeUid>>;
 
@@ -21,8 +21,8 @@ pub enum BroadcastMessage {
     Ready(Vec<u8>),
 }
 
-impl fmt::Debug for BroadcastMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Debug for BroadcastMessage {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             BroadcastMessage::Value(ref v) => write!(f, "Value({:?})", HexProof(&v)),
             BroadcastMessage::Echo(ref v) => write!(f, "Echo({:?})", HexProof(&v)),

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -319,4 +319,3 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
         }
     }
 }
-

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -7,21 +7,40 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
-use agreement;
-use agreement::{Agreement, AgreementMessage};
-
-use broadcast;
-use broadcast::{Broadcast, BroadcastMessage};
-
+use agreement::{self, Agreement, AgreementMessage};
+use broadcast::{self, Broadcast, BroadcastMessage};
 use messaging::{Target, TargetedMessage};
 
 // TODO: Make this a generic argument of `Broadcast`.
 type ProposedValue = Vec<u8>;
+
 // Type of output from the Common Subset message handler.
 type CommonSubsetOutput<NodeUid> = (
     Option<HashSet<ProposedValue>>,
     VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>,
 );
+
+#[derive(Clone, Debug)]
+pub enum Error {
+    UnexpectedMessage,
+    NotImplemented,
+    NoSuchBroadcastInstance,
+    NoSuchAgreementInstance,
+    Broadcast(broadcast::Error),
+    Agreement(agreement::Error),
+}
+
+impl From<broadcast::Error> for Error {
+    fn from(err: broadcast::Error) -> Error {
+        Error::Broadcast(err)
+    }
+}
+
+impl From<agreement::Error> for Error {
+    fn from(err: agreement::Error) -> Error {
+        Error::Agreement(err)
+    }
+}
 
 /// Message from Common Subset to remote nodes.
 pub enum Message<NodeUid> {
@@ -301,24 +320,3 @@ impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum Error {
-    UnexpectedMessage,
-    NotImplemented,
-    NoSuchBroadcastInstance,
-    NoSuchAgreementInstance,
-    Broadcast(broadcast::Error),
-    Agreement(agreement::Error),
-}
-
-impl From<broadcast::Error> for Error {
-    fn from(err: broadcast::Error) -> Error {
-        Error::Broadcast(err)
-    }
-}
-
-impl From<agreement::Error> for Error {
-    fn from(err: agreement::Error) -> Error {
-        Error::Agreement(err)
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@
 #![feature(optin_builtin_traits)]
 
 extern crate bincode;
+extern crate itertools;
 #[macro_use]
 extern crate log;
-extern crate itertools;
 extern crate merkle;
 extern crate protobuf;
 extern crate reed_solomon_erasure;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,18 +1,29 @@
 //! Construction of messages from protobuf buffers.
+
 pub mod message;
+
+use std::fmt::{self, Debug, Display, Formatter};
+
+use merkle::proof::{Lemma, Positioned, Proof};
+use ring::digest::Algorithm;
 
 use agreement::AgreementMessage;
 use broadcast::BroadcastMessage;
-use merkle::proof::{Lemma, Positioned, Proof};
-use proto::message::*;
-use ring::digest::Algorithm;
-use std::fmt;
+use proto::message::{
+    AgreementProto,
+    BroadcastProto,
+    EchoProto,
+    LemmaProto,
+    ProofProto,
+    ReadyProto,
+    ValueProto
+};
 
 /// Wrapper for a byte array, whose `Debug` implementation outputs shortened hexadecimal strings.
 pub struct HexBytes<'a>(pub &'a [u8]);
 
-impl<'a> fmt::Debug for HexBytes<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> Debug for HexBytes<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if self.0.len() > 6 {
             for byte in &self.0[..3] {
                 write!(f, "{:02x}", byte)?;
@@ -34,8 +45,8 @@ impl<'a> fmt::Debug for HexBytes<'a> {
 /// strings.
 pub struct HexList<'a, T: 'a>(pub &'a [T]);
 
-impl<'a, T: AsRef<[u8]>> fmt::Debug for HexList<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a, T: AsRef<[u8]>> Debug for HexList<'a, T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let v: Vec<_> = self.0.iter().map(|t| HexBytes(t.as_ref())).collect();
         write!(f, "{:?}", v)
     }
@@ -43,8 +54,8 @@ impl<'a, T: AsRef<[u8]>> fmt::Debug for HexList<'a, T> {
 
 pub struct HexProof<'a, T: 'a>(pub &'a Proof<T>);
 
-impl<'a, T: AsRef<[u8]>> fmt::Debug for HexProof<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a, T: AsRef<[u8]>> Debug for HexProof<'a, T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "Proof {{ algorithm: {:?}, root_hash: {:?}, lemma for leaf #{}, value: {:?} }}",
@@ -56,15 +67,15 @@ impl<'a, T: AsRef<[u8]>> fmt::Debug for HexProof<'a, T> {
     }
 }
 
-impl From<message::BroadcastProto> for BroadcastMessage {
-    fn from(proto: message::BroadcastProto) -> BroadcastMessage {
+impl From<BroadcastProto> for BroadcastMessage {
+    fn from(proto: BroadcastProto) -> BroadcastMessage {
         BroadcastMessage::from_proto(proto, &::ring::digest::SHA256)
             .expect("invalid broadcast message")
     }
 }
 
-impl From<BroadcastMessage> for message::BroadcastProto {
-    fn from(msg: BroadcastMessage) -> message::BroadcastProto {
+impl From<BroadcastMessage> for BroadcastProto {
+    fn from(msg: BroadcastMessage) -> BroadcastProto {
         msg.into_proto()
     }
 }
@@ -113,8 +124,8 @@ impl BroadcastMessage {
 }
 
 impl AgreementMessage {
-    pub fn into_proto(self) -> message::AgreementProto {
-        let mut p = message::AgreementProto::new();
+    pub fn into_proto(self) -> AgreementProto {
+        let mut p = AgreementProto::new();
         match self {
             AgreementMessage::BVal((e, b)) => {
                 p.set_epoch(e);
@@ -130,7 +141,7 @@ impl AgreementMessage {
 
     // TODO: Re-enable lint once implemented.
     #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-    pub fn from_proto(mp: message::AgreementProto) -> Option<Self> {
+    pub fn from_proto(mp: AgreementProto) -> Option<Self> {
         let epoch = mp.get_epoch();
         if mp.has_bval() {
             Some(AgreementMessage::BVal((epoch, mp.get_bval())))
@@ -266,8 +277,8 @@ fn path_of_lemma(mut lemma: &Lemma) -> BinaryPath {
     }
 }
 
-impl fmt::Display for BinaryPath {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for BinaryPath {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         for b in &self.0 {
             if *b {
                 write!(f, "1")?;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -10,13 +10,7 @@ use ring::digest::Algorithm;
 use agreement::AgreementMessage;
 use broadcast::BroadcastMessage;
 use proto::message::{
-    AgreementProto,
-    BroadcastProto,
-    EchoProto,
-    LemmaProto,
-    ProofProto,
-    ReadyProto,
-    ValueProto
+    AgreementProto, BroadcastProto, EchoProto, LemmaProto, ProofProto, ReadyProto, ValueProto,
 };
 
 /// Wrapper for a byte array, whose `Debug` implementation outputs shortened hexadecimal strings.

--- a/src/proto_io.rs
+++ b/src/proto_io.rs
@@ -131,10 +131,10 @@ impl<S: Read + Write, M: Message> ProtoIo<S, M>
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
-    
+
+    use super::ProtoIo;
     use broadcast::BroadcastMessage;
     use proto::message::BroadcastProto;
-    use super::ProtoIo;
 
     #[test]
     fn encode_decode_message() {

--- a/src/proto_io.rs
+++ b/src/proto_io.rs
@@ -1,10 +1,11 @@
 //! Protobuf message IO task structure.
 
-use protobuf::{self, Message};
-use std::io::{Read, Write};
+use std::cmp;
+use std::io::{self, Read, Write};
 use std::marker::PhantomData;
 use std::net::TcpStream;
-use std::{cmp, io};
+
+use protobuf::{self, CodedOutputStream, Message, ProtobufError};
 
 /// A magic key to put right before each message. An atavism of primitive serial
 /// protocols.
@@ -19,7 +20,7 @@ pub enum Error {
     DecodeError,
     FrameStartMismatch,
     // ProtocolError,
-    ProtobufError(protobuf::ProtobufError),
+    ProtobufError(ProtobufError),
 }
 
 impl From<io::Error> for Error {
@@ -28,8 +29,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<protobuf::ProtobufError> for Error {
-    fn from(err: protobuf::ProtobufError) -> Error {
+impl From<ProtobufError> for Error {
+    fn from(err: ProtobufError) -> Error {
         Error::ProtobufError(err)
     }
 }
@@ -67,7 +68,7 @@ pub struct ProtoIo<S: Read + Write, M> {
 }
 
 impl<M> ProtoIo<TcpStream, M> {
-    pub fn try_clone(&self) -> Result<Self, ::std::io::Error> {
+    pub fn try_clone(&self) -> Result<Self, io::Error> {
         Ok(ProtoIo {
             stream: self.stream.try_clone()?,
             buffer: [0; 1024 * 4],
@@ -112,7 +113,7 @@ impl<S: Read + Write, M: Message> ProtoIo<S, M>
     pub fn send(&mut self, message: &M) -> Result<(), Error> {
         let mut buffer: [u8; 4] = [0; 4];
         // Wrap stream
-        let mut stream = protobuf::CodedOutputStream::new(&mut self.stream);
+        let mut stream = CodedOutputStream::new(&mut self.stream);
         // Write magic number
         encode_u32_to_be(FRAME_START, &mut buffer[0..4])?;
         stream.write_raw_bytes(&buffer)?;
@@ -129,10 +130,11 @@ impl<S: Read + Write, M: Message> ProtoIo<S, M>
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+    
     use broadcast::BroadcastMessage;
     use proto::message::BroadcastProto;
-    use proto_io::*;
-    use std::io::Cursor;
+    use super::ProtoIo;
 
     #[test]
     fn encode_decode_message() {


### PR DESCRIPTION
- Standardized import ordering (from top of file downwards) to:
```
extern <crate name>
mod <mod name>
use:std:: ...
use::<extern crate name>:: ...
use::<mod name>:: ...
```
- Removed `*` imports.
- Removed redundant and/or unnecessary namespace (`::`) operators.