### PR TITLE
Add module-level Agreement, Coin and Subset documentation.

### DIFF
--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -45,7 +45,7 @@
 //!   * If both values are candidates, we set `e = s` and proceed to the next epoch.
 //!
 //! In epochs that are 0 modulo 3, the value `s` is `true`. In 1 modulo 3, it is `false`. In the
-//! case 2 modulo 3, we carefully flip a common coin to determine a pseudorandom `s`.
+//! case 2 modulo 3, we flip a common coin to determine a pseudorandom `s`.
 //!
 //! An adversary that knows each coin value, controls a few validators and controls network
 //! scheduling can delay the delivery of `Aux` and `BVal` messages to influence which candidate

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -1,4 +1,67 @@
-//! Binary Byzantine agreement protocol from a common coin protocol.
+//! # Binary Byzantine agreement protocol
+//!
+//! The Binary Agreement protocol allows each node to input one binary (`bool`) value, and will
+//! output a binary value. The output is guaranteed to have been input by at least one correct
+//! node, and all correct nodes will have the same output.
+//!
+//! ## How it works
+//!
+//! The algorithm proceeds in _epochs_, and the number of epochs it takes until it terminates is
+//! unbounded in theory but has a finite expected value. Each node keeps track of an _estimate_
+//! value `e`, which is initialized to the node's own input. Let's call a value `v`
+//! that has been input by at least one correct node and such that `!v` hasn't been _output_ by any
+//! correct node yet, a _viable output_. The estimate will always be a viable output.
+//!
+//! All messages are annotated with the epoch they belong to, but we omit that here for brevity.
+//!
+//! * At the beginning of each epoch, we multicast `BVal(e)`. It translates to: "I know that `e` is
+//! a viable output."
+//!
+//! * Once we receive `BVal(v)` with the same value from _f + 1_ different validators, we know that
+//!   at least one of them must be correct. So we know that `v` is a viable output. If we haven't
+//!   done so already we multicast `BVal(v)`. (Even if we already multicast `BVal(!v)`).
+//!
+//! * Let's say a node _believes in `v`_ if it received `BVal(v)` from _2 f + 1_ validators.
+//! For the _first_ value `v` we believe in, we multicast `Aux(v)`. It translates to:
+//! "I know that all correct nodes will eventually know that `v` is a viable output.
+//! I'm not sure about `!v` yet."
+//!
+//!   * Since every node will receive at least _2 f + 1_ `BVal` messages from correct validators,
+//!   there is at least one value `v`, such that every node receives _f + 1_ `BVal(v)` messages.
+//!   As a consequence, every correct validator will multicast `BVal(v)` itself. Hence we are
+//!   guaranteed to receive _2 f + 1_ `BVal(v)` messages.
+//!   In short: If _any_ correct node believes in `v`, _every_ correct node will.
+//!
+//!   * Every correct node will eventually send exactly one `Aux`, so we will receive at least
+//!   _2 f + 1_ `Aux` messages with values we believe in. At that point, we define the set `vals`
+//!   of _candidate values_: the set of values we believe in _and_ have received in an `Aux`.
+//!
+//! * Once we have the set of candidate values, we obtain a _coin value_ `s` (see below).
+//!
+//!   * If there is only a single candidate value `b`, we set our estimate `e = b`. If `s == b`,
+//!   we _output_ and send a `Term(b)` message which is interpreted as `BVal(b)` and `Aux(b)` for
+//!   all future epochs. If `s != b`, we just proceed to the next epoch.
+//!
+//!   * If both values are candidates, we set `e = s` and proceed to the next epoch.
+//!
+//! In epochs that are 0 modulo 3, the value `s` is `true`. In 1 modulo 3, it is `false`. In the
+//! case 2 modulo 3, we carefully flip a common coin to determine a pseudorandom `s`.
+//!
+//! An adversary that knows each coin value, controls a few validators and controls network
+//! scheduling can delay the delivery of `Aux` and `BVal` messages to influence which candidate
+//! values the nodes will end up with. In some circumstances that allows them to stall the network.
+//! This is even true if the coin is flipped too early: the adversary must not learn about the coin
+//! value early enough to delay enough `Aux` messages. That's why in the third case, the value `s`
+//! is determined as follows:
+//!
+//! * We multicast a `Conf` message containing our candidate values.
+//!
+//! * Since every good node believes in all values it puts into its `Conf` message, we will
+//! eventually receive _2 f + 1_ `Conf` messages containing only values we believe in. Then we
+//! trigger the common coin.
+//!
+//! * After _f + 1_ nodes have sent us their coin shares, we receive the coin output and assign it
+//! to `s`.
 
 pub mod bin_values;
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,7 +1,7 @@
 //! # Broadcast
 //!
