### PR TITLE
Implement Hash for "public" cryptographic types.

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -175,9 +175,10 @@ impl<E: Engine> PartialEq for Ciphertext<E> {
 
 impl<E: Engine> Hash for Ciphertext<E> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.into_affine().into_compressed().as_ref().hash(state);
-        self.1.hash(state);
-        self.2.into_affine().into_compressed().as_ref().hash(state);
+        let Ciphertext(ref u, ref v, ref w) = *self;
+        u.into_affine().into_compressed().as_ref().hash(state);
+        v.hash(state);
+        w.into_affine().into_compressed().as_ref().hash(state);
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -5,6 +5,7 @@ pub mod protobuf_impl;
 mod serde_impl;
 
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 use byteorder::{BigEndian, ByteOrder};
 use init_with::InitWith;
@@ -28,6 +29,12 @@ pub struct PublicKey<E: Engine>(#[serde(with = "serde_impl::projective")] E::G1)
 impl<E: Engine> PartialEq for PublicKey<E> {
     fn eq(&self, other: &PublicKey<E>) -> bool {
         self.0 == other.0
+    }
+}
+
+impl<E: Engine> Hash for PublicKey<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.into_affine().into_compressed().as_ref().hash(state);
     }
 }
 
@@ -82,6 +89,12 @@ impl<E: Engine> fmt::Debug for Signature<E> {
 impl<E: Engine> PartialEq for Signature<E> {
     fn eq(&self, other: &Signature<E>) -> bool {
         self.0 == other.0
+    }
+}
+
+impl<E: Engine> Hash for Signature<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.into_affine().into_compressed().as_ref().hash(state);
     }
 }
 
@@ -160,6 +173,14 @@ impl<E: Engine> PartialEq for Ciphertext<E> {
     }
 }
 
+impl<E: Engine> Hash for Ciphertext<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.into_affine().into_compressed().as_ref().hash(state);
+        self.1.hash(state);
+        self.2.into_affine().into_compressed().as_ref().hash(state);
+    }
+}
+
 impl<E: Engine> Ciphertext<E> {
     /// Returns `true` if this is a valid ciphertext. This check is necessary to prevent
     /// chosen-ciphertext attacks.
@@ -180,8 +201,14 @@ impl<E: Engine> PartialEq for DecryptionShare<E> {
     }
 }
 
+impl<E: Engine> Hash for DecryptionShare<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.into_affine().into_compressed().as_ref().hash(state);
+    }
+}
+
 /// A public key and an associated set of public key shares.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash)]
 pub struct PublicKeySet<E: Engine> {
     /// The coefficients of a polynomial whose value at `0` is the "master key", and value at
     /// `i + 1` is key share number `i`.

--- a/src/crypto/poly.rs
+++ b/src/crypto/poly.rs
@@ -20,6 +20,7 @@
 // TODO: Expand this explanation and add examples, once the API is complete and stable.
 
 use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
 use std::{cmp, iter, ops};
 
 use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField};
@@ -261,6 +262,15 @@ impl<E: Engine> PartialEq for Commitment<E> {
     }
 }
 
+impl<E: Engine> Hash for Commitment<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.coeff.len().hash(state);
+        for c in &self.coeff {
+            c.into_affine().into_compressed().as_ref().hash(state);
+        }
+    }
+}
+
 impl<B: Borrow<Commitment<E>>, E: Engine> ops::AddAssign<B> for Commitment<E> {
     fn add_assign(&mut self, rhs: B) {
         let len = cmp::max(self.coeff.len(), rhs.borrow().coeff.len());
@@ -401,6 +411,15 @@ pub struct BivarCommitment<E: Engine> {
     /// The commitments to the coefficients.
     #[serde(with = "super::serde_impl::projective_vec")]
     coeff: Vec<E::G1>,
+}
+
+impl<E: Engine> Hash for BivarCommitment<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.degree.hash(state);
+        for c in &self.coeff {
+            c.into_affine().into_compressed().as_ref().hash(state);
+        }
+    }
 }
 
 impl<E: Engine> BivarCommitment<E> {


### PR DESCRIPTION
This adds a `Hash` implementation for public keys, commitments,
ciphertexts and signatures — types that might make sense to be included
in special transactions. The `DynamicHoneyBadger` implementation will
require some of them.