### PR TITLE
Change 'NetworkInfo' to use clear-on-drop secret-keys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Vladimir Komendantskiy <komendantsky@gmail.com>"]
 [dependencies]
 bincode = "1.0.0"
 byteorder = "1.2.3"
+clear_on_drop = "0.2.3"
 derive_deref = "1.0.1"
 env_logger = "0.5.10"
 error-chain = "0.11.0"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -299,11 +299,11 @@ impl<E: Engine> SecretKeySet<E> {
     /// Returns the `i`-th secret key share.
     pub fn secret_key_share<T>(&self, i: T) -> ClearOnDrop<Box<SecretKey<E>>>
     where
-        T: Into<<E::Fr as PrimeField>::Repr>
+        T: Into<<E::Fr as PrimeField>::Repr>,
     {
-        ClearOnDrop::new(Box::new(
-            SecretKey(self.poly.evaluate(from_repr_plus_1::<E::Fr>(i.into())))
-        ))
+        ClearOnDrop::new(Box::new(SecretKey(
+            self.poly.evaluate(from_repr_plus_1::<E::Fr>(i.into())),
+        )))
     }
 
     /// Returns the corresponding public key set. That information can be shared publicly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@
 
 extern crate bincode;
 extern crate byteorder;
+extern crate clear_on_drop;
 #[macro_use(Deref, DerefMut)]
 extern crate derive_deref;
 #[macro_use]

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 
+use clear_on_drop::ClearOnDrop;
 use pairing::bls12_381::Bls12;
 
 use crypto::{PublicKeySet, SecretKey};
@@ -130,13 +131,19 @@ impl<'a, D: DistAlgorithm + 'a> Iterator for OutputIter<'a, D> {
 }
 
 /// Common data shared between algorithms.
+///
+/// *NOTE* `NetworkInfo` requires its `secret_key` to be heap allocated and
+/// wrapped by the `ClearOnDrop` type from the `clear_on_drop` crate. We
+/// use this construction to zero out the section of heap memory that is
+/// allocated for `secret_key` when the corresponding instance of
+/// `NetworkInfo` goes out of scope.
 #[derive(Debug)]
 pub struct NetworkInfo<NodeUid> {
     our_uid: NodeUid,
     all_uids: BTreeSet<NodeUid>,
     num_nodes: usize,
     num_faulty: usize,
-    secret_key: SecretKey<Bls12>,
+    secret_key: ClearOnDrop<Box<SecretKey<Bls12>>>,
     public_key_set: PublicKeySet<Bls12>,
     node_indices: BTreeMap<NodeUid, usize>,
 }
@@ -145,7 +152,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
     pub fn new(
         our_uid: NodeUid,
         all_uids: BTreeSet<NodeUid>,
-        secret_key: SecretKey<Bls12>,
+        secret_key: ClearOnDrop<Box<SecretKey<Bls12>>>,
         public_key_set: PublicKeySet<Bls12>,
     ) -> Self {
         if !all_uids.contains(&our_uid) {


### PR DESCRIPTION
- Changed `NetworkInfo` to use `ClearOnDrop<Box<SecretKey<Bls12>>>`.
- Changed `SecretKeySet.secret_key_share()` to return `ClearOnDrop<Box<SecretKey<E>>>`.