### PR TITLE
Add node transaction messages to Dynamic HB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Honey Badger is a modular library composed of several independent algorithms.  T
 
 In an optimal networking environment, output includes data sent from each node. In an adverse environment, the output is an agreed upon subset of data. Either way, the resulting output contains a batch of transactions which is guaranteed to be consistent across all nodes.  
 
+In addition to **full nodes**, the algorithms support **observers**: These don't actively participate, and don't need to be trusted, but they receive the output as well, and are able to verify it under the assumption that more than two thirds of the full nodes are correct.
+
 ## Algorithms
 
-- [ ] **[Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/honey_badger.rs):** The top level protocol proceeds in epochs using the protocols below. 
+- [x] **[Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/honey_badger.rs):** Each node inputs transactions. The protocol outputs a sequence of batches of transactions.
+
+- [ ] **[Dynamic Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/dynamic_honey_badger.rs):** This works like Honey Badger itself, but in addition allows dynamically adding and removing nodes to/from the network.
 
 - [x] **[Subset](https://github.com/poanetwork/hbbft/blob/master/src/common_subset.rs):** Each node inputs data. The nodes agree on a subset of suggested data. 
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Honey Badger is a modular library composed of several independent algorithms.  T
 
 In an optimal networking environment, output includes data sent from each node. In an adverse environment, the output is an agreed upon subset of data. Either way, the resulting output contains a batch of transactions which is guaranteed to be consistent across all nodes.  
 
-In addition to **full nodes**, the algorithms support **observers**: These don't actively participate, and don't need to be trusted, but they receive the output as well, and are able to verify it under the assumption that more than two thirds of the full nodes are correct.
+In addition to **validators**, the algorithms support **observers**: These don't actively participate, and don't need to be trusted, but they receive the output as well, and are able to verify it under the assumption that more than two thirds of the validators are correct.
 
 ## Algorithms
 
 - [x] **[Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/honey_badger.rs):** Each node inputs transactions. The protocol outputs a sequence of batches of transactions.
 
-- [ ] **[Dynamic Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/dynamic_honey_badger.rs):** This works like Honey Badger itself, but in addition allows dynamically adding and removing nodes to/from the network.
+- [ ] **[Dynamic Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/dynamic_honey_badger.rs):** A modified Honey Badger where nodes can dynamically add and remove other nodes to/from the network.
 
 - [x] **[Subset](https://github.com/poanetwork/hbbft/blob/master/src/common_subset.rs):** Each node inputs data. The nodes agree on a subset of suggested data. 
 

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -456,9 +456,11 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         self.output = Some(b);
         // Latch the decided state.
         self.decision = Some(b);
-        self.messages
-            .push_back(AgreementContent::Term(b).with_epoch(self.epoch));
-        self.received_term.insert(self.netinfo.our_uid().clone(), b);
+        if self.netinfo.is_peer() {
+            self.messages
+                .push_back(AgreementContent::Term(b).with_epoch(self.epoch));
+            self.received_term.insert(self.netinfo.our_uid().clone(), b);
+        }
         self.terminated = true;
         debug!(
             "Agreement instance {:?} decided: {}",
@@ -482,6 +484,9 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
     }
 
     fn send_aux(&mut self, b: bool) -> AgreementResult<()> {
+        if !self.netinfo.is_peer() {
+            return Ok(());
+        }
         // Multicast `Aux`.
         self.messages
             .push_back(AgreementContent::Aux(b).with_epoch(self.epoch));

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -307,7 +307,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
     }
 
     fn send_bval(&mut self, b: bool) -> AgreementResult<()> {
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
         // Record the value `b` as sent.
@@ -329,7 +329,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         // Trigger the start of the `Conf` round.
         self.conf_round = true;
 
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
 
@@ -456,7 +456,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         self.output = Some(b);
         // Latch the decided state.
         self.decision = Some(b);
-        if self.netinfo.is_peer() {
+        if self.netinfo.is_validator() {
             self.messages
                 .push_back(AgreementContent::Term(b).with_epoch(self.epoch));
             self.received_term.insert(self.netinfo.our_uid().clone(), b);
@@ -484,7 +484,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
     }
 
     fn send_aux(&mut self, b: bool) -> AgreementResult<()> {
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
         // Multicast `Aux`.

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -355,7 +355,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     /// Sends an `Echo` message and handles it. Does nothing if we are only an observer.
     fn send_echo(&mut self, p: Proof<Vec<u8>>) -> BroadcastResult<()> {
         self.echo_sent = true;
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
         let echo_msg = Target::All.message(BroadcastMessage::Echo(p.clone()));
@@ -367,7 +367,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     /// Sends a `Ready` message and handles it. Does nothing if we are only an observer.
     fn send_ready(&mut self, hash: &[u8]) -> BroadcastResult<()> {
         self.ready_sent = true;
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
         let ready_msg = Target::All.message(BroadcastMessage::Ready(hash.to_vec()));

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -126,7 +126,7 @@ where
     }
 
     fn get_coin(&mut self) -> Result<()> {
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return self.try_output();
         }
         let share = self.netinfo.secret_key().sign(&self.nonce);

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -180,7 +180,7 @@ impl<NodeUid: Clone + Debug + Ord> CommonSubset<NodeUid> {
     /// Common Subset input message handler. It receives a value for broadcast
     /// and redirects it to the corresponding broadcast instance.
     pub fn send_proposed_value(&mut self, value: ProposedValue) -> CommonSubsetResult<()> {
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
         let uid = self.netinfo.our_uid().clone();

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -29,12 +29,20 @@ const CHACHA_RNG_SEED_SIZE: usize = 8;
 const ERR_OS_RNG: &str = "could not initialize the OS random number generator";
 
 /// A public key, or a public key share.
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct PublicKey(#[serde(with = "serde_impl::projective")] G1);
 
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.into_affine().into_compressed().as_ref().hash(state);
+    }
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let uncomp = self.0.into_affine().into_uncompressed();
+        let bytes = uncomp.as_ref();
+        write!(f, "PublicKey({:?})", HexBytes(bytes))
     }
 }
 
@@ -82,7 +90,7 @@ impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let uncomp = self.0.into_affine().into_uncompressed();
         let bytes = uncomp.as_ref();
-        write!(f, "{:?}", HexBytes(bytes))
+        write!(f, "Signature({:?})", HexBytes(bytes))
     }
 }
 
@@ -104,8 +112,16 @@ impl Signature {
 }
 
 /// A secret key, or a secret key share.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SecretKey(Fr);
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let uncomp = self.public_key().0.into_affine().into_uncompressed();
+        let bytes = uncomp.as_ref();
+        write!(f, "SecretKey({:?})", HexBytes(bytes))
+    }
+}
 
 impl Default for SecretKey {
     fn default() -> Self {

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -28,7 +28,6 @@ error_chain!{
 
     errors {
         UnknownSender
-        ObserverCannotPropose
     }
 }
 
@@ -73,7 +72,8 @@ where
     type Error = Error;
 
     fn input(&mut self, input: Self::Input) -> HoneyBadgerResult<()> {
-        self.add_transactions(iter::once(input))
+        self.add_transactions(iter::once(input));
+        Ok(())
     }
 
     fn handle_message(
@@ -147,16 +147,8 @@ where
     }
 
     /// Adds transactions into the buffer.
-    pub fn add_transactions<I: IntoIterator<Item = Tx>>(
-        &mut self,
-        txs: I,
-    ) -> HoneyBadgerResult<()> {
-        if self.netinfo.is_peer() {
-            self.buffer.extend(txs);
-            Ok(())
-        } else {
-            Err(ErrorKind::ObserverCannotPropose.into())
-        }
+    pub fn add_transactions<I: IntoIterator<Item = Tx>>(&mut self, txs: I) {
+        self.buffer.extend(txs);
     }
 
     /// Empties and returns the transaction buffer.

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -545,9 +545,14 @@ pub struct Batch<Tx, NodeUid> {
 }
 
 impl<Tx, NodeUid: Ord> Batch<Tx, NodeUid> {
-    /// Returns an iterator over all transactions included in the batch.
+    /// Returns an iterator over references to all transactions included in the batch.
     pub fn iter(&self) -> impl Iterator<Item = &Tx> {
         self.transactions.values().flat_map(|vec| vec)
+    }
+
+    /// Returns an iterator over all transactions included in the batch. Consumes the batch.
+    pub fn into_tx_iter(self) -> impl Iterator<Item = Tx> {
+        self.transactions.into_iter().flat_map(|(_, vec)| vec)
     }
 
     /// Returns the number of transactions in the batch (without detecting duplicates).

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -158,7 +158,7 @@ where
 
     /// Proposes a new batch in the current epoch.
     fn propose(&mut self) -> HoneyBadgerResult<()> {
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(());
         }
         let proposal = self.choose_transactions()?;
@@ -441,7 +441,7 @@ where
         proposer_id: &NodeUid,
         ciphertext: &Ciphertext,
     ) -> HoneyBadgerResult<bool> {
-        if !self.netinfo.is_peer() {
+        if !self.netinfo.is_validator() {
             return Ok(ciphertext.verify());
         }
         let share = match self.netinfo.secret_key().decrypt_share(&ciphertext) {

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -142,7 +142,7 @@ pub struct NetworkInfo<NodeUid> {
     all_uids: BTreeSet<NodeUid>,
     num_nodes: usize,
     num_faulty: usize,
-    is_peer: bool,
+    is_validator: bool,
     secret_key: ClearOnDrop<Box<SecretKey>>,
     public_key_set: PublicKeySet,
     public_keys: BTreeMap<NodeUid, PublicKey>,
@@ -157,7 +157,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
         public_key_set: PublicKeySet,
     ) -> Self {
         let num_nodes = all_uids.len();
-        let is_peer = all_uids.contains(&our_uid);
+        let is_validator = all_uids.contains(&our_uid);
         let node_indices: BTreeMap<NodeUid, usize> = all_uids
             .iter()
             .enumerate()
@@ -172,7 +172,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
             all_uids,
             num_nodes,
             num_faulty: (num_nodes - 1) / 3,
-            is_peer,
+            is_validator,
             secret_key,
             public_key_set,
             public_keys,
@@ -236,7 +236,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
 
     /// Returns `true` if this node takes part in the consensus itself. If not, it is only an
     /// observer.
-    pub fn is_peer(&self) -> bool {
-        self.is_peer
+    pub fn is_validator(&self) -> bool {
+        self.is_validator
     }
 }

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 
 use rand::Rng;
 
-use hbbft::dynamic_honey_badger::{Change, DynamicHoneyBadger, Input};
+use hbbft::dynamic_honey_badger::{Change, ChangeState, DynamicHoneyBadger, Input};
 use hbbft::messaging::NetworkInfo;
 
 use network::{Adversary, MessageScheduler, NodeUid, SilentAdversary, TestNetwork, TestNode};
@@ -39,18 +39,14 @@ fn test_dynamic_honey_badger<A>(
     fn has_remove(node: &TestNode<DynamicHoneyBadger<usize, NodeUid>>) -> bool {
         node.outputs()
             .iter()
-            .filter_map(|batch| batch.change())
-            .any(|change| *change == Change::Remove(NodeUid(0)))
+            .any(|batch| batch.change == ChangeState::Complete(Change::Remove(NodeUid(0))))
     }
 
     fn has_add(node: &TestNode<DynamicHoneyBadger<usize, NodeUid>>) -> bool {
-        node.outputs()
-            .iter()
-            .filter_map(|batch| batch.change())
-            .any(|change| match *change {
-                Change::Add(ref id, _) => *id == NodeUid(0),
-                _ => false,
-            })
+        node.outputs().iter().any(|batch| match batch.change {
+            ChangeState::Complete(Change::Add(ref id, _)) => *id == NodeUid(0),
+            _ => false,
+        })
     }
 
     // Returns `true` if the node has not output all transactions yet.

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -108,7 +108,10 @@ where
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn new_dynamic_hb(netinfo: Rc<NetworkInfo<NodeUid>>) -> DynamicHoneyBadger<usize, NodeUid> {
-    DynamicHoneyBadger::new((*netinfo).clone(), 12).expect("Instantiate dynamic_honey_badger")
+    DynamicHoneyBadger::builder((*netinfo).clone())
+        .batch_size(12)
+        .build()
+        .expect("Instantiate dynamic_honey_badger")
 }
 
 fn test_dynamic_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use rand::{self, Rng};
 
-use hbbft::crypto::SecretKeySet;
+use hbbft::crypto::{PublicKeySet, SecretKeySet};
 use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
 
 /// A node identifier. In the tests, nodes are simply numbered.
@@ -150,6 +150,7 @@ where
     pub nodes: BTreeMap<D::NodeUid, TestNode<D>>,
     pub observer: TestNode<D>,
     pub adv_nodes: BTreeMap<D::NodeUid, Rc<NetworkInfo<D::NodeUid>>>,
+    pub pk_set: PublicKeySet,
     adversary: A,
 }
 
@@ -205,6 +206,7 @@ where
             nodes: (0..good_num).map(NodeUid).map(new_node_by_id).collect(),
             observer: new_node_by_id(NodeUid(good_num + adv_num)).1,
             adversary: adversary(adv_nodes.clone()),
+            pk_set: pk_set.clone(),
             adv_nodes,
         };
         let msgs = network.adversary.step();


### PR DESCRIPTION
This allows adding and removing full peers to/from the pool of observers.

To allow a joining node to participate in the on-chain key generation, messages are signed and broadcast to all nodes, and the receiver inputs them as transactions.