### PR TITLE
Allow observer nodes in all algorithms.

### DIFF
--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -307,7 +307,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
     }
 
     fn send_bval(&mut self, b: bool) -> AgreementResult<()> {
-        if !self.netinfo.is_full_node() {
+        if !self.netinfo.is_peer() {
             return Ok(());
         }
         // Record the value `b` as sent.
@@ -329,7 +329,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         // Trigger the start of the `Conf` round.
         self.conf_round = true;
 
-        if !self.netinfo.is_full_node() {
+        if !self.netinfo.is_peer() {
             return Ok(());
         }
 

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -227,12 +227,14 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
             self.decision = Some(input);
             self.output = Some(input);
             self.terminated = true;
+            self.send_bval(input)?;
+            self.send_aux(input)
+        } else {
+            // Set the initial estimated value to the input value.
+            self.estimated = Some(input);
+            // Record the input value as sent.
+            self.send_bval(input)
         }
-
-        // Set the initial estimated value to the input value.
-        self.estimated = Some(input);
-        // Record the input value as sent.
-        self.send_bval(input)
     }
 
     /// Acceptance check to be performed before setting the input value.
@@ -305,6 +307,9 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
     }
 
     fn send_bval(&mut self, b: bool) -> AgreementResult<()> {
+        if !self.netinfo.is_full_node() {
+            return Ok(());
+        }
         // Record the value `b` as sent.
         self.sent_bval.insert(b);
         // Multicast `BVal`.
@@ -321,12 +326,17 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
             return Ok(());
         }
 
+        // Trigger the start of the `Conf` round.
+        self.conf_round = true;
+
+        if !self.netinfo.is_full_node() {
+            return Ok(());
+        }
+
         let v = self.bin_values;
         // Multicast `Conf`.
         self.messages
             .push_back(AgreementContent::Conf(v).with_epoch(self.epoch));
-        // Trigger the start of the `Conf` round.
-        self.conf_round = true;
         // Receive the `Conf` message locally.
         let our_uid = &self.netinfo.our_uid().clone();
         self.handle_conf(our_uid, v)

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -293,7 +293,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
 
         // Otherwise multicast the proof in an `Echo` message, and handle it ourselves.
         self.echo_sent = true;
