### PR TITLE
Added a CONF round

### DIFF
--- a/proto/message.proto
+++ b/proto/message.proto
@@ -48,5 +48,6 @@ message AgreementProto {
   oneof payload {
     bool bval = 2;
     bool aux = 3;
+    uint32 conf = 4;
   }
 }

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -1,10 +1,9 @@
 //! Binary Byzantine agreement protocol from a common coin protocol.
 
-use itertools::Itertools;
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::mem;
+use std::mem::replace;
 
 use messaging::{DistAlgorithm, Target, TargetedMessage};
 
@@ -19,6 +18,82 @@ error_chain!{
     }
 }
 
+/// A lattice-valued description of the state of `bin_values`.
+#[cfg_attr(feature = "serialization-serde", derive(Serialize))]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BinValues {
+    None,
+    False,
+    True,
+    Both,
+}
+
+impl BinValues {
+    pub fn new() -> Self {
+        BinValues::None
+    }
+
+    pub fn clear(&mut self) {
+        replace(self, BinValues::None);
+    }
+
+    fn single(b: bool) -> Self {
+        if b {
+            BinValues::True
+        } else {
+            BinValues::False
+        }
+    }
+
+    /// Inserts a boolean value into the `BinValues` and returns true iff the `BinValues` has
+    /// changed as a result.
+    pub fn insert(&mut self, b: bool) -> bool {
+        match self {
+            BinValues::None => {
+                replace(self, BinValues::single(b));
+                true
+            }
+            BinValues::False if b => {
+                replace(self, BinValues::Both);
+                true
+            }
+            BinValues::True if !b => {
+                replace(self, BinValues::Both);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn contains(&self, b: bool) -> bool {
+        match self {
+            BinValues::None => false,
+            BinValues::Both => true,
+            BinValues::False if !b => true,
+            BinValues::True if b => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_subset(&self, other: &BinValues) -> bool {
+        match self {
+            BinValues::None => true,
+            BinValues::False if *other == BinValues::False || *other == BinValues::Both => true,
+            BinValues::True if *other == BinValues::True || *other == BinValues::Both => true,
+            BinValues::Both if *other == BinValues::Both => true,
+            _ => false,
+        }
+    }
+
+    pub fn definite(&self) -> Option<bool> {
+        match self {
+            BinValues::False => Some(false),
+            BinValues::True => Some(true),
+            _ => None,
+        }
+    }
+}
+
 /// Messages sent during the binary Byzantine agreement stage.
 #[cfg_attr(feature = "serialization-serde", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -27,6 +102,8 @@ pub enum AgreementMessage {
     BVal(u32, bool),
     /// AUX message with an epoch.
     Aux(u32, bool),
+    /// CONF message with an epoch.
+    Conf(u32, BinValues),
 }
 
 impl AgreementMessage {
@@ -34,6 +111,7 @@ impl AgreementMessage {
         match *self {
             AgreementMessage::BVal(epoch, _) => epoch,
             AgreementMessage::Aux(epoch, _) => epoch,
+            AgreementMessage::Conf(epoch, _) => epoch,
         }
     }
 }
@@ -46,13 +124,15 @@ pub struct Agreement<NodeUid> {
     num_faulty_nodes: usize,
     epoch: u32,
     /// Bin values. Reset on every epoch update.
-    bin_values: BTreeSet<bool>,
+    bin_values: BinValues,
     /// Values received in BVAL messages. Reset on every epoch update.
-    received_bval: HashMap<NodeUid, BTreeSet<bool>>,
+    received_bval: BTreeMap<NodeUid, BTreeSet<bool>>,
     /// Sent BVAL values. Reset on every epoch update.
     sent_bval: BTreeSet<bool>,
     /// Values received in AUX messages. Reset on every epoch update.
-    received_aux: HashMap<NodeUid, bool>,
+    received_aux: BTreeMap<NodeUid, bool>,
+    /// Received CONF messages. Reset on every epoch update.
+    received_conf: BTreeMap<NodeUid, BinValues>,
     /// The estimate of the decision value in the current epoch.
     estimated: Option<bool>,
     /// The value output by the agreement instance. It is set once to `Some(b)`
@@ -76,6 +156,8 @@ pub struct Agreement<NodeUid> {
     terminated: bool,
     /// The outgoing message queue.
     messages: VecDeque<AgreementMessage>,
+    /// Whether the CONF message round has been started in the current epoch.
+    conf_sent: bool,
 }
 
 impl<NodeUid: Clone + Debug + Eq + Hash + Ord> DistAlgorithm for Agreement<NodeUid> {
@@ -109,6 +191,7 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> DistAlgorithm for Agreement<NodeU
         match message {
             AgreementMessage::BVal(_, b) => self.handle_bval(sender_id, b),
             AgreementMessage::Aux(_, b) => self.handle_aux(sender_id, b),
+            AgreementMessage::Conf(_, v) => self.handle_conf(sender_id, v),
         }
     }
 
@@ -143,16 +226,18 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
             num_nodes,
             num_faulty_nodes,
             epoch: 0,
-            bin_values: BTreeSet::new(),
-            received_bval: HashMap::new(),
+            bin_values: BinValues::new(),
+            received_bval: BTreeMap::new(),
             sent_bval: BTreeSet::new(),
-            received_aux: HashMap::new(),
+            received_aux: BTreeMap::new(),
+            received_conf: BTreeMap::new(),
             estimated: None,
             output: None,
             decision: None,
             incoming_queue: Vec::new(),
             terminated: false,
             messages: VecDeque::new(),
+            conf_sent: false,
         }
     }
 
@@ -192,21 +277,33 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
         // upon receiving BVAL_r(b) messages from 2f + 1 nodes,
         // bin_values_r := bin_values_r ∪ {b}
         if count_bval == 2 * self.num_faulty_nodes + 1 {
-            let bin_values_was_empty = self.bin_values.is_empty();
-            self.bin_values.insert(b);
+            let previous_bin_values = self.bin_values.clone();
+            let bin_values_changed = self.bin_values.insert(b);
 
             // wait until bin_values_r != 0, then multicast AUX_r(w)
             // where w ∈ bin_values_r
-            if bin_values_was_empty {
+            if previous_bin_values == BinValues::None {
                 // Send an AUX message at most once per epoch.
-                self.send_aux(b)?;
+                self.send_aux(b)
+            } else if self.conf_sent
+                && bin_values_changed
+                && self.count_conf() >= self.num_nodes - self.num_faulty_nodes
+            {
+                // Respond to a change in `bin_values` from the CONF round. Since BVAL messages
+                // continue getting handled during the CONF round and `bin_values` is still allowed
+                // to change, the value of `count_conf` may increase at this point. The COIN subalgo
+                // has to be invoked without waiting for another CONF message to trigger it.
+                self.invoke_coin()
+            } else {
+                Ok(())
             }
         } else if count_bval == self.num_faulty_nodes + 1 && !self.sent_bval.contains(&b) {
             // upon receiving BVAL_r(b) messages from f + 1 nodes, if
             // BVAL_r(b) has not been sent, multicast BVAL_r(b)
-            self.send_bval(b)?;
+            self.send_bval(b)
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 
     fn send_bval(&mut self, b: bool) -> AgreementResult<()> {
@@ -220,9 +317,55 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
         self.handle_bval(&our_uid, b)
     }
 
+    fn send_conf(&mut self) -> AgreementResult<()> {
+        if self.conf_sent {
+            // Only one CONF message is allowed in an epoch.
+            return Ok(());
+        }
+
+        // Trigger the start of the CONF round.
+        self.conf_sent = true;
+        let v = &self.bin_values.clone();
+        // Multicast CONF.
+        self.messages
+            .push_back(AgreementMessage::Conf(self.epoch, v.clone()));
+        // Receive the CONF message locally.
+        let our_uid = self.uid.clone();
+        self.handle_conf(&our_uid, v.clone())
+    }
+
+    /// Waits until at least (N − f) AUX_r messages have been received, such that
+    /// the set of values carried by these messages, vals, are a subset of
+    /// bin_values_r (note that bin_values_r may continue to change as BVAL_r
+    /// messages are received, thus this condition may be triggered upon arrival
+    /// of either an AUX_r or a BVAL_r message).
     fn handle_aux(&mut self, sender_id: &NodeUid, b: bool) -> AgreementResult<()> {
+        // Perform the AUX message round only if a CONF round hasn't started yet.
+        if self.conf_sent {
+            return Ok(());
+        }
         self.received_aux.insert(sender_id.clone(), b);
-        self.try_coin()
+        if self.bin_values == BinValues::None {
+            return Ok(());
+        }
+        if self.count_aux() < self.num_nodes - self.num_faulty_nodes {
+            // Continue waiting for the (N - f) AUX messages.
+            return Ok(());
+        }
+        // Start the CONF message round.
+        self.send_conf()
+    }
+
+    fn handle_conf(&mut self, sender_id: &NodeUid, v: BinValues) -> AgreementResult<()> {
+        self.received_conf.insert(sender_id.clone(), v);
+        if !self.conf_sent {
+            return Ok(());
+        }
+        if self.count_conf() < self.num_nodes - self.num_faulty_nodes {
+            // Continue waiting for (N - f) CONF messages
+            return Ok(());
+        }
+        self.invoke_coin()
     }
 
     fn send_aux(&mut self, b: bool) -> AgreementResult<()> {
@@ -234,8 +377,8 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
         self.handle_aux(&our_uid, b)
     }
 
-    /// AUX_r messages such that the set of values carried by those messages is
-    /// a subset of bin_values_r. Outputs this subset.
+    /// The count of AUX_r messages such that the set of values carried by those messages is a
+    /// subset of bin_values_r. Outputs this subset.
     ///
     /// FIXME: Clarify whether the values of AUX messages should be the same or
     /// not. It is assumed in `count_aux` that they can differ.
@@ -244,37 +387,36 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
     /// so waiting for N - f agreeing messages would not always terminate. We
     /// can, however, expect every good node to send an AUX value that will
     /// eventually end up in our bin_values.
-    fn count_aux(&self) -> (usize, BTreeSet<bool>) {
-        let (vals_cnt, vals) = self
-            .received_aux
+    fn count_aux(&self) -> usize {
+        self.received_aux
             .values()
-            .filter(|b| self.bin_values.contains(b))
-            .tee();
-
-        (vals_cnt.count(), vals.cloned().collect())
+            .filter(|&&b| self.bin_values.contains(b))
+            .count()
     }
 
-    /// Waits until at least (N − f) AUX_r messages have been received, such that
-    /// the set of values carried by these messages, vals, are a subset of
-    /// bin_values_r (note that bin_values_r may continue to change as BVAL_r
-    /// messages are received, thus this condition may be triggered upon arrival
-    /// of either an AUX_r or a BVAL_r message).
-    ///
-    /// Once the (N - f) messages are received, gets a common coin and uses it
-    /// to compute the next decision estimate and outputs the optional decision
-    /// value.  The function may start the next epoch. In that case, it also
-    /// returns a message for broadcast.
-    fn try_coin(&mut self) -> AgreementResult<()> {
-        if self.bin_values.is_empty() {
-            return Ok(());
-        }
-        let (count_aux, vals) = self.count_aux();
-        if count_aux < self.num_nodes - self.num_faulty_nodes {
-            // Continue waiting for the (N - f) AUX messages.
-            return Ok(());
-        }
+    /// Counts the number of received CONF messages.
+    fn count_conf(&self) -> usize {
+        self.received_conf
+            .values()
+            .filter(|&conf| conf.is_subset(&self.bin_values))
+            .count()
+    }
 
-        debug!("{:?} try_coin in epoch {}", self.uid, self.epoch);
+    fn start_next_epoch(&mut self) {
+        self.bin_values.clear();
+        self.received_bval.clear();
+        self.sent_bval.clear();
+        self.received_aux.clear();
+        self.received_conf.clear();
+        self.conf_sent = false;
+        self.epoch += 1;
+    }
+
+    /// Gets a common coin and uses it to compute the next decision estimate and outputs the
+    /// optional decision value.  The function may start the next epoch. In that case, it also
+    /// returns a message for broadcast.
+    fn invoke_coin(&mut self) -> AgreementResult<()> {
+        debug!("{:?} invoke_coin in epoch {}", self.uid, self.epoch);
         // FIXME: Implement the Common Coin algorithm. At the moment the
         // coin value is common across different nodes but not random.
         let coin = (self.epoch % 2) == 0;
@@ -288,22 +430,13 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
             return Ok(());
         }
 
-        // Start the next epoch.
-        self.bin_values.clear();
-        self.received_bval.clear();
-        self.sent_bval.clear();
-        self.received_aux.clear();
-        self.epoch += 1;
+        self.start_next_epoch();
         debug!(
             "Agreement instance {:?} started epoch {}",
             self.uid, self.epoch
         );
 
-        if vals.len() != 1 {
-            self.estimated = Some(coin);
-        } else {
-            // NOTE: `vals` has exactly one element due to `vals.len() == 1`
-            let b = vals.into_iter().next().unwrap();
+        if let Some(b) = self.bin_values.definite() {
             self.estimated = Some(b);
             // Outputting a value is allowed only once.
             if self.decision.is_none() && b == coin {
@@ -313,11 +446,13 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
                 self.decision = Some(b);
                 debug!("Agreement instance {:?} output: {}", self.uid, b);
             }
-        };
+        } else {
+            self.estimated = Some(coin);
+        }
 
         let b = self.estimated.unwrap();
         self.send_bval(b)?;
-        let queued_msgs = mem::replace(&mut self.incoming_queue, Vec::new());
+        let queued_msgs = replace(&mut self.incoming_queue, Vec::new());
         for (sender_id, msg) in queued_msgs {
             self.handle_message(&sender_id, msg)?;
         }

--- a/src/agreement/bin_values.rs
+++ b/src/agreement/bin_values.rs
@@ -1,0 +1,112 @@
+use std::iter::FromIterator;
+use std::mem::replace;
+
+/// A lattice-valued description of the state of `bin_values`, essentially the same as the set of
+/// subsets of `bool`.
+#[cfg_attr(feature = "serialization-serde", derive(Serialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BinValues {
+    None,
+    False,
+    True,
+    Both,
+}
+
+impl BinValues {
+    pub fn new() -> Self {
+        BinValues::None
+    }
+
+    pub fn clear(&mut self) {
+        replace(self, BinValues::None);
+    }
+
+    fn from_bool(b: bool) -> Self {
+        if b {
+            BinValues::True
+        } else {
+            BinValues::False
+        }
+    }
+
+    /// Inserts a boolean value into the `BinValues` and returns true iff the `BinValues` has
+    /// changed as a result.
+    pub fn insert(&mut self, b: bool) -> bool {
+        match self {
+            BinValues::None => {
+                replace(self, BinValues::from_bool(b));
+                true
+            }
+            BinValues::False if b => {
+                replace(self, BinValues::Both);
+                true
+            }
+            BinValues::True if !b => {
+                replace(self, BinValues::Both);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn union(&mut self, other: BinValues) {
+        match self {
+            BinValues::None => {
+                replace(self, other);
+            }
+            BinValues::False if other == BinValues::True => {
+                replace(self, BinValues::Both);
+            }
+            BinValues::True if other == BinValues::False => {
+                replace(self, BinValues::Both);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn contains(&self, b: bool) -> bool {
+        match self {
+            BinValues::None => false,
+            BinValues::Both => true,
+            BinValues::False if !b => true,
+            BinValues::True if b => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_subset(&self, other: BinValues) -> bool {
+        match self {
+            BinValues::None => true,
+            BinValues::False if other == BinValues::False || other == BinValues::Both => true,
+            BinValues::True if other == BinValues::True || other == BinValues::Both => true,
+            BinValues::Both if other == BinValues::Both => true,
+            _ => false,
+        }
+    }
+
+    pub fn definite(&self) -> Option<bool> {
+        match self {
+            BinValues::False => Some(false),
+            BinValues::True => Some(true),
+            _ => None,
+        }
+    }
+}
+
+impl Default for BinValues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FromIterator<BinValues> for BinValues {
+    fn from_iter<I: IntoIterator<Item = BinValues>>(iter: I) -> Self {
+        let mut v = BinValues::new();
+
+        for i in iter {
+            v.union(i);
+        }
+
+        v
+    }
+}

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -1,6 +1,6 @@
 //! Binary Byzantine agreement protocol from a common coin protocol.
 
-mod bin_values;
+pub mod bin_values;
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
@@ -38,26 +38,26 @@ pub enum AgreementContent {
 #[cfg_attr(feature = "serialization-serde", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AgreementMessage {
-    epoch: u32,
-    content: AgreementContent,
+    pub epoch: u32,
+    pub content: AgreementContent,
 }
 
 impl AgreementMessage {
-    fn bval(epoch: u32, b: bool) -> Self {
+    pub fn bval(epoch: u32, b: bool) -> Self {
         AgreementMessage {
             epoch,
             content: AgreementContent::BVal(b),
         }
     }
 
-    fn aux(epoch: u32, b: bool) -> Self {
+    pub fn aux(epoch: u32, b: bool) -> Self {
         AgreementMessage {
             epoch,
             content: AgreementContent::Aux(b),
         }
     }
 
-    fn conf(epoch: u32, v: BinValues) -> Self {
+    pub fn conf(epoch: u32, v: BinValues) -> Self {
         AgreementMessage {
             epoch,
             content: AgreementContent::Conf(v),

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -26,11 +26,11 @@ error_chain!{
 #[cfg_attr(feature = "serialization-serde", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AgreementContent {
-    /// BVAL message with an epoch.
+    /// `BVal` message.
     BVal(bool),
-    /// AUX message with an epoch.
+    /// `Aux` message.
     Aux(bool),
-    /// CONF message with an epoch.
+    /// `Conf` message.
     Conf(BinValues),
 }
 
@@ -76,11 +76,11 @@ pub struct Agreement<NodeUid> {
     bin_values: BinValues,
     /// Values received in `BVal` messages. Reset on every epoch update.
     received_bval: BTreeMap<NodeUid, BTreeSet<bool>>,
-    /// Sent BVAL values. Reset on every epoch update.
+    /// Sent `BVal` values. Reset on every epoch update.
     sent_bval: BTreeSet<bool>,
     /// Values received in `Aux` messages. Reset on every epoch update.
     received_aux: BTreeMap<NodeUid, bool>,
-    /// Received CONF messages. Reset on every epoch update.
+    /// Received `Conf` messages. Reset on every epoch update.
     received_conf: BTreeMap<NodeUid, BinValues>,
     /// The estimate of the decision value in the current epoch.
     estimated: Option<bool>,
@@ -330,12 +330,9 @@ impl<NodeUid: Clone + Debug + Eq + Hash + Ord> Agreement<NodeUid> {
     /// The count of `Aux` messages such that the set of values carried by those messages is a
     /// subset of bin_values_r.
     ///
-    /// FIXME: Clarify whether the values of `Aux` messages should be the same or not. It is assumed
-    /// in `count_aux` that they can differ.
-    ///
     /// In general, we can't expect every good node to send the same `Aux` value, so waiting for N -
     /// f agreeing messages would not always terminate. We can, however, expect every good node to
-    /// send an `Aux` value that will eventually end up in our bin_values.
+    /// send an `Aux` value that will eventually end up in our `bin_values`.
     fn count_aux(&self) -> usize {
         self.received_aux
             .values()

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -4,8 +4,8 @@ pub mod message;
 use merkle::proof::{Lemma, Positioned, Proof};
 use ring::digest::Algorithm;
 
-use agreement::{AgreementContent, AgreementMessage};
 use agreement::bin_values::BinValues;
+use agreement::{AgreementContent, AgreementMessage};
 use broadcast::BroadcastMessage;
 use proto::message::*;
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,11 +1,13 @@
 //! Construction of messages from protobuf buffers.
 pub mod message;
 
-use agreement::{AgreementMessage, BinValues};
-use broadcast::BroadcastMessage;
 use merkle::proof::{Lemma, Positioned, Proof};
-use proto::message::*;
 use ring::digest::Algorithm;
+
+use agreement::{AgreementContent, AgreementMessage};
+use agreement::bin_values::BinValues;
+use broadcast::BroadcastMessage;
+use proto::message::*;
 
 impl From<message::BroadcastProto> for BroadcastMessage {
     fn from(proto: message::BroadcastProto) -> BroadcastMessage {
@@ -66,17 +68,15 @@ impl BroadcastMessage {
 impl AgreementMessage {
     pub fn into_proto(self) -> message::AgreementProto {
         let mut p = message::AgreementProto::new();
-        match self {
-            AgreementMessage::BVal(e, b) => {
-                p.set_epoch(e);
+        p.set_epoch(self.epoch);
+        match self.content {
+            AgreementContent::BVal(b) => {
                 p.set_bval(b);
             }
-            AgreementMessage::Aux(e, b) => {
-                p.set_epoch(e);
+            AgreementContent::Aux(b) => {
                 p.set_aux(b);
             }
-            AgreementMessage::Conf(e, v) => {
-                p.set_epoch(e);
+            AgreementContent::Conf(v) => {
                 let bin_values = match v {
                     BinValues::None => 0,
                     BinValues::False => 1,
@@ -94,9 +94,9 @@ impl AgreementMessage {
     pub fn from_proto(mp: message::AgreementProto) -> Option<Self> {
         let epoch = mp.get_epoch();
         if mp.has_bval() {
-            Some(AgreementMessage::BVal(epoch, mp.get_bval()))
+            Some(AgreementMessage::bval(epoch, mp.get_bval()))
         } else if mp.has_aux() {
-            Some(AgreementMessage::Aux(epoch, mp.get_aux()))
+            Some(AgreementMessage::aux(epoch, mp.get_aux()))
         } else if mp.has_conf() {
             match mp.get_conf() {
                 0 => Some(BinValues::None),
@@ -104,7 +104,7 @@ impl AgreementMessage {
                 2 => Some(BinValues::True),
                 3 => Some(BinValues::Both),
                 _ => None,
-            }.map(|bin_values| AgreementMessage::Conf(epoch, bin_values))
+            }.map(|bin_values| AgreementMessage::conf(epoch, bin_values))
         } else {
             None
         }


### PR DESCRIPTION
In order to guarantee termination, the common coin is invoked in the CONF round only for the subset of `bin_values` committed to in the CONF message. The Cobalt fix used the whole set of `bin_values`, which led to non-termination in our tests.