### PR TITLE
Implement `Rand` for `SecretKey`.

### DIFF
--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -11,10 +11,8 @@ use hbbft::crypto::{PublicKey, SecretKey};
 use hbbft::sync_key_gen::SyncKeyGen;
 
 fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
-    let mut rng = rand::thread_rng();
-
     // Generate individual key pairs for encryption. These are not suitable for threshold schemes.
-    let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| SecretKey::new(&mut rng)).collect();
+    let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| rand::random()).collect();
     let pub_keys: BTreeMap<usize, PublicKey> = sec_keys
         .iter()
         .map(|sk| sk.public_key())
@@ -37,8 +35,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
     let mut accepts = Vec::new();
     for (sender_id, proposal) in proposals[..=threshold].iter().enumerate() {
         for (node_id, node) in nodes.iter_mut().enumerate() {
-            let accept = node
-                .handle_propose(&sender_id, proposal.clone().expect("proposal"))
+            let accept = node.handle_propose(&sender_id, proposal.clone().expect("proposal"))
                 .expect("valid proposal");
             // Only the first `threshold + 1` manage to commit their `Accept`s.
             if node_id <= 2 * threshold {

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -35,7 +35,8 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
     let mut accepts = Vec::new();
     for (sender_id, proposal) in proposals[..=threshold].iter().enumerate() {
         for (node_id, node) in nodes.iter_mut().enumerate() {
-            let accept = node.handle_propose(&sender_id, proposal.clone().expect("proposal"))
+            let accept = node
+                .handle_propose(&sender_id, proposal.clone().expect("proposal"))
                 .expect("valid proposal");
             // Only the first `threshold + 1` manage to commit their `Accept`s.
             if node_id <= 2 * threshold {


### PR DESCRIPTION
I am trying to cut the noise of `let rng = rand::thread_rng(); Foo::random(&mut rng)`, to make tests easier to read and reduce the coupling to a specific RNG, however the API is not well suited to instantiate types that need additional parameters. At least `SecretKey` can (and should) implemented `Rand` here.

Caveats:

* `ThreadRng` in newer versions is marked as cryptographically secure through the `CryptoRng` trait, I do not see any issues in using it. It leverages the OS random generator (which on Linux collects entropy from various sources and adds them to a pool, possibly including real hardware random number generators) and falls back on a generator based on CPU jitter. Said RNG errs on the side of entropy, so it should not be less random, it is simply slower by three to six orders of magnitude.
* The `Rand` trait is deprecated, however the `rand` crate is due another overhaul in the near future it seems. We need to pick one version and implement against that for now and it seems we are stuck on the 0.4 branch, since pairing will not compile with 0.5.
* I briefly considered (and implemented, but left out of the PR) `generate` functions that essentially do the little `thread_rng`-instantiation-dance, but I think they are too much code added for too few gains.