### PR TITLE
Show `rustfmt` version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - protoc --version
   - rm protoc-3.5.1-linux-x86_64.zip
   - rustup component add rustfmt-preview
+  - rustfmt --version
   - cargo install clippy -f --vers=0.0.202
 env:
   global:


### PR DESCRIPTION
A small addition to the CI script. It is still a bit tricky to get the exact rustfmt version out of rustup, being able to verify using rustfmt --version helps immensely.