-//! The Reliable Broadcast Protocol assumes a network of `N` nodes that send signed messages to
-//! each other, with at most `f` of them faulty, where `3 * f < N`. Handling the networking and
+//! The Reliable Broadcast Protocol assumes a network of _N_ nodes that send signed messages to
+//! each other, with at most _f_ of them faulty, where _3 f < N_. Handling the networking and
 //! signing is the responsibility of this crate's user; a message is only handed to the Broadcast
 //! instance after it has been verified to be "from node i". One of the nodes is the "proposer"
 //! who sends a value. It needs to be determined beforehand, and all nodes need to know and agree
@@ -11,7 +11,7 @@
 //!
 //! ## How it works
 //!
-//! * The proposer uses a Reed-Solomon code to split the value into `N` chunks, `f + 1` of which
+//! * The proposer uses a Reed-Solomon code to split the value into _N_ chunks, _2 f + 1_ of which
 //! suffice to reconstruct the value. These chunks are put into a Merkle tree, so that with the
 //! tree's root hash `h`, branch `bi` and chunk `si`, the `i`-th chunk `si` can be verified by
 //! anyone as belonging to the Merkle tree with root hash `h`. These values are "proof" number `i`:
@@ -21,24 +21,24 @@
 //! * Every (correct) node that receives `Value(pi)` from the proposer sends it on to everyone else
 //! as `Echo(pi)`. An `Echo` translates to: "I have received `pi` directly from the proposer." If
 //! the proposer sends another `Value` message it is ignored.
-//! * So every node that receives at least `f + 1` `Echo` messages with the same root hash can
+//! * So every node that receives at least _2 f + 1_ `Echo` messages with the same root hash can
 //! decode a value.
-//! * Every node that has received `N - f` `Echo`s with the same root hash from different nodes
-//! knows that at least `f + 1` _correct_ nodes have sent an `Echo` with that hash to everyone, and
-//! therefore everyone will eventually receive at least `f + 1` of them. So upon receiving `N - f`
-//! `Echo`s, they send a `Ready(h)` to everyone. It translates to: "I know that everyone will
-//! eventually be able to decode the value with root hash `h`." Moreover, since every correct node
-//! only sends one kind of `Echo` message, there is no danger of receiving `N - f` `Echo`s with two
-//! different root hashes.
-//! * Even without enough `Echo` messages, if a node receives `f + 1` `Ready` messages, it knows
+//! * Every node that has received _N - f_ `Echo`s with the same root hash from different nodes
+//! knows that at least _2 f + 1_ _correct_ nodes have sent an `Echo` with that hash to everyone,
+//! and therefore everyone will eventually receive at least _2 f + 1_ of them. So upon receiving
+//! _N - f_ `Echo`s, they send a `Ready(h)` to everyone. It translates to: "I know that everyone
+//! will eventually be able to decode the value with root hash `h`." Moreover, since every correct
+//! node only sends one kind of `Echo` message, there is no danger of receiving _N - f_ `Echo`s
+//! with two different root hashes.
+//! * Even without enough `Echo` messages, if a node receives _2 f + 1_ `Ready` messages, it knows
 //! that at least one _correct_ node has sent `Ready`. It therefore also knows that everyone will
 //! be able to decode eventually, and multicasts `Ready` itself.