-        if self.netinfo.is_full_node() {
+        if self.netinfo.is_peer() {
             let our_uid = &self.netinfo.our_uid().clone();
             self.handle_echo(our_uid, p.clone())?;
             let echo_msg = Target::All.message(BroadcastMessage::Echo(p));
@@ -330,7 +330,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
 
         // Upon receiving `N - f` `Echo`s with this root hash, multicast `Ready`.
         self.ready_sent = true;
-        if self.netinfo.is_full_node() {
+        if self.netinfo.is_peer() {
             let ready_msg = Target::All.message(BroadcastMessage::Ready(hash.clone()));
             self.messages.push_back(ready_msg);
             let our_uid = &self.netinfo.our_uid().clone();
@@ -358,7 +358,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
         if self.count_readys(hash) == self.netinfo.num_faulty() + 1 && !self.ready_sent {
             // Enqueue a broadcast of a Ready message.
             self.ready_sent = true;
-            if self.netinfo.is_full_node() {
+            if self.netinfo.is_peer() {
                 let ready_msg = Target::All.message(BroadcastMessage::Ready(hash.to_vec()));
                 self.messages.push_back(ready_msg);
             }

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -126,7 +126,7 @@ where
     }
 
     fn get_coin(&mut self) -> Result<()> {
-        if !self.netinfo.is_full_node() {
+        if !self.netinfo.is_peer() {
             return self.try_output();
         }
         let share = self.netinfo.secret_key().sign(&self.nonce);

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -180,6 +180,9 @@ impl<NodeUid: Clone + Debug + Ord> CommonSubset<NodeUid> {
     /// Common Subset input message handler. It receives a value for broadcast
     /// and redirects it to the corresponding broadcast instance.
     pub fn send_proposed_value(&mut self, value: ProposedValue) -> CommonSubsetResult<()> {
+        if !self.netinfo.is_full_node() {
+            return Ok(());
+        }
         let uid = self.netinfo.our_uid().clone();
         // Upon receiving input v_i , input v_i to RBC_i. See Figure 2.
         self.process_broadcast(&uid, |bc| bc.input(value))

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -180,7 +180,7 @@ impl<NodeUid: Clone + Debug + Ord> CommonSubset<NodeUid> {
     /// Common Subset input message handler. It receives a value for broadcast
     /// and redirects it to the corresponding broadcast instance.
     pub fn send_proposed_value(&mut self, value: ProposedValue) -> CommonSubsetResult<()> {
-        if !self.netinfo.is_full_node() {
+        if !self.netinfo.is_peer() {
             return Ok(());
         }
         let uid = self.netinfo.our_uid().clone();

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -152,7 +152,7 @@ where
         &mut self,
         txs: I,
     ) -> HoneyBadgerResult<()> {
-        if self.netinfo.is_full_node() {
+        if self.netinfo.is_peer() {
             self.buffer.extend(txs);
             Ok(())
         } else {
@@ -167,7 +167,7 @@ where
 
     /// Proposes a new batch in the current epoch.
     fn propose(&mut self) -> HoneyBadgerResult<()> {
-        if !self.netinfo.is_full_node() {
+        if !self.netinfo.is_peer() {
             return Ok(());
         }
         let proposal = self.choose_transactions()?;
@@ -428,7 +428,7 @@ where
                 self.verify_pending_decryption_shares(&proposer_id, &ciphertext);
             self.remove_incorrect_decryption_shares(&proposer_id, incorrect_senders);
 
-            if self.netinfo.is_full_node() {
+            if self.netinfo.is_peer() {
                 if let Some(share) = self.netinfo.secret_key().decrypt_share(&ciphertext) {
                     // Send the share to remote nodes.
                     self.messages.0.push_back(

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -142,6 +142,7 @@ pub struct NetworkInfo<NodeUid> {
     all_uids: BTreeSet<NodeUid>,
     num_nodes: usize,
     num_faulty: usize,
+    is_peer: bool,
     secret_key: ClearOnDrop<Box<SecretKey>>,
     public_key_set: PublicKeySet,
     node_indices: BTreeMap<NodeUid, usize>,
@@ -155,6 +156,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
         public_key_set: PublicKeySet,
     ) -> Self {
         let num_nodes = all_uids.len();
+        let is_peer = all_uids.contains(&our_uid);
         let node_indices = all_uids
             .iter()
             .cloned()
@@ -166,6 +168,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
             all_uids,
             num_nodes,
             num_faulty: (num_nodes - 1) / 3,
+            is_peer,
             secret_key,
             public_key_set,
             node_indices,
@@ -219,6 +222,6 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
     /// Returns `true` if this node takes part in the consensus itself. If not, it is only an
     /// observer.
     pub fn is_peer(&self) -> bool {
-        self.all_uids.contains(&self.our_uid)
+        self.is_peer
     }
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -218,7 +218,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
 
     /// Returns `true` if this node takes part in the consensus itself. If not, it is only an
     /// observer.
-    pub fn is_full_node(&self) -> bool {
+    pub fn is_peer(&self) -> bool {
         self.all_uids.contains(&self.our_uid)
     }
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -154,9 +154,6 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
         secret_key: ClearOnDrop<Box<SecretKey>>,
         public_key_set: PublicKeySet,
     ) -> Self {
-        if !all_uids.contains(&our_uid) {
-            panic!("Missing own ID");
-        }
         let num_nodes = all_uids.len();
         let node_indices = all_uids
             .iter()
@@ -217,5 +214,11 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
     /// independent from the public key, so that reusing keys would be safer.
     pub fn invocation_id(&self) -> Vec<u8> {
         self.public_key_set.public_key().to_bytes()
+    }
+
+    /// Returns `true` if this node takes part in the consensus itself. If not, it is only an
+    /// observer.
+    pub fn is_full_node(&self) -> bool {
+        self.all_uids.contains(&self.our_uid)
     }
 }

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -57,6 +57,7 @@ fn test_agreement<A: Adversary<Agreement<NodeUid>>>(
             expected = Some(node.outputs()[0]);
         }
     }
+    assert!(expected.iter().eq(network.observer.outputs()));
 }
 
 fn test_agreement_different_sizes<A, F>(new_adversary: F)

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -107,6 +107,7 @@ fn test_broadcast<A: Adversary<Broadcast<NodeUid>>>(
     for node in network.nodes.values() {
         assert!(once(&proposed_value.to_vec()).eq(node.outputs()));
     }
+    assert!(once(&proposed_value.to_vec()).eq(network.observer.outputs()));
 }
 
 fn new_broadcast(netinfo: Rc<NetworkInfo<NodeUid>>) -> Broadcast<NodeUid> {

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -49,6 +49,7 @@ fn test_common_subset<A: Adversary<CommonSubset<NodeUid>>>(
         expected = Some(node.outputs()[0].clone());
     }
     let output = expected.unwrap();
+    assert!(once(&output).eq(network.observer.outputs()));
     // The Common Subset algorithm guarantees that more than two thirds of the proposed elements
     // are in the set.
     assert!(output.len() * 3 > inputs.len() * 2);


### PR DESCRIPTION
This allows nodes to join the network without sending any messages
themselves. They can't give any input and just observe the outcome.

Closes #81