### PR TITLE
Common Subset test and fixes

### DIFF
--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -140,11 +140,12 @@ impl<NodeUid: Clone + Eq + Hash> Agreement<NodeUid> {
         // upon receiving BVAL_r(b) messages from 2f + 1 nodes,
         // bin_values_r := bin_values_r ∪ {b}
         if count_bval == 2 * self.num_faulty_nodes + 1 {
+            let bin_values_was_empty = self.bin_values.is_empty();
             self.bin_values.insert(b);
 
             // wait until bin_values_r != 0, then multicast AUX_r(w)
             // where w ∈ bin_values_r
-            if self.bin_values.len() == 1 {
+            if bin_values_was_empty {
                 // Send an AUX message at most once per epoch.
                 outgoing.push_back(AgreementMessage::Aux(self.epoch, b));
                 // Receive the AUX message locally.

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -242,7 +242,10 @@ impl<NodeUid: Clone + Debug + Eq + Hash> Agreement<NodeUid> {
         self.sent_bval.clear();
         self.received_aux.clear();
         self.epoch += 1;
-        debug!("Agreement instance {:?} started epoch {}", self.uid, self.epoch);
+        debug!(
+            "Agreement instance {:?} started epoch {}",
+            self.uid, self.epoch
+        );
 
         let decision = if vals.len() != 1 {
             self.estimated = Some(coin);

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -4,7 +4,7 @@
 #![allow(unused)]
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::hash::Hash;
 
 use agreement;
@@ -25,7 +25,7 @@ type CommonSubsetOutput<NodeUid> = (
 
 /// Message from Common Subset to remote nodes.
 #[cfg_attr(feature = "serialization-serde", derive(Serialize))]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Message<NodeUid> {
     /// A message for the broadcast algorithm concerning the set element proposed by the given node.
     Broadcast(NodeUid, BroadcastMessage),
@@ -67,7 +67,7 @@ pub struct CommonSubset<NodeUid: Eq + Hash + Ord> {
     agreement_results: HashMap<NodeUid, bool>,
 }
 
-impl<NodeUid: Clone + Debug + Display + Eq + Hash + Ord> CommonSubset<NodeUid> {
+impl<NodeUid: Clone + Debug + Eq + Hash + Ord> CommonSubset<NodeUid> {
     pub fn new(uid: NodeUid, all_uids: &HashSet<NodeUid>) -> Result<Self, Error> {
         let num_nodes = all_uids.len();
         let num_faulty_nodes = (num_nodes - 1) / 3;

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -289,8 +289,10 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> CommonSubset<NodeUid> {
                 .filter(|(k, _)| delivered_1.get(k).is_some())
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
-            debug!("Broadcast results among the Agreement instances that delivered 1: {:?}",
-                   broadcast_results);
+            debug!(
+                "Broadcast results among the Agreement instances that delivered 1: {:?}",
+                broadcast_results
+            );
 
             if delivered_1.len() == broadcast_results.len() {
                 debug!("Agreement instances completed with {:?}", broadcast_results);

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -146,8 +146,8 @@ where
         // FIXME: Handle the node IDs in `ser_batches`.
         let batches: Vec<Vec<T>> = if let Some(ser_batches) = cs_out {
             ser_batches
-                .into_iter()
-                .map(|(_, ser_batch)| bincode::deserialize(&ser_batch))
+                .values()
+                .map(|ser_batch| bincode::deserialize(&ser_batch))
                 .collect::<Result<_, _>>()?
         } else {
             return Ok(());

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -138,14 +138,16 @@ where
             return Ok(());
         }
         let (cs_out, cs_msgs) = self.common_subset.handle_message(sender_id, message)?;
+
         for targeted_msg in cs_msgs {
             let msg = targeted_msg.map(|cs_msg| Message::CommonSubset(epoch, cs_msg));
             self.messages.push_back(msg);
         }
+        // FIXME: Handle the node IDs in `ser_batches`.
         let batches: Vec<Vec<T>> = if let Some(ser_batches) = cs_out {
             ser_batches
                 .into_iter()
-                .map(|ser_batch| bincode::deserialize(&ser_batch))
+                .map(|(_, ser_batch)| bincode::deserialize(&ser_batch))
                 .collect::<Result<_, _>>()?
         } else {
             return Ok(());

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -1,0 +1,177 @@
+//! Integration tests of the Asynchronous Common Subset protocol.
+
+extern crate hbbft;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use std::collections::{BTreeMap, HashSet, VecDeque};
+
+use hbbft::common_subset;
+use hbbft::common_subset::CommonSubset;
+use hbbft::messaging::TargetedMessage;
+
+type ProposedValue = Vec<u8>;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct NodeUid(usize);
+
+/// The queue of messages of a particular Common Subset instance received by a node.
+type InputQueue = VecDeque<common_subset::Message<NodeUid>>;
+/// The queue of messages output from a Common Subset instance.
+type OutputQueue = VecDeque<TargetedMessage<common_subset::Message<NodeUid>, NodeUid>>;
+
+struct TestNode {
+    /// Sender ID.
+    id: NodeUid,
+    /// The Common Subset algorithm.
+    cs: CommonSubset<NodeUid>,
+    /// Queue of tuples of a sender ID and a message.
+    queue: VecDeque<(NodeUid, common_subset::Message<NodeUid>)>,
+    /// The output of the Common Subset algorithm, if there is one.
+    decision: Option<HashSet<ProposedValue>>,
+}
+
+impl TestNode {
+    fn new(id: NodeUid, cs: CommonSubset<NodeUid>) -> TestNode {
+        TestNode {
+            id,
+            cs,
+            queue: VecDeque::new(),
+            decision: None,
+        }
+    }
+
+    fn handle_message(&mut self) -> (Option<HashSet<Vec<u8>>>, OutputQueue) {
+        let (sender_id, message) = self.queue
+            .pop_front()
+            .expect("popping a message off the queue");
+        let (output, messages) = self.cs
+            .handle_message(&sender_id, message)
+            .expect("handling a Common Subset message");
+        debug!("{:?} produced messages: {:?}", self.id, messages);
+        if let Some(ref decision) = output {
+            self.decision = Some(decision.clone());
+        }
+        (output, messages)
+    }
+}
+
+struct TestNetwork {
+    nodes: BTreeMap<NodeUid, TestNode>,
+    /// The next node to handle a message in its queue.
+    scheduled_node_id: NodeUid,
+}
+
+impl TestNetwork {
+    fn new(all_ids: &HashSet<NodeUid>) -> TestNetwork {
+        let num_nodes = all_ids.len();
+        // Make a node with an Agreement instance associated with the proposer node 0.
+        let make_node = |id: NodeUid| {
+            let cs = CommonSubset::new(id, all_ids).expect("Node creation");
+            (id, TestNode::new(id, cs))
+        };
+        TestNetwork {
+            nodes: (0..num_nodes).map(NodeUid).map(make_node).collect(),
+            scheduled_node_id: NodeUid(0),
+        }
+    }
+
+    fn dispatch_messages(&mut self, sender_id: NodeUid, messages: InputQueue) {
+        for message in messages {
+            for (id, node) in &mut self.nodes {
+                if *id != sender_id {
+                    debug!(
+                        "Dispatching from {:?} to {:?}: {:?}",
+                        sender_id, id, message
+                    );
+                    node.queue.push_back((sender_id, message.clone()));
+                }
+            }
+        }
+    }
+
+    // Gets a node for receiving a message and picks the next node with a
+    // non-empty message queue in a cyclic order.
+    fn pick_node(&mut self) -> NodeUid {
+        let id = self.scheduled_node_id;
+        // Try a node with a higher ID for fairness.
+        if let Some(next_id) = self.nodes
+            .iter()
+            .find(|(&next_id, node)| id < next_id && !node.queue.is_empty())
+            .map(|(id, _)| *id)
+        {
+            self.scheduled_node_id = next_id;
+        } else {
+            // Fall back to nodes up to the currently scheduled ID.
+            self.scheduled_node_id = self.nodes
+                .iter()
+                .find(|(&next_id, node)| id >= next_id && !node.queue.is_empty())
+                .map(|(id, _)| *id)
+                .expect("no more messages in any node's queue")
+        }
+        debug!("Picked node {:?}", self.scheduled_node_id);
+        id
+    }
+
+    fn step(&mut self) -> (NodeUid, Option<HashSet<ProposedValue>>) {
+        let sender_id = self.pick_node();
+        let (output, messages) = self.nodes.get_mut(&sender_id).unwrap().handle_message();
+        let messages = messages
+            .into_iter()
+            .map(|TargetedMessage { target: _, message }| message)
+            .collect();
+        self.dispatch_messages(sender_id, messages);
+        (sender_id, output)
+    }
+
+    /// Make Node 0 propose a value.
+    fn send_proposed_value(&mut self, value: ProposedValue) {
+        let sender_id = NodeUid(0);
+        let messages = self.nodes
+            .get_mut(&sender_id)
+            .unwrap()
+            .cs
+            .send_proposed_value(value)
+            .expect("send proposed value");
+        self.dispatch_messages(
+            sender_id,
+            messages
+                .into_iter()
+                .map(|TargetedMessage { target: _, message }| message)
+                .collect(),
+        );
+    }
+}
+
+fn test_common_subset(mut network: TestNetwork) -> BTreeMap<NodeUid, TestNode> {
+    let _ = env_logger::try_init();
+
+    // Pick the first node with a non-empty queue.
+    network.pick_node();
+
+    while network.nodes.values().any(|node| node.decision.is_none()) {
+        let (NodeUid(id), output) = network.step();
+        if let Some(decision) = output {
+            debug!("Node {} output {:?}", id, decision);
+        }
+    }
+    network.nodes
+}
+
+#[test]
+fn test_common_subset_4_nodes() {
+    let proposed_value = Vec::from("Fake news");
+    let all_ids: HashSet<NodeUid> = (0..4).map(NodeUid).collect();
+    let mut network = TestNetwork::new(&all_ids);
+
+    network.send_proposed_value(proposed_value.clone());
+    let nodes = test_common_subset(network);
+
+    for node in nodes.values() {
+        assert_eq!(
+            node.decision,
+            Some(vec![proposed_value.clone()].into_iter().collect())
+        );
+    }
+}

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -5,7 +5,7 @@ extern crate hbbft;
 extern crate log;
 extern crate env_logger;
 
-use std::collections::{BTreeMap, HashSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use hbbft::common_subset;
 use hbbft::common_subset::CommonSubset;
@@ -119,7 +119,7 @@ impl TestNetwork {
         let (output, messages) = self.nodes.get_mut(&sender_id).unwrap().handle_message();
         let messages = messages
             .into_iter()
-            .map(|TargetedMessage { target: _, message }| message)
+            .map(|TargetedMessage { message, .. }| message)
             .collect();
         self.dispatch_messages(sender_id, messages);
         (sender_id, output)
@@ -137,7 +137,7 @@ impl TestNetwork {
             sender_id,
             messages
                 .into_iter()
-                .map(|TargetedMessage { target: _, message }| message)
+                .map(|TargetedMessage { message, .. }| message)
                 .collect(),
         );
     }
@@ -165,7 +165,7 @@ fn test_common_subset_4_nodes() {
     let mut network = TestNetwork::new(&all_ids);
     let expected_node_decision: HashMap<NodeUid, ProposedValue> = all_ids
         .iter()
-        .map(|id| (id.clone(), proposed_value.clone()))
+        .map(|id| (*id, proposed_value.clone()))
         .collect();
 
     network.send_proposed_value(NodeUid(0), proposed_value.clone());
@@ -176,9 +176,6 @@ fn test_common_subset_4_nodes() {
     let nodes = test_common_subset(network);
 
     for node in nodes.values() {
-        assert_eq!(
-            node.decision,
-            Some(expected_node_decision.clone())
-        );
+        assert_eq!(node.decision, Some(expected_node_decision.clone()));
     }
 }


### PR DESCRIPTION
The Common Subset output is changed from a set of proposed values into a map from node IDs to proposed values. In `src/agreement.rs`, AUX messages are now guaranteed to be sent once an epoch.