### PR TITLE
Avoid redundant key computations.

### DIFF
--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -136,8 +136,7 @@ where
     }
 
     fn handle_share(&mut self, sender_id: &NodeUid, share: Signature) -> Result<()> {
-        if let Some(i) = self.netinfo.node_index(sender_id) {
-            let pk_i = self.netinfo.public_key_set().public_key_share(*i as u64);
+        if let Some(pk_i) = self.netinfo.public_key_share(sender_id) {
             if !pk_i.verify(&share, &self.nonce) {
                 // Silently ignore the invalid share.
                 return Ok(());

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -223,7 +223,7 @@ impl PublicKeySet {
 
     /// Returns the public key.
     pub fn public_key(&self) -> PublicKey {
-        PublicKey(self.commit.evaluate(0))
+        PublicKey(self.commit.coeff[0])
     }
 
     /// Returns the `i`-th public key share.

--- a/src/crypto/poly.rs
+++ b/src/crypto/poly.rs
@@ -29,7 +29,7 @@ use rand::Rng;
 pub struct Poly {
     /// The coefficients of a polynomial.
     #[serde(with = "super::serde_impl::field_vec")]
-    coeff: Vec<Fr>,
+    pub(super) coeff: Vec<Fr>,
 }
 
 impl<B: Borrow<Poly>> ops::AddAssign<B> for Poly {
@@ -246,7 +246,7 @@ impl Poly {
 pub struct Commitment {
     /// The coefficients of the polynomial.
     #[serde(with = "super::serde_impl::projective_vec")]
-    coeff: Vec<G1>,
+    pub(super) coeff: Vec<G1>,
 }
 
 impl Hash for Commitment {

--- a/src/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger.rs
@@ -265,7 +265,7 @@ where
     /// Starts Key Generation for the set of nodes implied by the `change`.
     fn start_key_gen(&mut self, change: Change<NodeUid>) -> Result<()> {
         // Use the existing key shares - with the change applied - as keys for DKG.
-        let mut pub_keys = self.netinfo.public_key_map();
+        let mut pub_keys = self.netinfo.public_key_map().clone();
         if match change {
             Change::Remove(id) => pub_keys.remove(&id).is_none(),
             Change::Add(id, pub_key) => pub_keys.insert(id, pub_key).is_some(),

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -278,9 +278,11 @@ where
         share: &DecryptionShare,
         ciphertext: &Ciphertext,
     ) -> bool {
-        let sender: u64 = *self.netinfo.node_index(sender_id).unwrap() as u64;
-        let pk = self.netinfo.public_key_set().public_key_share(sender);
-        pk.verify_decryption_share(&share, ciphertext)
+        if let Some(pk) = self.netinfo.public_key_share(sender_id) {
+            pk.verify_decryption_share(&share, ciphertext)
+        } else {
+            false
+        }
     }
 
     /// When selections of transactions have been decrypted for all valid proposers in this epoch,


### PR DESCRIPTION
This precomputes the keys in `NetworkInfo` instead of doing the calculation on every call to `public_key_share`.