-//! * If a node has received `2 * f + 1` `Ready`s (with matching root hash) from different nodes,
-//! it knows that at least `f + 1` _correct_ nodes have sent it. Therefore, every correct node will
-//! eventually receive `f + 1`, and multicast it itself. Therefore, every correct node will
-//! eventually receive `2 * f + 1` `Ready`s, too. _And_ we know at this point that every correct
-//! node will eventually be able to decode (i.e. receive at least `f + 1` `Echo` messages).
-//! * So a node with `2 * f + 1` `Ready`s and `f + 1` `Echos` will decode and _output_ the value,
+//! * If a node has received _2 f + 1_ `Ready`s (with matching root hash) from different nodes,
+//! it knows that at least _2 f + 1_ _correct_ nodes have sent it. Therefore, every correct node
+//! will eventually receive _2 f + 1_, and multicast it itself. Therefore, every correct node will
+//! eventually receive _2 f + 1_ `Ready`s, too. _And_ we know at this point that every correct
+//! node will eventually be able to decode (i.e. receive at least _2 f + 1_ `Echo` messages).
+//! * So a node with _2 f + 1_ `Ready`s and _2 f + 1_ `Echos` will decode and _output_ the value,
 //! knowing that every other correct node will eventually do the same.
 
 use std::collections::{BTreeMap, VecDeque};
@@ -325,7 +325,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
             return self.compute_output(&hash);
         }
 
-        // Upon receiving `N - f` `Echo`s with this root hash, multicast `Ready`.
+        // Upon receiving _N - f_ `Echo`s with this root hash, multicast `Ready`.
         self.send_ready(&hash)
     }
 

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -8,7 +8,7 @@
 //! nonces (that can be feasibly computed), the output is uniformly distributed.
 // TODO: Bold claims! How much can we actually prove about that?
 //!
-//! The nodes input a signal (no data, just `()`), and after `f + 1` nodes have provided input,
+//! The nodes input a signal (no data, just `()`), and after _2 f + 1_ nodes have provided input,
 //! everyone receives the output value. In particular, the adversary cannot know the output value
 //! before at least one correct node has provided input.
 //!
@@ -16,10 +16,10 @@
 //!
 //! The algorithm uses a threshold signature scheme with the uniqueness property: For each public
 //! key and message, there is exactly one valid signature. This signature can be produced using
-//! signatures shares from any `f + 1` holders of secret key shares.
+//! signatures shares from any _2 f + 1_ holders of secret key shares.
 //!
 //! * On input, a node signs the nonce and sends its signature share to everyone else.
-//! * When a node has received `f + 1` shares, it computes the main signature and outputs the XOR
+//! * When a node has received _2 f + 1_ shares, it computes the main signature and outputs the XOR
 //! of its bits.
 
 use std::collections::{BTreeMap, VecDeque};

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -1,12 +1,11 @@
 //! # A Cryptographic Common Coin
 //!
-//! The Common Coin produces a pseudorandom binary value that the correct nodes agree on, and that\
+//! The Common Coin produces a pseudorandom binary value that the correct nodes agree on, and that
 //! cannot be known beforehand.
 //!
 //! Every Common Coin instance has a _nonce_ that determines the value, without giving it away: It
-//! is not feasible to compute the output from the nonce alone, and for any "natural" sequence of
-//! nonces (that can be feasibly computed), the output is uniformly distributed.
-// TODO: Bold claims! How much can we actually prove about that?
+//! is not feasible to compute the output from the nonce alone, and the output is uniformly
+//! distributed.
 //!
 //! The nodes input a signal (no data, just `()`), and after _2 f + 1_ nodes have provided input,
 //! everyone receives the output value. In particular, the adversary cannot know the output value

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -15,8 +15,8 @@
 //! ## How it works
 //!
 //! The algorithm uses a threshold signature scheme with the uniqueness property: For each public
-//! key and message, there is exactly one valid signature. This signature can be produced using
-//! signatures shares from any _2 f + 1_ holders of secret key shares.
+//! key and message, there is exactly one valid signature. This group signature is produced using
+//! signature shares from any combination of _2 f + 1_ secret key share holders.
 //!
 //! * On input, a node signs the nonce and sends its signature share to everyone else.
 //! * When a node has received _2 f + 1_ shares, it computes the main signature and outputs the XOR

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -1,4 +1,26 @@
-//! Common coin from a given set of keys based on a `pairing` threshold signature scheme.
+//! # A Cryptographic Common Coin
+//!
+//! The Common Coin produces a pseudorandom binary value that the correct nodes agree on, and that\
+//! cannot be known beforehand.
+//!
+//! Every Common Coin instance has a _nonce_ that determines the value, without giving it away: It
+//! is not feasible to compute the output from the nonce alone, and for any "natural" sequence of
+//! nonces (that can be feasibly computed), the output is uniformly distributed.
+// TODO: Bold claims! How much can we actually prove about that?
+//!
+//! The nodes input a signal (no data, just `()`), and after `f + 1` nodes have provided input,
+//! everyone receives the output value. In particular, the adversary cannot know the output value
+//! before at least one correct node has provided input.
+//!
+//! ## How it works
+//!
+//! The algorithm uses a threshold signature scheme with the uniqueness property: For each public
+//! key and message, there is exactly one valid signature. This signature can be produced using
+//! signatures shares from any `f + 1` holders of secret key shares.
+//!
+//! * On input, a node signs the nonce and sends its signature share to everyone else.
+//! * When a node has received `f + 1` shares, it computes the main signature and outputs the XOR
+//! of its bits.
 
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -1,23 +1,23 @@
 //! # Asynchronous Common Subset algorithm.
 //!
