### PR TITLE
Implement a random adversary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ merkle = { git = "https://github.com/afck/merkle.rs", branch = "public-proof", f
 pairing = { version = "0.14.2", features = ["u128-support"] }
 protobuf = { version = "2.0.0", optional = true }
 rand = "0.4.2"
+rand_derive = "0.3.1"
 reed-solomon-erasure = "3.1.0"
 ring = "^0.12"
 serde = "1.0.55"

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -6,6 +6,8 @@ extern crate hbbft;
 extern crate itertools;
 extern crate pairing;
 extern crate rand;
+#[macro_use]
+extern crate rand_derive;
 extern crate serde;
 #[macro_use(Deserialize, Serialize)]
 extern crate serde_derive;
@@ -62,7 +64,7 @@ struct Args {
 }
 
 /// A node identifier. In the simulation, nodes are simply numbered.
-#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy, Rand)]
 pub struct NodeUid(pub usize);
 
 /// A transaction.

--- a/src/agreement/bin_values.rs
+++ b/src/agreement/bin_values.rs
@@ -3,7 +3,7 @@ use std::mem::replace;
 
 /// A lattice-valued description of the state of `bin_values`, essentially the same as the set of
 /// subsets of `bool`.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Rand)]
 pub enum BinValues {
     None,
     False,

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -65,6 +65,7 @@
 
 pub mod bin_values;
 
+use rand;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::mem::replace;
@@ -122,10 +123,30 @@ impl AgreementContent {
 }
 
 /// Messages sent during the binary Byzantine agreement stage.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
 pub struct AgreementMessage {
     pub epoch: u32,
     pub content: AgreementContent,
+}
+
+// NOTE: Extending rand_derive to correctly generate random values from boxes would make this
+// implementation obsolete; however at the time of this writing, `rand::Rand` is already deprecated
+// with no replacement in sight.
+impl rand::Rand for AgreementContent {
+    fn rand<R: rand::Rng>(rng: &mut R) -> Self {
+        let message_type = *rng
+            .choose(&["bval", "aux", "conf", "term", "coin"])
+            .unwrap();
+
+        match message_type {
+            "bval" => AgreementContent::BVal(rand::random()),
+            "aux" => AgreementContent::Aux(rand::random()),
+            "conf" => AgreementContent::Conf(rand::random()),
+            "term" => AgreementContent::Term(rand::random()),
+            "coin" => AgreementContent::Coin(Box::new(rand::random())),
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Possible values of the common coin schedule defining the method to derive the common coin in a

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -45,7 +45,7 @@ error_chain! {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
 pub struct CommonCoinMessage(Signature);
 
 impl CommonCoinMessage {

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -32,6 +32,7 @@ use broadcast::{self, Broadcast, BroadcastMessage, BroadcastResult};
 use fault_log::FaultLog;
 use fmt::HexBytes;
 use messaging::{DistAlgorithm, NetworkInfo, TargetedMessage};
+use rand::Rand;
 
 error_chain!{
     types {
@@ -54,8 +55,8 @@ error_chain!{
 type ProposedValue = Vec<u8>;
 
 /// Message from Common Subset to remote nodes.
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum Message<NodeUid> {
+#[derive(Serialize, Deserialize, Clone, Debug, Rand)]
+pub enum Message<NodeUid: Rand> {
     /// A message for the broadcast algorithm concerning the set element proposed by the given node.
     Broadcast(NodeUid, BroadcastMessage),
     /// A message for the agreement algorithm concerning the set element proposed by the given
@@ -65,9 +66,9 @@ pub enum Message<NodeUid> {
 
 /// The queue of outgoing messages in a `CommonSubset` instance.
 #[derive(Deref, DerefMut)]
-struct MessageQueue<NodeUid>(VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>);
+struct MessageQueue<NodeUid: Rand>(VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>);
 
-impl<NodeUid: Clone + Debug + Ord> MessageQueue<NodeUid> {
+impl<NodeUid: Clone + Debug + Ord + Rand> MessageQueue<NodeUid> {
     /// Appends to the queue the messages from `agr`, wrapped with `proposer_id`.
     fn extend_agreement(&mut self, proposer_id: &NodeUid, agr: &mut Agreement<NodeUid>) {
         let convert = |msg: TargetedMessage<AgreementMessage, NodeUid>| {
@@ -86,7 +87,7 @@ impl<NodeUid: Clone + Debug + Ord> MessageQueue<NodeUid> {
 }
 
 /// Asynchronous Common Subset algorithm instance
-pub struct CommonSubset<NodeUid> {
+pub struct CommonSubset<NodeUid: Rand> {
     /// Shared network information.
     netinfo: Arc<NetworkInfo<NodeUid>>,
     broadcast_instances: BTreeMap<NodeUid, Broadcast<NodeUid>>,
@@ -101,7 +102,7 @@ pub struct CommonSubset<NodeUid> {
     decided: bool,
 }
 
-impl<NodeUid: Clone + Debug + Ord> DistAlgorithm for CommonSubset<NodeUid> {
+impl<NodeUid: Clone + Debug + Ord + Rand> DistAlgorithm for CommonSubset<NodeUid> {
     type NodeUid = NodeUid;
     type Input = ProposedValue;
     type Output = BTreeMap<NodeUid, ProposedValue>;
@@ -145,7 +146,7 @@ impl<NodeUid: Clone + Debug + Ord> DistAlgorithm for CommonSubset<NodeUid> {
     }
 }
 
-impl<NodeUid: Clone + Debug + Ord> CommonSubset<NodeUid> {
+impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
     pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>, session_id: u64) -> CommonSubsetResult<Self> {
         // Create all broadcast instances.
         let mut broadcast_instances: BTreeMap<NodeUid, Broadcast<NodeUid>> = BTreeMap::new();

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -16,7 +16,7 @@ use clear_on_drop::ClearOnDrop;
 use init_with::InitWith;
 use pairing::bls12_381::{Bls12, Fr, FrRepr, G1, G1Affine, G2, G2Affine};
 use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField};
-use rand::{ChaChaRng, OsRng, Rand, Rng, SeedableRng};
+use rand::{ChaChaRng, OsRng, Rng, SeedableRng};
 use ring::digest;
 
 use self::error::{ErrorKind, Result};
@@ -83,7 +83,8 @@ impl PublicKey {
 }
 
 /// A signature, or a signature share.
-#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+// note: random signatures can be generated for testing
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Rand)]
 pub struct Signature(#[serde(with = "serde_impl::projective")] G2);
 
 impl fmt::Debug for Signature {
@@ -112,7 +113,7 @@ impl Signature {
 }
 
 /// A secret key, or a secret key share.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Rand)]
 pub struct SecretKey(Fr);
 
 impl fmt::Debug for SecretKey {
@@ -126,12 +127,6 @@ impl fmt::Debug for SecretKey {
 impl Default for SecretKey {
     fn default() -> Self {
         SecretKey(Fr::zero())
-    }
-}
-
-impl Rand for SecretKey {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
-        SecretKey(rng.gen())
     }
 }
 
@@ -203,7 +198,7 @@ impl Ciphertext {
 }
 
 /// A decryption share. A threshold of decryption shares can be used to decrypt a message.
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq, Rand)]
 pub struct DecryptionShare(#[serde(with = "serde_impl::projective")] G1);
 
 impl Hash for DecryptionShare {

--- a/src/dynamic_honey_badger/batch.rs
+++ b/src/dynamic_honey_badger/batch.rs
@@ -1,4 +1,5 @@
 use super::ChangeState;
+use rand::Rand;
 use std::collections::BTreeMap;
 
 /// A batch of transactions the algorithm has output.
@@ -13,7 +14,7 @@ pub struct Batch<C, NodeUid> {
     pub change: ChangeState<NodeUid>,
 }
 
-impl<C, NodeUid: Ord> Batch<C, NodeUid> {
+impl<C, NodeUid: Ord + Rand> Batch<C, NodeUid> {
     /// Returns a new, empty batch with the given epoch.
     pub fn new(epoch: u64) -> Self {
         Batch {

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -4,6 +4,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use rand::Rand;
 use serde::{Deserialize, Serialize};
 
 use super::{DynamicHoneyBadger, MessageQueue, VoteCounter};
@@ -25,7 +26,7 @@ pub struct DynamicHoneyBadgerBuilder<C, NodeUid> {
 impl<C, NodeUid> DynamicHoneyBadgerBuilder<C, NodeUid>
 where
     C: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
-    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash,
+    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash + Rand,
 {
     /// Returns a new `DynamicHoneyBadgerBuilder` configured to use the node IDs and cryptographic
     /// keys specified by `netinfo`.

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -44,6 +44,7 @@
 //! `SyncKeyGen` instance is dropped, and a new one is started to create keys according to the new
 //! pending change.
 
+use rand::Rand;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -84,7 +85,7 @@ pub enum Input<C, NodeUid> {
 }
 
 /// A Honey Badger instance that can handle adding and removing nodes.
-pub struct DynamicHoneyBadger<C, NodeUid>
+pub struct DynamicHoneyBadger<C, NodeUid: Rand>
 where
     C: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
     NodeUid: Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug,
@@ -114,7 +115,7 @@ where
 impl<C, NodeUid> DistAlgorithm for DynamicHoneyBadger<C, NodeUid>
 where
     C: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
-    NodeUid: Eq + Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
+    NodeUid: Eq + Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Rand,
 {
     type NodeUid = NodeUid;
     type Input = Input<C, NodeUid>;
@@ -178,7 +179,7 @@ where
 impl<C, NodeUid> DynamicHoneyBadger<C, NodeUid>
 where
     C: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
-    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash,
+    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash + Rand,
 {
     /// Returns a new `DynamicHoneyBadgerBuilder` configured to use the node IDs and cryptographic
     /// keys specified by `netinfo`.
@@ -487,7 +488,7 @@ pub enum KeyGenMessage {
 
 /// A message sent to or received from another node's Honey Badger instance.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum Message<NodeUid> {
+pub enum Message<NodeUid: Rand> {
     /// A message belonging to the `HoneyBadger` algorithm started in the given epoch.
     HoneyBadger(u64, HbMessage<NodeUid>),
     /// A transaction to be committed, signed by a node.
@@ -496,7 +497,7 @@ pub enum Message<NodeUid> {
     SignedVote(SignedVote<NodeUid>),
 }
 
-impl<NodeUid> Message<NodeUid> {
+impl<NodeUid: Rand> Message<NodeUid> {
     pub fn epoch(&self) -> u64 {
         match *self {
             Message::HoneyBadger(epoch, _) => epoch,
@@ -508,11 +509,11 @@ impl<NodeUid> Message<NodeUid> {
 
 /// The queue of outgoing messages in a `HoneyBadger` instance.
 #[derive(Deref, DerefMut)]
-struct MessageQueue<NodeUid>(VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>);
+struct MessageQueue<NodeUid: Rand>(VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>);
 
 impl<NodeUid> MessageQueue<NodeUid>
 where
-    NodeUid: Eq + Hash + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r>,
+    NodeUid: Eq + Hash + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Rand,
 {
     /// Appends to the queue the messages from `hb`, wrapped with `epoch`.
     fn extend_with_epoch<Tx>(&mut self, epoch: u64, hb: &mut HoneyBadger<Tx, NodeUid>)

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -1,3 +1,4 @@
+use rand::Rand;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
@@ -45,7 +46,7 @@ pub struct HoneyBadgerBuilder<C, NodeUid> {
 impl<C, NodeUid> HoneyBadgerBuilder<C, NodeUid>
 where
     C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
-    NodeUid: Ord + Clone + Debug,
+    NodeUid: Ord + Clone + Debug + Rand,
 {
     /// Returns a new `HoneyBadgerBuilder` configured to use the node IDs and cryptographic keys
     /// specified by `netinfo`.
@@ -82,7 +83,7 @@ where
 }
 
 /// An instance of the Honey Badger Byzantine fault tolerant consensus algorithm.
-pub struct HoneyBadger<C, NodeUid> {
+pub struct HoneyBadger<C, NodeUid: Rand> {
     /// Shared network data.
     netinfo: Arc<NetworkInfo<NodeUid>>,
     /// The earliest epoch from which we have not yet received output.
@@ -113,7 +114,7 @@ pub struct HoneyBadger<C, NodeUid> {
 impl<C, NodeUid> DistAlgorithm for HoneyBadger<C, NodeUid>
 where
     C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
-    NodeUid: Ord + Clone + Debug,
+    NodeUid: Ord + Clone + Debug + Rand,
 {
     type NodeUid = NodeUid;
     type Input = C;
@@ -169,7 +170,7 @@ where
 impl<C, NodeUid> HoneyBadger<C, NodeUid>
 where
     C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
-    NodeUid: Ord + Clone + Debug,
+    NodeUid: Ord + Clone + Debug + Rand,
 {
     /// Returns a new `HoneyBadgerBuilder` configured to use the node IDs and cryptographic keys
     /// specified by `netinfo`.
@@ -629,8 +630,8 @@ impl<C, NodeUid: Ord> Batch<C, NodeUid> {
 }
 
 /// The content of a `HoneyBadger` message. It should be further annotated with an epoch.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum MessageContent<NodeUid> {
+#[derive(Clone, Debug, Deserialize, Rand, Serialize)]
+pub enum MessageContent<NodeUid: Rand> {
     /// A message belonging to the common subset algorithm in the given epoch.
     CommonSubset(common_subset::Message<NodeUid>),
     /// A decrypted share of the output of `proposer_id`.
@@ -640,7 +641,7 @@ pub enum MessageContent<NodeUid> {
     },
 }
 
-impl<NodeUid> MessageContent<NodeUid> {
+impl<NodeUid: Rand> MessageContent<NodeUid> {
     pub fn with_epoch(self, epoch: u64) -> Message<NodeUid> {
         Message {
             epoch,
@@ -650,13 +651,13 @@ impl<NodeUid> MessageContent<NodeUid> {
 }
 
 /// A message sent to or received from another node's Honey Badger instance.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Message<NodeUid> {
+#[derive(Clone, Debug, Deserialize, Rand, Serialize)]
+pub struct Message<NodeUid: Rand> {
     epoch: u64,
     content: MessageContent<NodeUid>,
 }
 
-impl<NodeUid> Message<NodeUid> {
+impl<NodeUid: Rand> Message<NodeUid> {
     pub fn epoch(&self) -> u64 {
         self.epoch
     }
@@ -664,9 +665,9 @@ impl<NodeUid> Message<NodeUid> {
 
 /// The queue of outgoing messages in a `HoneyBadger` instance.
 #[derive(Deref, DerefMut)]
-struct MessageQueue<NodeUid>(VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>);
+struct MessageQueue<NodeUid: Rand>(VecDeque<TargetedMessage<Message<NodeUid>, NodeUid>>);
 
-impl<NodeUid: Clone + Debug + Ord> MessageQueue<NodeUid> {
+impl<NodeUid: Clone + Debug + Ord + Rand> MessageQueue<NodeUid> {
     /// Appends to the queue the messages from `cs`, wrapped with `epoch`.
     fn extend_with_epoch(&mut self, epoch: u64, cs: &mut CommonSubset<NodeUid>) {
         let convert = |msg: TargetedMessage<common_subset::Message<NodeUid>, NodeUid>| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ extern crate pairing;
 #[cfg(feature = "serialization-protobuf")]
 extern crate protobuf;
 extern crate rand;
+#[macro_use]
+extern crate rand_derive;
 extern crate reed_solomon_erasure;
 extern crate ring;
 extern crate serde;

--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -2,6 +2,7 @@
 //!
 //! This works exactly like Dynamic Honey Badger, but it has a transaction queue built in.
 
+use rand::Rand;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -39,7 +40,7 @@ pub struct QueueingHoneyBadgerBuilder<Tx, NodeUid> {
 impl<Tx, NodeUid> QueueingHoneyBadgerBuilder<Tx, NodeUid>
 where
     Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Clone,
-    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash,
+    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash + Rand,
 {
     /// Returns a new `QueueingHoneyBadgerBuilder` configured to use the node IDs and cryptographic
     /// keys specified by `netinfo`.
@@ -109,7 +110,7 @@ where
 pub struct QueueingHoneyBadger<Tx, NodeUid>
 where
     Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
-    NodeUid: Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug,
+    NodeUid: Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug + Rand,
 {
     /// The target number of transactions to be included in each batch.
     batch_size: usize,
@@ -124,7 +125,7 @@ where
 impl<Tx, NodeUid> DistAlgorithm for QueueingHoneyBadger<Tx, NodeUid>
 where
     Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Clone,
-    NodeUid: Eq + Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
+    NodeUid: Eq + Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Rand,
 {
     type NodeUid = NodeUid;
     type Input = Input<Tx, NodeUid>;
@@ -180,7 +181,7 @@ where
 impl<Tx, NodeUid> QueueingHoneyBadger<Tx, NodeUid>
 where
     Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Clone,
-    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash,
+    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash + Rand,
 {
     /// Returns a new `QueueingHoneyBadgerBuilder` configured to use the node IDs and cryptographic
     /// keys specified by `netinfo`.

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -21,6 +21,8 @@ extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate rand_derive;
 
 mod network;
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -47,7 +47,7 @@ impl ProposeAdversary {
 }
 
 impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
-    fn pick_node(&self, nodes: &BTreeMap<NodeUid, TestNode<Broadcast<NodeUid>>>) -> NodeUid {
+    fn pick_node(&mut self, nodes: &BTreeMap<NodeUid, TestNode<Broadcast<NodeUid>>>) -> NodeUid {
         self.scheduler.pick_node(nodes)
     }
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -8,6 +8,8 @@ extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate rand_derive;
 
 mod network;
 
@@ -19,8 +21,11 @@ use rand::Rng;
 
 use hbbft::broadcast::{Broadcast, BroadcastMessage};
 use hbbft::crypto::SecretKeySet;
-use hbbft::messaging::{DistAlgorithm, NetworkInfo, TargetedMessage};
-use network::{Adversary, MessageScheduler, NodeUid, SilentAdversary, TestNetwork, TestNode};
+use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
+use network::{
+    Adversary, MessageScheduler, MessageWithSender, NodeUid, RandomAdversary, SilentAdversary,
+    TestNetwork, TestNode,
+};
 
 /// An adversary that inputs an alternate value.
 struct ProposeAdversary {
@@ -47,7 +52,7 @@ impl ProposeAdversary {
 }
 
 impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
-    fn pick_node(&mut self, nodes: &BTreeMap<NodeUid, TestNode<Broadcast<NodeUid>>>) -> NodeUid {
+    fn pick_node(&self, nodes: &BTreeMap<NodeUid, TestNode<Broadcast<NodeUid>>>) -> NodeUid {
         self.scheduler.pick_node(nodes)
     }
 
@@ -55,7 +60,7 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         // All messages are ignored.
     }
 
-    fn step(&mut self) -> Vec<(NodeUid, TargetedMessage<BroadcastMessage, NodeUid>)> {
+    fn step(&mut self) -> Vec<MessageWithSender<Broadcast<NodeUid>>> {
         if self.has_sent {
             return vec![];
         }
@@ -84,7 +89,9 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         ));
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
         bc.input(b"Fake news".to_vec()).expect("propose");
-        bc.message_iter().map(|msg| (id, msg)).collect()
+        bc.message_iter()
+            .map(|msg| MessageWithSender::new(id, msg))
+            .collect()
     }
 }
 
@@ -181,4 +188,16 @@ fn test_broadcast_first_delivery_adv_propose() {
         ProposeAdversary::new(MessageScheduler::First, good_nodes, adv_nodes)
     };
     test_broadcast_different_sizes(new_adversary, b"Foo");
+}
+
+#[test]
+fn test_broadcast_random_adversary() {
+    let new_adversary = |_, _| {
+        // Note: Set this to 0.8 to watch 30 gigs of RAM disappear.
+        RandomAdversary::new(0.2, 0.2, || TargetedMessage {
+            target: Target::All,
+            message: rand::random(),
+        })
+    };
+    test_broadcast_different_sizes(new_adversary, b"RandomFoo");
 }

--- a/tests/common_coin.rs
+++ b/tests/common_coin.rs
@@ -8,6 +8,8 @@ extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate rand_derive;
 
 mod network;
 

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -8,6 +8,8 @@ extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate rand_derive;
 
 mod network;
 

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -8,6 +8,8 @@ extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate rand_derive;
 
 mod network;
 

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -56,7 +56,7 @@ impl FaultyShareAdversary {
 }
 
 impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
-    fn pick_node(&self, nodes: &BTreeMap<NodeUid, TestNode<UsizeHoneyBadger>>) -> NodeUid {
+    fn pick_node(&mut self, nodes: &BTreeMap<NodeUid, TestNode<UsizeHoneyBadger>>) -> NodeUid {
         self.scheduler.pick_node(nodes)
     }
 

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -8,6 +8,8 @@ extern crate env_logger;
 extern crate pairing;
 extern crate rand;
 #[macro_use]
+extern crate rand_derive;
+#[macro_use]
 extern crate serde_derive;
 
 mod network;
@@ -23,7 +25,8 @@ use hbbft::messaging::{NetworkInfo, Target, TargetedMessage};
 use hbbft::transaction_queue::TransactionQueue;
 
 use network::{
-    Adversary, MessageScheduler, MessageWithSender, NodeUid, SilentAdversary, TestNetwork, TestNode,
+    Adversary, MessageScheduler, MessageWithSender, NodeUid, RandomAdversary, SilentAdversary,
+    TestNetwork, TestNode,
 };
 
 type UsizeHoneyBadger = HoneyBadger<Vec<usize>, NodeUid>;
@@ -56,7 +59,7 @@ impl FaultyShareAdversary {
 }
 
 impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
-    fn pick_node(&mut self, nodes: &BTreeMap<NodeUid, TestNode<UsizeHoneyBadger>>) -> NodeUid {
+    fn pick_node(&self, nodes: &BTreeMap<NodeUid, TestNode<UsizeHoneyBadger>>) -> NodeUid {
         self.scheduler.pick_node(nodes)
     }
 
@@ -100,7 +103,7 @@ impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
                         .expect("decryption share");
                     // Send the share to remote nodes.
                     for proposer_id in 0..self.num_good + self.num_adv {
-                        outgoing.push((
+                        outgoing.push(MessageWithSender::new(
                             NodeUid(sender_id),
                             Target::All.message(
                                 MessageContent::DecryptionShare {
@@ -234,6 +237,18 @@ fn test_honey_badger_first_delivery_silent() {
 fn test_honey_badger_faulty_share() {
     let new_adversary = |num_good: usize, num_adv: usize, adv_nodes| {
         FaultyShareAdversary::new(num_good, num_adv, adv_nodes, MessageScheduler::Random)
+    };
+    test_honey_badger_different_sizes(new_adversary, 8);
+}
+
+#[test]
+fn test_honey_badger_random_adversary() {
+    let new_adversary = |_, _, _| {
+        // A 10% injection chance is roughly ~13k extra messages added.
+        RandomAdversary::new(0.1, 0.1, || TargetedMessage {
+            target: Target::All,
+            message: rand::random(),
+        })
     };
     test_honey_badger_different_sizes(new_adversary, 8);
 }

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -68,6 +68,11 @@ impl<D: DistAlgorithm> TestNode<D> {
             .expect("handling message");
         self.outputs.extend(self.algo.output_iter());
     }
+
+    /// Checks whether the node has messages to process
+    fn is_idle(&self) -> bool {
+        self.queue.is_empty()
+    }
 }
 
 /// A strategy for picking the next good node to handle a message.
@@ -118,7 +123,7 @@ pub trait Adversary<D: DistAlgorithm> {
     ///
     /// Starvation is illegal, i.e. in every iteration a node that has pending incoming messages
     /// must be chosen.
-    fn pick_node(&self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid;
+    fn pick_node(&mut self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid;
 
     /// Called when a node controlled by the adversary receives a message
     fn push_message(&mut self, sender_id: D::NodeUid, msg: TargetedMessage<D::Message, D::NodeUid>);
@@ -140,7 +145,7 @@ impl SilentAdversary {
 }
 
 impl<D: DistAlgorithm> Adversary<D> for SilentAdversary {
-    fn pick_node(&self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid {
+    fn pick_node(&mut self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid {
         self.scheduler.pick_node(nodes)
     }
 
@@ -300,12 +305,18 @@ where
         // now one node is chosen to make progress. we let the adversary decide which node
         let id = self.adversary.pick_node(&self.nodes);
 
-        // TODO: ensure the adversary is honest and does pick a node that has actual messages to
-        //       process
-
         // the node handles the incoming message and creates new outgoing ones to be dispatched
         let msgs: Vec<_> = {
             let node = self.nodes.get_mut(&id).unwrap();
+
+            // ensure the adversary is playing fair by selecting a node that will result in actual
+            // progress being made. otherwise `TestNode::handle_message()` will panic on `expect()`
+            // with a much more cryptic error message
+            assert!(
+                !node.is_idle(),
+                "adversary illegally selected an idle node in pick_node()"
+            );
+
             node.handle_message();
             node.algo.message_iter().collect()
         };

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::{self, Debug};
-use std::hash::Hash;
 use std::mem;
 use std::sync::Arc;
 
@@ -352,10 +351,7 @@ impl<D: DistAlgorithm, F: Fn() -> TargetedMessage<D::Message, D::NodeUid>> Adver
 /// 2. Send arbitrary messages to any node originating from one of the nodes they control.
 ///
 /// See the `step` function for details on actual operation of the network.
-pub struct TestNetwork<A: Adversary<D>, D: DistAlgorithm>
-where
-    <D as DistAlgorithm>::NodeUid: Hash,
-{
+pub struct TestNetwork<A: Adversary<D>, D: DistAlgorithm> {
     pub nodes: BTreeMap<D::NodeUid, TestNode<D>>,
     pub observer: TestNode<D>,
     pub adv_nodes: BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>,

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::hash::Hash;
+use std::mem;
 use std::sync::Arc;
 
 use rand::{self, Rng};
@@ -9,7 +10,7 @@ use hbbft::crypto::{PublicKeySet, SecretKeySet};
 use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
 
 /// A node identifier. In the tests, nodes are simply numbered.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Clone, Copy, Serialize, Deserialize, Rand)]
 pub struct NodeUid(pub usize);
 
 /// A "node" running an instance of the algorithm `D`.
@@ -110,26 +111,61 @@ impl MessageScheduler {
     }
 }
 
-pub type MessageWithSender<D> = (
-    <D as DistAlgorithm>::NodeUid,
-    TargetedMessage<<D as DistAlgorithm>::Message, <D as DistAlgorithm>::NodeUid>,
-);
+/// A message combined with a sender.
+pub struct MessageWithSender<D: DistAlgorithm> {
+    /// The sender of the message.
+    pub sender: <D as DistAlgorithm>::NodeUid,
+    /// The targeted message (recipient and message body).
+    pub tm: TargetedMessage<<D as DistAlgorithm>::Message, <D as DistAlgorithm>::NodeUid>,
+}
+
+// The Debug implementation cannot be derived automatically, possibly due to a compiler bug. For
+// this reason, it is implemented manually here.
+impl<D: DistAlgorithm> fmt::Debug for MessageWithSender<D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "MessageWithSender {{ sender: {:?}, tm: {:?} }}",
+            self.sender, self.tm.target
+        )
+    }
+}
+
+impl<D: DistAlgorithm> MessageWithSender<D> {
+    /// Creates a new message with a sender.
+    pub fn new(
+        sender: D::NodeUid,
+        tm: TargetedMessage<D::Message, D::NodeUid>,
+    ) -> MessageWithSender<D> {
+        MessageWithSender { sender, tm }
+    }
+}
 
 /// An adversary that can control a set of nodes and pick the next good node to receive a message.
 ///
 /// See `TestNetwork::step()` for a more detailed description of its capabilities.
 pub trait Adversary<D: DistAlgorithm> {
-    /// Chooses a node to be the next one to handle a message
+    /// Chooses a node to be the next one to handle a message.
     ///
     /// Starvation is illegal, i.e. in every iteration a node that has pending incoming messages
     /// must be chosen.
-    fn pick_node(&mut self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid;
+    fn pick_node(&self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid;
 
-    /// Called when a node controlled by the adversary receives a message
+    /// Called when a node controlled by the adversary receives a message.
     fn push_message(&mut self, sender_id: D::NodeUid, msg: TargetedMessage<D::Message, D::NodeUid>);
 
-    /// Produces a list of messages to be sent from the adversary's nodes
+    /// Produces a list of messages to be sent from the adversary's nodes.
     fn step(&mut self) -> Vec<MessageWithSender<D>>;
+
+    /// Initialize an adversary. This function's primary purpose is to inform the adversary over
+    /// some aspects of the network, such as which nodes they control.
+    fn init(
+        &mut self,
+        _all_nodes: &BTreeMap<D::NodeUid, TestNode<D>>,
+        _adv_nodes: &BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>,
+    ) {
+        // default: does nothing
+    }
 }
 
 /// An adversary whose nodes never send any messages.
@@ -145,7 +181,7 @@ impl SilentAdversary {
 }
 
 impl<D: DistAlgorithm> Adversary<D> for SilentAdversary {
-    fn pick_node(&mut self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid {
+    fn pick_node(&self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid {
         self.scheduler.pick_node(nodes)
     }
 
@@ -158,19 +194,164 @@ impl<D: DistAlgorithm> Adversary<D> for SilentAdversary {
     }
 }
 
+/// Return true with a certain `probability` ([0 .. 1.0]).
+fn randomly(probability: f32) -> bool {
+    assert!(probability <= 1.0);
+    assert!(probability >= 0.0);
+
+    let mut rng = rand::thread_rng();
+    rng.gen_range(0.0, 1.0) <= probability
+}
+
+#[test]
+fn test_randomly() {
+    assert!(randomly(1.0));
+    assert!(!randomly(0.0));
+}
+
+/// An adversary that performs naive replay attacks.
+///
+/// The adversary will randomly take a message that is sent to one of its nodes and re-send it to
+/// a different node. Additionally, it will inject unrelated messages at random.
+#[allow(unused)] // not used in all tests
+pub struct RandomAdversary<D: DistAlgorithm, F> {
+    /// The underlying scheduler used
+    scheduler: MessageScheduler,
+
+    /// Node ids seen by the adversary.
+    known_node_ids: Vec<D::NodeUid>,
+    /// Node ids under control of adversary
+    known_adversarial_ids: Vec<D::NodeUid>,
+
+    /// Internal queue for messages to be returned on the next `Adversary::step()` call
+    outgoing: Vec<MessageWithSender<D>>,
+    /// Generates random messages to be injected
+    generator: F,
+
+    /// Probability of a message replay
+    p_replay: f32,
+    /// Probability of a message injection
+    p_inject: f32,
+}
+
+impl<D: DistAlgorithm, F> RandomAdversary<D, F> {
+    /// Creates a new random adversary instance.
+    #[allow(unused)]
+    pub fn new(p_replay: f32, p_inject: f32, generator: F) -> RandomAdversary<D, F> {
+        assert!(
+            p_inject < 0.95,
+            "injections are repeated, p_inject must be smaller than 0.95"
+        );
+
+        RandomAdversary {
+            // The random adversary, true to its name, always schedules randomly.
+            scheduler: MessageScheduler::Random,
+            known_node_ids: Vec::new(),
+            known_adversarial_ids: Vec::new(),
+            outgoing: Vec::new(),
+            generator,
+            p_replay,
+            p_inject,
+        }
+    }
+}
+
+impl<D: DistAlgorithm, F: Fn() -> TargetedMessage<D::Message, D::NodeUid>> Adversary<D>
+    for RandomAdversary<D, F>
+{
+    fn init(
+        &mut self,
+        all_nodes: &BTreeMap<D::NodeUid, TestNode<D>>,
+        nodes: &BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>,
+    ) {
+        self.known_adversarial_ids = nodes.keys().cloned().collect();
+        self.known_node_ids = all_nodes.keys().cloned().collect();
+    }
+
+    fn pick_node(&self, nodes: &BTreeMap<D::NodeUid, TestNode<D>>) -> D::NodeUid {
+        // Just let the scheduler pick a node.
+        self.scheduler.pick_node(nodes)
+    }
+
+    fn push_message(&mut self, _: D::NodeUid, msg: TargetedMessage<D::Message, D::NodeUid>) {
+        // If we have not discovered the network topology yet, abort.
+        if self.known_node_ids.is_empty() {
+            return;
+        }
+
+        // only replay a message in some cases
+        if !randomly(self.p_replay) {
+            return;
+        }
+
+        let TargetedMessage { message, target } = msg;
+
+        match target {
+            Target::All => {
+                // Ideally, we would want to handle broadcast messages as well; however the
+                // adversary API is quite cumbersome at the moment in regards to access to the
+                // network topology. To re-send a broadcast message from one of the attacker
+                // controlled nodes, we would have to get a list of attacker controlled nodes
+                // here and use a random one as the origin/sender, this is not done here.
+                return;
+            }
+            Target::Node(our_node_id) => {
+                // Choose a new target to send the message to. The unwrap never fails, because we
+                // ensured that `known_node_ids` is non-empty earlier.
+                let mut rng = rand::thread_rng();
+                let new_target_node = rng.choose(&self.known_node_ids).unwrap().clone();
+
+                // TODO: We could randomly broadcast it instead, if we had access to topology
+                //       information.
+                self.outgoing.push(MessageWithSender::new(
+                    our_node_id,
+                    TargetedMessage {
+                        target: Target::Node(new_target_node),
+                        message,
+                    },
+                ));
+            }
+        }
+    }
+
+    fn step(&mut self) -> Vec<MessageWithSender<D>> {
+        // Clear messages.
+        let mut tmp = Vec::new();
+        mem::swap(&mut tmp, &mut self.outgoing);
+
+        // Possibly inject more messages:
+        while randomly(self.p_inject) {
+            let mut rng = rand::thread_rng();
+
+            // Pick a random adversarial node and create a message using the generator.
+            if let Some(sender) = rng.choose(&self.known_adversarial_ids[..]) {
+                let tm = (self.generator)();
+
+                // Add to outgoing queue.
+                tmp.push(MessageWithSender::new(sender.clone(), tm));
+            }
+        }
+
+        if !tmp.is_empty() {
+            println!("Injecting random messages: {:?}", tmp);
+        }
+        tmp
+    }
+}
+
 /// A collection of `TestNode`s representing a network.
 ///
-/// Each TestNetwork type is tied to a specific adversary and a distributed algorithm. It consists
+/// Each `TestNetwork` type is tied to a specific adversary and a distributed algorithm. It consists
 /// of a set of nodes, some of which are controlled by the adversary and some of which may be
 /// observer nodes, as well as a set of threshold-cryptography public keys.
 ///
 /// In addition to being able to participate correctly in the network using his nodes, the
 /// adversary can:
 ///
-/// 1. decide which node is the next one to make progress.
-/// 2. send arbitrary messages to any node originating from one of the nodes they control
+/// 1. Decide which node is the next one to make progress,
+/// 2. Send arbitrary messages to any node originating from one of the nodes they control.
 ///
-/// See the `step` function for details on actual operation of the network
+/// See the `step` function for details on actual operation of the network.
 pub struct TestNetwork<A: Adversary<D>, D: DistAlgorithm>
 where
     <D as DistAlgorithm>::NodeUid: Hash,
@@ -230,6 +411,7 @@ where
             .map(NodeUid)
             .map(new_adv_node_by_id)
             .collect();
+
         let mut network = TestNetwork {
             nodes: (0..good_num).map(NodeUid).map(new_node_by_id).collect(),
             observer: new_node_by_id(NodeUid(good_num + adv_num)).1,
@@ -237,9 +419,13 @@ where
             pk_set: pk_set.clone(),
             adv_nodes,
         };
+
+        // Inform the adversary about their nodes.
+        network.adversary.init(&network.nodes, &network.adv_nodes);
+
         let msgs = network.adversary.step();
-        for (sender_id, msg) in msgs {
-            network.dispatch_messages(sender_id, vec![msg]);
+        for MessageWithSender { sender, tm } in msgs {
+            network.dispatch_messages(sender, vec![tm]);
         }
         let mut initial_msgs: Vec<(D::NodeUid, Vec<_>)> = Vec::new();
         for (id, node) in &mut network.nodes {
@@ -290,28 +476,28 @@ where
 
     /// Performs one iteration of the network, consisting of the following steps:
     ///
-    /// 1. Give the adversary a chance to send messages of his choosing through `Adversary::step()`
+    /// 1. Give the adversary a chance to send messages of his choosing through `Adversary::step()`,
     /// 2. Let the adversary pick a node that receives its next message through
-    ///    `Adversary::pick_node()`
+    ///    `Adversary::pick_node()`.
     ///
-    /// Returns the node id of the node that made progress
+    /// Returns the node ID of the node that made progress.
     pub fn step(&mut self) -> NodeUid {
-        // we let the adversary send out messages to any number of nodes
+        // We let the adversary send out messages to any number of nodes.
         let msgs = self.adversary.step();
-        for (sender_id, msg) in msgs {
-            self.dispatch_messages(sender_id, Some(msg));
+        for MessageWithSender { sender, tm } in msgs {
+            self.dispatch_messages(sender, Some(tm));
         }
 
-        // now one node is chosen to make progress. we let the adversary decide which node
+        // Now one node is chosen to make progress, we let the adversary decide which.
         let id = self.adversary.pick_node(&self.nodes);
 
-        // the node handles the incoming message and creates new outgoing ones to be dispatched
+        // The node handles the incoming message and creates new outgoing ones to be dispatched.
         let msgs: Vec<_> = {
             let node = self.nodes.get_mut(&id).unwrap();
 
-            // ensure the adversary is playing fair by selecting a node that will result in actual
-            // progress being made. otherwise `TestNode::handle_message()` will panic on `expect()`
-            // with a much more cryptic error message
+            // Ensure the adversary is playing fair by selecting a node that will result in actual
+            // progress being made, otherwise `TestNode::handle_message()` will panic on `expect()`
+            // with a much more cryptic error message.
             assert!(
                 !node.is_idle(),
                 "adversary illegally selected an idle node in pick_node()"

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -8,6 +8,8 @@ extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate rand_derive;
 
 mod network;
 


### PR DESCRIPTION
This branch implements a `RandomAdversary`, which should partially handle #84. Its approach is a bit naive, leveraging two vectors of attack:

1. Replay attacks. These can be implemented automatically, since they require no knowledge of the underlying protocol. With a random probability, the adversary will duplicate a message sent from one node to one of the nodes under its control and broadcast it to all nodes (it could easily be made to select a random correct node instead, but the API makes this a little too cumbersome at the moment. See the comments below for details).
2. Random message generation. At every step of the protocol, the `RandomAdversary` can inject one or more random messages into the network, e.g. setting `p_inject` to `0.10` (10%) will cause one-in-ten steps to create and inject a random message into the network.

## Code structure

The diff is a bit hard to read due to a lot of single-word changes throughout the codebase, the following explanations might help navigate by inverting the process:

Central structure is the `RandomAdversary` implementation, which simply implements the `Adversary` trait. It is instantiated in `test_broadcast_random_adversary` and `test_honey_badger_random_adversary`, which are fairly short.

The `Adversary` trait had to be extended by an `init` function, even though it already abuses (?) `pick_node` to find out about the list of nodes present in the network (for this, `pick_node` had to become a self-mutating method).

In general (this might be enough for another issue), the `Adversary` model present in the tests could use a bit of improvement - the current process of passing in closures beforehand is not a good fit, either the init function could be passed the network topology (i.e. which are the failing nodes and which are the correct ones) as a parameter, or it should be made available in every function to the adversary, should they want to check out what other nodes are available.

One issue is the way that random data is generated: Ideally, the random generation would be decoupled from the "production" code, however, this would result in an even larger extra code blob. To save a bit on implementation time for what is at this point a bit of a proof-of-concept, the `rand_derive` crate has been used to perform 80% of the busy work of generating random messages.

This has two drawbacks: For one, it touches deeply on almost every module, as suddenly `NodeId`s need to be able to generated randomly, causing yet another trait requirement to be added to various impls and types. Also, the `rand::Rand` trait itself is deprecated in `rand` 0.5 and onward, however neither for `Rand` nor `derive(Rand)` has a decent substitue been implemented or suggested so far. I would suggest sticking with 0.4 anyway, as pairing requires it as well.

If one follows the road draw by this PR alone, additional random generation might have to be added, to enable generation of context-based random values (e.g. injected messages with the correct epoch).

### Extras

To get a little more familiar with the code, I also wrote a minimal broadcast protocol implementation for the module docs, it is fairly concise and does simulate the complete network. Occasional docstrings have been added as well.

I smuggled in a small refactoring in `MessageWithSender`; instead of a tuple type alias it is now a proper `struct`. This made it a lot more readable in output and code. Old code can/has been refactored by using `MessageWithSender::new`, which takes are arguments in the same order.

A small utility function in the form of `randomly` has been added.

`SecretKey`s can now be generated randomly. This was possible before, but done in the `new` function, now it uses the `Rand` trait. I am not a fan of both approaches, I would like to see a proper key generation function in the underlying cryptographic library (`pairing`); even if all it does is spit out a random number, the caller can be sure that it is up to the library implementer to take care of rejecting bad/trivial/broken keys. Otherwise, it is a bit unnverving to use the library without a deep understanding of the underlying cipher system, which reduces the usefulness of said library quite a bit.

## Other Issues/Missing

* Testing: The adversary itself is not well tested, testing random tests is a bit weird. I am leaving this up to "further work" for now.
* Reproducability and test cases: There might be better options, see #84 for details.
* The current approach does not do "correct" epochs for Honey Badger and others, mainly because the `rand::random()` function does not allow for parameters to be passed and bespoke functions have not been written.
