### PR TITLE
Doc updates: Contributing File, Code of Conduct, README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at andreas@poa.network. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+## Contributing
+
+Thank your for contributing to this project! We welcome collaborators and expect users to follow our [code of conduct](CODE_OF_CONDUCT.md) when submitting code or comments.
+
+1. Fork the repo ( https://github.com/poanetwork/hbbft/fork ).
+2. Create your feature branch (`git checkout -b my-new-feature`).
+3. Write tests that cover your work.
+4. Run Rustfmt, Clippy, and all tests to ensure CI rules are satisfied. Correct versions and feature flags can be found in the [`.travis.yml`](https://github.com/poanetwork/hbbft/blob/master/.travis.yml) file.
+5. Commit your changes (`git commit -am 'Add some feature'`).
+6. Push to your branch (`git push origin my-new-feature`).
+7. Create a new Pull Request.
+
+### General
+
+* Commits should be one logical change that still allows all tests to pass.  We prefer smaller commits if there could be two levels of logic grouping.  The goal is to provide future contributors (including your future self) the reasoning behind your changes and allow them to cherry-pick, patch or port those changes in isolation to other branches or forks.
+* If during your PR you reveal a pre-existing bug:
+  1. Try to isolate the bug and fix it on an independent branch and PR it first.
+  2. Try to fix the bug in a separate commit from other changes:
+     1. Commit the code in the broken state that revealed the bug originally
+     2. Commit the fix for the bug.
+     3. Continue original PR work.
+
+### Pull Requests
+All pull requests should include: 
+* A clear, readable description of the purpose of the PR
+* A clear, readable description of changes
+* Any additional concerns or comments (optional)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ We have simplified algorithm naming conventions from the original paper.
 | Binary Agreement | Binary Byzantine Agreement (BBA) |  
 | Coin             | Common Coin                      |  
 
+## Contributing
+
+See the [CONTRIBUTING](CONTRIBUTING.md) document for contribution, testing and pull request protocol.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ $ cargo run --example simulation --release -- -h
 See [Issues](https://github.com/poanetwork/hbbft/issues) for all tasks.
 
 - [ ] Dynamic Honey Badger (adding and removing nodes in a live network environment) ([#47](https://github.com/poanetwork/hbbft/issues/47#issuecomment-394640406))
-
-- [ ] Optimize Coin algorithm using a schedule ([#69](https://github.com/poanetwork/hbbft/issues/69))
-
+- [ ] Create additional adversarial scenarios and tests
 - [ ] Networking example to detail Honey Badger implementation
 
 ## Protocol Modifications

--- a/TODO
+++ b/TODO
@@ -1,12 +1,4 @@
 TODO
 ====
 
-* Fix the inappropriate use of Common Coin in the Byzantine Agreement protocol
-
-   This bug is explained in https://github.com/amiller/HoneyBadgerBFT/issues/59
-   where a solution is suggested introducing an additional type of message,
-   CONF.
-
-   There may be alternative solutions, such as using a different Byzantine
-   Agreement protocol altogether, for example,
-   https://people.csail.mit.edu/silvio/Selected%20Scientific%20Papers/Distributed%20Computation/BYZANTYNE%20AGREEMENT%20MADE%20TRIVIAL.pdf
+See [Issues](https://github.com/poanetwork/hbbft/issues) for current issues in queue.


### PR DESCRIPTION
After talking with folks in several other POA projects I decided to add our own contributing.md file for hbbft. There are not too many projects at this point and each have different testing requirements, pull request templates, languages and other features that make them unique. So, let's make this contributing file work best for this project.   I grabbed some language from other contributing files, feel free to modify as needed. 

Other changes:

- Added standard CODE_OF_CONDUCT file
- Updated TODO file to point to Issues (can possibly delete or repurpose this file)
- Updated README TODOS - Deleted Optimize Coin Algorithm and added adversarial tests. Any additional TODOs that contributors might want to tackle should be added here.