-//! The Asynchronous Common Subset protocol assumes a network of `N` nodes that send signed
-//! messages to each other, with at most `f` of them malicious, where `3 * f < N`. Handling the
+//! The Asynchronous Common Subset protocol assumes a network of _N_ nodes that send signed
+//! messages to each other, with at most _f_ of them malicious, where _3 f < N_. Handling the
 //! networking and signing is the responsibility of the user: only when a message has been
 //! verified to be "from node i", it can be handed to the `CommonSubset` instance.
 //!
 //! Each participating node proposes an element for inclusion. Under the above conditions, the
 //! protocol guarantees that all of the correct nodes output the same set, consisting of at least
-//! `N - f` of the proposed elements.
+//! _N - f_ of the proposed elements.
 //!
 //! ## How it works
 //!
 //! * `CommonSubset` instantiates one `Broadcast` algorithm for each of the participating nodes.
-//! At least `N - f` of these - the ones whose proposer is not faulty - will eventually output
+//! At least _N - f_ of these - the ones whose proposer is not faulty - will eventually output
 //! the element proposed by that node.
 //! * It also instantiates an `Agreement` instance for each participating node, to decide whether
 //! that node's proposed element should be included in the common set. Whenever an element is
 //! received via broadcast, we input "yes" (`true`) into the corresponding `Agreement` instance.
-//! * When `N - f` `Agreement` instances have decided "yes", we input "no" (`false`) into the
+//! * When _N - f_ `Agreement` instances have decided "yes", we input "no" (`false`) into the
 //! remaining ones, where we haven't provided input yet.
 //! * Once all `Agreement` instances have decided, `CommonSubset` returns the set of all proposed
 //! values for which the decision was "yes".

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -1,4 +1,26 @@
-//! Asynchronous Common Subset algorithm.
+//! # Asynchronous Common Subset algorithm.
+//!
+//! The Asynchronous Common Subset protocol assumes a network of `N` nodes that send signed
+//! messages to each other, with at most `f` of them malicious, where `3 * f < N`. Handling the
+//! networking and signing is the responsibility of the user: only when a message has been
+//! verified to be "from node i", it can be handed to the `CommonSubset` instance.
+//!
+//! Each participating node proposes an element for inclusion. Under the above conditions, the
+//! protocol guarantees that all of the correct nodes output the same set, consisting of at least
+//! `N - f` of the proposed elements.
+//!
+//! ## How it works
+//!
+//! * `CommonSubset` instantiates one `Broadcast` algorithm for each of the participating nodes.
+//! At least `N - f` of these - the ones whose proposer is not faulty - will eventually output
+//! the element proposed by that node.
+//! * It also instantiates an `Agreement` instance for each participating node, to decide whether
+//! that node's proposed element should be included in the common set. Whenever an element is
+//! received via broadcast, we input "yes" (`true`) into the corresponding `Agreement` instance.
+//! * When `N - f` `Agreement` instances have decided "yes", we input "no" (`false`) into the
+//! remaining ones, where we haven't provided input yet.
+//! * Once all `Agreement` instances have decided, `CommonSubset` returns the set of all proposed
+//! values for which the decision was "yes".
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
@@ -64,28 +86,6 @@ impl<NodeUid: Clone + Debug + Ord> MessageQueue<NodeUid> {
 }
 
 /// Asynchronous Common Subset algorithm instance
