### PR TITLE
Added error-chain error handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,14 @@ authors = ["Vladimir Komendantskiy <komendantsky@gmail.com>"]
 bincode = "1.0.0"
 derive_deref = "1.0.1"
 env_logger = "0.5.10"
+error-chain = "0.11.0"
 itertools = "0.7"
 log = "0.4.1"
 merkle = { git = "https://github.com/afck/merkle.rs", branch = "public-proof" }
 protobuf = { version = "2.0.0", optional = true }
 rand = "0.4.2"
-reed-solomon-erasure = "3.0"
+# reed-solomon-erasure = "3.0"
+reed-solomon-erasure = { git = "https://github.com/darrenldl/reed-solomon-erasure.git", branch = "dev" }
 ring = "^0.12"
 serde = "1.0.55"
 serde_derive = { version = "1.0.55", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ log = "0.4.1"
 merkle = { git = "https://github.com/afck/merkle.rs", branch = "public-proof" }
 protobuf = { version = "2.0.0", optional = true }
 rand = "0.4.2"
-# reed-solomon-erasure = "3.0"
-reed-solomon-erasure = { git = "https://github.com/darrenldl/reed-solomon-erasure.git", branch = "dev" }
+reed-solomon-erasure = "3.1.0"
 ring = "^0.12"
 serde = "1.0.55"
 serde_derive = { version = "1.0.55", optional = true }

--- a/examples/network/commst.rs
+++ b/examples/network/commst.rs
@@ -85,7 +85,7 @@ impl<'a, P: Message + 'a, M: Into<P> + From<P> + Send + 'a> CommsTask<'a, P, M> 
                             message: message.into(),
                         }).unwrap();
                     }
-                    Err(proto_io::Error(proto_io::ErrorKind::Protobuf(e), _)) {
+                    Err(proto_io::Error(proto_io::ErrorKind::Protobuf(e), _)) => {
                         warn!("Node {} - Protobuf error {}", node_index, e)
                     }
                     Err(e) => {

--- a/examples/network/commst.rs
+++ b/examples/network/commst.rs
@@ -85,7 +85,7 @@ impl<'a, P: Message + 'a, M: Into<P> + From<P> + Send + 'a> CommsTask<'a, P, M> 
                             message: message.into(),
                         }).unwrap();
                     }
-                    Err(proto_io::Error::Protobuf(e)) => {
+                    Err(proto_io::Error(proto_io::ErrorKind::Protobuf(e), _)) {
                         warn!("Node {} - Protobuf error {}", node_index, e)
                     }
                     Err(e) => {

--- a/examples/network/commst.rs
+++ b/examples/network/commst.rs
@@ -85,7 +85,7 @@ impl<'a, P: Message + 'a, M: Into<P> + From<P> + Send + 'a> CommsTask<'a, P, M> 
                             message: message.into(),
                         }).unwrap();
                     }
-                    Err(proto_io::Error::ProtobufError(e)) => {
+                    Err(proto_io::Error::Protobuf(e)) => {
                         warn!("Node {} - Protobuf error {}", node_index, e)
                     }
                     Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ extern crate bincode;
 #[macro_use(Deref, DerefMut)]
 extern crate derive_deref;
 #[macro_use]
+extern crate error_chain;
+#[macro_use]
 extern crate log;
 extern crate itertools;
 extern crate merkle;


### PR DESCRIPTION
Changed error handling from using `enum Error`'s to using the `error-chain` crate.

*Note:* the following lines in `Cargo.toml`

```
# reed-solomon-erasure = "3.0"
reed-solomon-erasure = { git = "https://github.com/darrenldl/reed-solomon-erasure.git", branch = "dev" }
```

should be changed to

```
reed-solomon-erasure = "<NEW VERSION NUMBER>"
```

to reflect (the soon to be published to crates.io) version bump for `reed-solomon-erasure`.

The `dev` branch in `reed-solomon-erasure` currently contains changes that implement`std::error::Error` for `reed-solomon-erasure::Error`. These changes are required by this PR.