### PR TITLE
Remove unused feature, allowing compilation on stable again.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,6 @@
 //! If `serialization-protobuf` is enabled, the message types support serialization with [Google
 //! protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
 
-#![feature(optin_builtin_traits)]
 // TODO: Remove this once https://github.com/rust-lang-nursery/error-chain/issues/245 is resolved.
 #![allow(renamed_and_removed_lints)]
 


### PR DESCRIPTION
There is no evidence that [optin_builtin_traits](https://doc.rust-lang.org/beta/unstable-book/language-features/optin-builtin-traits.html) are used any longer (the keyword `auto` does not even show up in the codebase).

Removing this features allow compilation on stable Rust 1.27 and possible earlier versions.