-///
-/// The Asynchronous Common Subset protocol assumes a network of `N` nodes that send signed
-/// messages to each other, with at most `f` of them malicious, where `3 * f < N`. Handling the
-/// networking and signing is the responsibility of the user: only when a message has been
-/// verified to be "from node i", it can be handed to the `CommonSubset` instance.
-///
-/// Each participating node proposes an element for inclusion. Under the above conditions, the
-/// protocol guarantees that all of the good nodes output the same set, consisting of at least
-/// `N - f` of the proposed elements.
-///
-/// The algorithm works as follows:
-///
-/// * `CommonSubset` instantiates one `Broadcast` algorithm for each of the participating nodes.
-/// At least `N - f` of these - the ones whose proposer is not malicious - will eventually output
-/// the element proposed by that node.
-/// * It also instantiates an `Agreement` instance for each participating node, to decide whether
-/// that node's proposed element should be included in the common set. Whenever an element is
-/// received via broadcast, we input "yes" (`true`) into the corresponding `Agreement` instance.
-/// * When `N - f` `Agreement` instances have decided "yes", we input "no" (`false`) into the
-/// remaining ones, where we haven't provided input yet.
-/// * Once all `Agreement` instances have decided, `CommonSubset` returns the set of all proposed
-/// values for which the decision was "yes".
 pub struct CommonSubset<NodeUid> {
     /// Shared network information.
     netinfo: Rc<NetworkInfo<NodeUid>>,

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -3,18 +3,19 @@
 //! The Asynchronous Common Subset protocol assumes a network of _N_ nodes that send signed
 //! messages to each other, with at most _f_ of them malicious, where _3 f < N_. Handling the
 //! networking and signing is the responsibility of the user: only when a message has been
-//! verified to be "from node i", it can be handed to the `CommonSubset` instance.
+//! verified to be "from node i" (e.g. using cryptographic signatures), it can be handed to the
+//! `CommonSubset` instance.
 //!
-//! Each participating node proposes an element for inclusion. Under the above conditions, the
-//! protocol guarantees that all of the correct nodes output the same set, consisting of at least
-//! _N - f_ of the proposed elements.
+//! Each node proposes an element for inclusion. Under the above conditions, the protocol
+//! guarantees that all correct nodes output the same set, consisting of at least _N - f_ of the
+//! proposed elements.
 //!
 //! ## How it works
 //!
 //! * `CommonSubset` instantiates one `Broadcast` algorithm for each of the participating nodes.
 //! At least _N - f_ of these - the ones whose proposer is not faulty - will eventually output
 //! the element proposed by that node.
-//! * It also instantiates an `Agreement` instance for each participating node, to decide whether
+//! * It also instantiates Binary Agreement for each participating node, to decide whether
 //! that node's proposed element should be included in the common set. Whenever an element is
 //! received via broadcast, we input "yes" (`true`) into the corresponding `Agreement` instance.
 //! * When _N - f_ `Agreement` instances have decided "yes", we input "no" (`false`) into the

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -105,7 +105,7 @@ impl Signature {
         let uncomp = self.0.into_affine().into_uncompressed();
         let bytes = uncomp.as_ref();
         let xor_bytes: u8 = bytes.iter().fold(0, |result, byte| result ^ byte);
-        let parity = 0 != xor_bytes % 2;
+        let parity = 0 != xor_bytes.count_ones() % 2;
         debug!("Signature: {:?}, output: {}", HexBytes(bytes), parity);
         parity
     }

--- a/src/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger.rs
@@ -1,7 +1,7 @@
 //! # Dynamic Honey Badger
 //!
-//! Like Honey Badger, this protocol allows a network of `N` nodes with at most `f` faulty ones,
-//! where `3 * f < N`, to input "transactions" - any kind of data -, and to agree on a sequence of
+//! Like Honey Badger, this protocol allows a network of _N_ nodes with at most _f_ faulty ones,
+//! where _3 f < N_, to input "transactions" - any kind of data -, and to agree on a sequence of
 //! _batches_ of transactions. The protocol proceeds in _epochs_, starting at number 0, and outputs
 //! one batch in each epoch. It never terminates: It handles a continuous stream of incoming
 //! transactions and keeps producing new batches from them. All correct nodes will output the same

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! Consensus algorithms are fundamental to resilient, distributed systems such as decentralized
 //! databases and blockchains. Byzantine fault tolerant systems can reach consensus with a number
-//! of faulty nodes `f` (including complete takeover by an attacker), as long as the total number
-//! `N` of nodes is greater than `3 * f`.
+//! of faulty nodes _f_ (including complete takeover by an attacker), as long as the total number
+//! _N_ of nodes is greater than _3 f_.
 //!
 //! The Honey Badger consensus algorithm is both Byzantine fault tolerant and asynchronous. It does
 //! not make timing assumptions about message delivery. An adversary can control network scheduling
@@ -32,7 +32,7 @@
 //! the instance sent to corresponding nodes.
 //!
 //! The algorithm outputs _batches_ of transactions. The order and content of these batches is
-//! guaranteed to be the same for all correct nodes, assuming enough nodes (`N > 3 * f`) are
+//! guaranteed to be the same for all correct nodes, assuming enough nodes (_N > 3 f_) are
 //! functional and correct.
 //!
 //!
@@ -55,11 +55,11 @@
 //!
 //! [**Common Subset**](common_subset/index.html)
 //!
-//! Each node inputs one item. The output is a set of at least `N - f` nodes' IDs, together with
+//! Each node inputs one item. The output is a set of at least _N - f_ nodes' IDs, together with
 //! their items, and will be the same in every correct node.
 //!
 //! This is the main building block of Honey Badger: In each epoch, every node proposes a number of
-//! transactions. Using the Common Subset protocol, they agree on at least `N - f` of those
+//! transactions. Using the Common Subset protocol, they agree on at least _N - f_ of those
 //! proposals. The batch contains the union of these sets of transactions.
 //!
 //! [**Reliable Broadcast**](broadcast/index.html)
@@ -81,7 +81,7 @@
 //!
 //! [**Common Coin**](common_coin/index.html)
 //!
-//! Each node inputs `()` to initiate a coin flip. Once `f + 1` nodes have input, either all nodes
+//! Each node inputs `()` to initiate a coin flip. Once _f + 1_ nodes have input, either all nodes
 //! receive `true` or all nodes receive `false`. The outcome cannot be known by the adversary
 //! before at least one correct node has provided input, and is uniformly distributed and
 //! pseudorandom.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! Consensus algorithms are fundamental to resilient, distributed systems such as decentralized
 //! databases and blockchains. Byzantine fault tolerant systems can reach consensus with a number
-//! of failed nodes `f` (including complete takeover by an attacker), as long as the total number
+//! of faulty nodes `f` (including complete takeover by an attacker), as long as the total number
 //! `N` of nodes is greater than `3 * f`.
 //!
 //! The Honey Badger consensus algorithm is both Byzantine fault tolerant and asynchronous. It does
@@ -40,12 +40,18 @@
 //!
 //! Honey Badger is modular, and composed of several algorithms that can also be used independently.
 //!
-//! [**Honey Badger BFT**](honey_badger/index.html)
+//! [**Honey Badger**](honey_badger/index.html)
 //!
 //! The nodes input any number of _transactions_ (any user-defined type) and output a sequence of
 //! _batches_. The batches have sequential numbers (_epochs_) and contain a set of transactions
 //! that were input by the nodes. The sequence and contents of the batches will be the same in all
 //! nodes.
+//!
+//! [**Dynamic Honey Badger**](dynamic_honey_badger/index.html)
+//!
+//! A modified Honey Badger where validators can dynamically add and remove others to/from the
+//! network. In addition to the transactions, they can input `Add` and `Remove` requests. The
+//! output batches contain information about validator changes.
 //!
 //! [**Common Subset**](common_subset/index.html)
 //!
@@ -73,7 +79,7 @@
 //! This is used in Subset to decide whether each node's proposal should be included in the subset
 //! or not.
 //!
-//! **Common Coin** (TBD)
+//! [**Common Coin**](common_coin/index.html)
 //!
 //! Each node inputs `()` to initiate a coin flip. Once `f + 1` nodes have input, either all nodes
 //! receive `true` or all nodes receive `false`. The outcome cannot be known by the adversary


### PR DESCRIPTION
Also change the signature parity computation, such that every bit is taken into account instead of only the last bit of each byte.

Closes #100