### PR TITLE
Make SyncKeyGen NodeUid-aware.

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -104,7 +104,7 @@ impl Signature {
 }
 
 /// A secret key, or a secret key share.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecretKey(Fr);
 
 impl Default for SecretKey {

--- a/src/crypto/poly.rs
+++ b/src/crypto/poly.rs
@@ -390,8 +390,8 @@ impl BivarPoly {
     }
 }
 
-/// A commitment to a bivariate polynomial.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A commitment to a symmetric bivariate polynomial.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BivarCommitment {
     /// The polynomial's degree in each of the two variables.
     degree: usize,

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -136,7 +136,7 @@ impl<'a, D: DistAlgorithm + 'a> Iterator for OutputIter<'a, D> {
 /// use this construction to zero out the section of heap memory that is
 /// allocated for `secret_key` when the corresponding instance of
 /// `NetworkInfo` goes out of scope.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NetworkInfo<NodeUid> {
     our_uid: NodeUid,
     all_uids: BTreeSet<NodeUid>,

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -19,6 +19,8 @@ extern crate hbbft;
 extern crate log;
 extern crate pairing;
 extern crate rand;
+#[macro_use]
+extern crate serde_derive;
 
 mod network;
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -6,6 +6,8 @@ extern crate log;
 extern crate env_logger;
 extern crate pairing;
 extern crate rand;
+#[macro_use]
+extern crate serde_derive;
 
 mod network;
 

--- a/tests/common_coin.rs
+++ b/tests/common_coin.rs
@@ -6,6 +6,8 @@ extern crate hbbft;
 extern crate log;
 extern crate pairing;
 extern crate rand;
+#[macro_use]
+extern crate serde_derive;
 
 mod network;
 

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -6,6 +6,8 @@ extern crate hbbft;
 extern crate log;
 extern crate pairing;
 extern crate rand;
+#[macro_use]
+extern crate serde_derive;
 
 mod network;
 

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -6,6 +6,8 @@ extern crate log;
 extern crate env_logger;
 extern crate pairing;
 extern crate rand;
+#[macro_use]
+extern crate serde_derive;
 
 mod network;
 

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -9,7 +9,7 @@ use hbbft::crypto::SecretKeySet;
 use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
 
 /// A node identifier. In the tests, nodes are simply numbered.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct NodeUid(pub usize);
 
 /// A "node" running an instance of the algorithm `D`.


### PR DESCRIPTION
This allows the caller to address nodes by ID instead of by index.

Also contains a few other minor changes that will be needed for
`DynamicHoneyBadger`.