### PR TITLE
Zero out `SecretKey` memory when dropped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Vladimir Komendantskiy <komendantsky@gmail.com>"]
 [dependencies]
 bincode = "1.0.0"
 byteorder = "1.2.3"
+clear_on_drop = "0.2.3"
 derive_deref = "1.0.1"
 env_logger = "0.5.10"
 error-chain = "0.11.0"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -8,6 +8,8 @@ mod serde_impl;
 use self::keygen::{Commitment, Poly};
 
 use std::fmt;
+use std::mem;
+use std::ptr;
 
 use byteorder::{BigEndian, ByteOrder};
 use init_with::InitWith;
@@ -105,6 +107,17 @@ pub struct SecretKey<E: Engine>(E::Fr);
 impl<E: Engine> PartialEq for SecretKey<E> {
     fn eq(&self, other: &SecretKey<E>) -> bool {
         self.0 == other.0
+    }
+}
+
+impl<E: Engine> Drop for SecretKey<E> {
+    fn drop(&mut self) {
+        let size = mem::size_of_val(self);
+        unsafe {
+            let p = self as *mut Self;
+            ptr::write_bytes(p as *mut u8, 0, size);
+            ptr::write(p, SecretKey(E::Fr::zero()));
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 extern crate bincode;
 extern crate byteorder;
+extern crate clear_on_drop;
 #[macro_use(Deref, DerefMut)]
 extern crate derive_deref;
 #[macro_use]

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use clear_on_drop::ClearOnDrop;
 use pairing::bls12_381::Bls12;
 
 use crypto::{PublicKeySet, SecretKey};
@@ -212,5 +213,12 @@ impl<NodeUid: Clone + Hash + Ord> NetworkInfo<NodeUid> {
     /// independent from the public key, so that reusing keys would be safer.
     pub fn invocation_id(&self) -> Vec<u8> {
         self.public_key_set.public_key().to_bytes()
+    }
+}
+
+// Overwrites the portion of memory that was allocated for `secret_key`.
+impl<NodeUid: Clone + Eq + Hash> Drop for NetworkInfo<NodeUid> {
+    fn drop(&mut self) {
+        let _ = ClearOnDrop::new(&mut self.secret_key);
     }
 }


### PR DESCRIPTION
- Added the `Drop` trait to `SecretKey`.