### PR TITLE
Output NetworkInfo from Dynamic Honey Badger

### DIFF
--- a/src/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger.rs
@@ -206,7 +206,7 @@ where
     /// The messages that need to be sent to other nodes.
     messages: MessageQueue<NodeUid>,
     /// The outputs from completed epochs.
-    output: VecDeque<Batch<Tx, NodeUid>>,
+    output: VecDeque<(Batch<Tx, NodeUid>, NetworkInfo<NodeUid>)>,
 }
 
 impl<Tx, NodeUid> DistAlgorithm for DynamicHoneyBadger<Tx, NodeUid>
@@ -216,7 +216,7 @@ where
 {
     type NodeUid = NodeUid;
     type Input = Input<Tx, NodeUid>;
-    type Output = Batch<Tx, NodeUid>;
+    type Output = (Batch<Tx, NodeUid>, NetworkInfo<NodeUid>);
     type Message = Message<NodeUid>;
     type Error = Error;
 
@@ -356,7 +356,7 @@ where
                     batch.change = ChangeState::InProgress(change.clone());
                 }
             }
-            self.output.push_back(batch);
+            self.output.push_back((batch, self.netinfo.clone()));
         }
         self.messages
             .extend_with_epoch(self.start_epoch, &mut self.honey_badger);


### PR DESCRIPTION
This allows the user to use current cryptographic keys and key shares.

An example use case would be if we want to make the sequence of batches
verifiable for third parties, like a blockchain. We would have each
batch signed by the set of validators that produced it, and whenever a
validator changes, sign the new public key using the old key shares.

To a third party that would then look like the owner of the secret key
signed each batch, and occasionally changed their key.

Closes #102