### PR TITLE
Separate queue from Honey Badger.

### DIFF
--- a/src/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger.rs
@@ -56,7 +56,7 @@ use clear_on_drop::ClearOnDrop;
 use serde::{Deserialize, Serialize};
 
 use crypto::{PublicKey, PublicKeySet, SecretKey, Signature};
-use fault_log::FaultLog;
+use fault_log::{FaultKind, FaultLog};
 use honey_badger::{self, HoneyBadger, Message as HbMessage};
 use messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
 use sync_key_gen::{Accept, Propose, ProposeOutcome, SyncKeyGen};
@@ -349,6 +349,8 @@ where
                     }
                     if !self.verify_signature(&s_id, &sig, &node_tx)? {
                         info!("Invalid signature from {:?} for: {:?}.", s_id, node_tx);
+                        let fault_kind = FaultKind::InvalidNodeTransactionSignature;
+                        fault_log.append(s_id.clone(), fault_kind);
                         continue;
                     }
                     use self::NodeTransaction::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,4 +134,6 @@ pub mod messaging;
 pub mod proto;
 #[cfg(feature = "serialization-protobuf")]
 pub mod proto_io;
+pub mod queueing_honey_badger;
 pub mod sync_key_gen;
+pub mod transaction_queue;

--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -12,10 +12,9 @@ use serde::{Deserialize, Serialize};
 use dynamic_honey_badger::{self, Batch as DhbBatch, DynamicHoneyBadger, Message};
 use fault_log::FaultLog;
 use messaging::{DistAlgorithm, NetworkInfo, TargetedMessage};
+use transaction_queue::TransactionQueue;
 
 pub use dynamic_honey_badger::{Change, ChangeState, Input};
-
-use transaction_queue::TransactionQueue;
 
 error_chain!{
     links {

--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -1,0 +1,200 @@
+//! # Queueing Honey Badger
+//!
+//! This works exactly like Dynamic Honey Badger, but it has a transaction queue built in.
+
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+use dynamic_honey_badger::{self, Batch as DhbBatch, DynamicHoneyBadger, Message};
+use fault_log::FaultLog;
+use messaging::{DistAlgorithm, NetworkInfo, TargetedMessage};
+
+pub use dynamic_honey_badger::{Change, ChangeState, Input};
+
+use transaction_queue::TransactionQueue;
+
+error_chain!{
+    links {
+        DynamicHoneyBadger(dynamic_honey_badger::Error, dynamic_honey_badger::ErrorKind);
+    }
+}
+
+/// A Queueing Honey Badger builder, to configure the parameters and create new instances of
+/// `QueueingHoneyBadger`.
+pub struct QueueingHoneyBadgerBuilder<Tx, NodeUid> {
+    /// Shared network data.
+    netinfo: NetworkInfo<NodeUid>,
+    /// The target number of transactions to be included in each batch.
+    batch_size: usize,
+    /// The epoch at which to join the network.
+    start_epoch: u64,
+    /// The maximum number of future epochs for which we handle messages simultaneously.
+    max_future_epochs: usize,
+    _phantom: PhantomData<Tx>,
+}
+
+impl<Tx, NodeUid> QueueingHoneyBadgerBuilder<Tx, NodeUid>
+where
+    Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Clone,
+    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash,
+{
+    /// Returns a new `QueueingHoneyBadgerBuilder` configured to use the node IDs and cryptographic
+    /// keys specified by `netinfo`.
+    pub fn new(netinfo: NetworkInfo<NodeUid>) -> Self {
+        // TODO: Use the defaults from `HoneyBadgerBuilder`.
+        QueueingHoneyBadgerBuilder {
+            netinfo,
+            batch_size: 100,
+            start_epoch: 0,
+            max_future_epochs: 3,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Sets the target number of transactions per batch.
+    pub fn batch_size(&mut self, batch_size: usize) -> &mut Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Sets the maximum number of future epochs for which we handle messages simultaneously.
+    pub fn max_future_epochs(&mut self, max_future_epochs: usize) -> &mut Self {
+        self.max_future_epochs = max_future_epochs;
+        self
+    }
+
+    /// Sets the epoch at which to join the network as an observer. This requires the node to
+    /// receive all broadcast messages for `start_epoch` and later.
+    pub fn start_epoch(&mut self, start_epoch: u64) -> &mut Self {
+        self.start_epoch = start_epoch;
+        self
+    }
+
+    /// Creates a new Queueing Honey Badger instance with an empty buffer.
+    pub fn build(&self) -> QueueingHoneyBadger<Tx, NodeUid>
+    where
+        Tx: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
+    {
+        self.build_with_transactions(None)
+            .expect("building without transactions cannot fail")
+    }
+
+    /// Returns a new Queueing Honey Badger instance that starts with the given transactions in its
+    /// buffer.
+    pub fn build_with_transactions<TI>(&self, txs: TI) -> Result<QueueingHoneyBadger<Tx, NodeUid>>
+    where
+        TI: IntoIterator<Item = Tx>,
+        Tx: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
+    {
+        let dyn_hb = DynamicHoneyBadger::builder(self.netinfo.clone())
+            .max_future_epochs(self.max_future_epochs)
+            .build();
+        let queue = TransactionQueue(txs.into_iter().collect());
+        let mut qhb = QueueingHoneyBadger {
+            dyn_hb,
+            queue,
+            batch_size: self.batch_size,
+            output: VecDeque::new(),
+        };
+        let _ = qhb.propose()?; // Fault log is empty: no contact with other nodes yet.
+        Ok(qhb)
+    }
+}
+
+/// A Honey Badger instance that can handle adding and removing nodes and manages a transaction
+/// queue.
+pub struct QueueingHoneyBadger<Tx, NodeUid>
+where
+    Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
+    NodeUid: Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug,
+{
+    /// The target number of transactions to be included in each batch.
+    batch_size: usize,
+    /// The internal `DynamicHoneyBadger` instance.
+    dyn_hb: DynamicHoneyBadger<Vec<Tx>, NodeUid>,
+    /// The queue of pending transactions that haven't been output in a batch yet.
+    queue: TransactionQueue<Tx>,
+    /// The outputs from completed epochs.
+    output: VecDeque<Batch<Tx, NodeUid>>,
+}
+
+impl<Tx, NodeUid> DistAlgorithm for QueueingHoneyBadger<Tx, NodeUid>
+where
+    Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Clone,
+    NodeUid: Eq + Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
+{
+    type NodeUid = NodeUid;
+    type Input = Input<Tx, NodeUid>;
+    type Output = Batch<Tx, NodeUid>;
+    type Message = Message<NodeUid>;
+    type Error = Error;
+
+    fn input(&mut self, input: Self::Input) -> Result<FaultLog<NodeUid>> {
+        // User transactions are forwarded to `HoneyBadger` right away. Internal messages are
+        // in addition signed and broadcast.
+        match input {
+            Input::User(tx) => {
+                self.queue.0.push_back(tx);
+                Ok(FaultLog::new())
+            }
+            Input::Change(change) => Ok(self.dyn_hb.input(Input::Change(change))?),
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        sender_id: &NodeUid,
+        message: Self::Message,
+    ) -> Result<FaultLog<NodeUid>> {
+        let mut fault_log = self.dyn_hb.handle_message(sender_id, message)?;
+        while let Some(batch) = self.dyn_hb.next_output() {
+            self.queue.remove_all(batch.iter());
+            self.output.push_back(batch);
+        }
+        if !self.dyn_hb.has_input() {
+            self.propose()?.merge_into(&mut fault_log);
+        }
+        Ok(fault_log)
+    }
+
+    fn next_message(&mut self) -> Option<TargetedMessage<Self::Message, NodeUid>> {
+        self.dyn_hb.next_message()
+    }
+
+    fn next_output(&mut self) -> Option<Self::Output> {
+        self.output.pop_front()
+    }
+
+    fn terminated(&self) -> bool {
+        false
+    }
+
+    fn our_id(&self) -> &NodeUid {
+        self.dyn_hb.our_id()
+    }
+}
+
+impl<Tx, NodeUid> QueueingHoneyBadger<Tx, NodeUid>
+where
+    Tx: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash + Clone,
+    NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash,
+{
+    /// Returns a new `QueueingHoneyBadgerBuilder` configured to use the node IDs and cryptographic
+    /// keys specified by `netinfo`.
+    pub fn builder(netinfo: NetworkInfo<NodeUid>) -> QueueingHoneyBadgerBuilder<Tx, NodeUid> {
+        QueueingHoneyBadgerBuilder::new(netinfo)
+    }
+
+    /// Initiates the next epoch by proposing a batch from the queue.
+    fn propose(&mut self) -> Result<FaultLog<NodeUid>> {
+        let amount = self.batch_size / self.dyn_hb.netinfo().num_nodes();
+        let proposal = self.queue.choose(amount, self.batch_size);
+        Ok(self.dyn_hb.input(Input::User(proposal))?)
+    }
+}
+
+pub type Batch<Tx, NodeUid> = DhbBatch<Vec<Tx>, NodeUid>;

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -1,0 +1,34 @@
+use std::cmp;
+use std::collections::{HashSet, VecDeque};
+use std::hash::Hash;
+
+use rand;
+
+/// A wrapper providing a few convenience methods for a queue of pending transactions.
+#[derive(Debug)]
+pub struct TransactionQueue<Tx>(pub VecDeque<Tx>);
+
+impl<Tx: Clone> TransactionQueue<Tx> {
+    /// Removes the given transactions from the queue.
+    pub fn remove_all<'a, I>(&mut self, txs: I)
+    where
+        I: IntoIterator<Item = &'a Tx>,
+        Tx: Eq + Hash + 'a,
+    {
+        let tx_set: HashSet<_> = txs.into_iter().collect();
+        self.0.retain(|tx| !tx_set.contains(tx));
+    }
+
+    /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
+    /// No transactions are removed from the queue.
+    // TODO: Return references, once the `HoneyBadger` API accepts them. Remove `Clone` bound.
+    pub fn choose(&self, amount: usize, batch_size: usize) -> Vec<Tx> {
+        let mut rng = rand::thread_rng();
+        let limit = cmp::min(batch_size, self.0.len());
+        let sample = match rand::seq::sample_iter(&mut rng, self.0.iter().take(limit), amount) {
+            Ok(choice) => choice,
+            Err(choice) => choice, // Fewer than `amount` were available, which is fine.
+        };
+        sample.into_iter().cloned().collect()
+    }
+}

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -42,6 +42,12 @@ impl<D: DistAlgorithm> TestNode<D> {
         self.outputs.extend(self.algo.output_iter());
     }
 
+    /// Returns the internal algorithm's instance.
+    #[allow(unused)] // Not used in all tests.
+    pub fn instance(&self) -> &D {
+        &self.algo
+    }
+
     /// Creates a new test node with the given broadcast instance.
     fn new(mut algo: D) -> TestNode<D> {
         let outputs = algo.output_iter().collect();

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -1,4 +1,4 @@
-//! Network tests for Dynamic Honey Badger.
+//! Network tests for Queueing Honey Badger.
 
 extern crate hbbft;
 #[macro_use]
@@ -18,34 +18,31 @@ use std::rc::Rc;
 
 use rand::Rng;
 
-use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input};
 use hbbft::messaging::NetworkInfo;
-use hbbft::transaction_queue::TransactionQueue;
+use hbbft::queueing_honey_badger::{Change, ChangeState, Input, QueueingHoneyBadger};
 
 use network::{Adversary, MessageScheduler, NodeUid, SilentAdversary, TestNetwork, TestNode};
 
-type UsizeDhb = DynamicHoneyBadger<Vec<usize>, NodeUid>;
-
 /// Proposes `num_txs` values and expects nodes to output and order them.
-fn test_dynamic_honey_badger<A>(mut network: TestNetwork<A, UsizeDhb>, num_txs: usize)
-where
-    A: Adversary<UsizeDhb>,
+fn test_queueing_honey_badger<A>(
+    mut network: TestNetwork<A, QueueingHoneyBadger<usize, NodeUid>>,
+    num_txs: usize,
+) where
+    A: Adversary<QueueingHoneyBadger<usize, NodeUid>>,
 {
-    let new_queue = |id: &NodeUid| (*id, TransactionQueue((0..num_txs).collect()));
-    let mut queues: BTreeMap<_, _> = network.nodes.keys().map(new_queue).collect();
-    for (id, queue) in &queues {
-        network.input(*id, Input::User(queue.choose(3, 10)));
+    // The second half of the transactions will be input only after a node has been removed.
+    network.input_all(Input::Change(Change::Remove(NodeUid(0))));
+    for tx in 0..(num_txs / 2) {
+        network.input_all(Input::User(tx));
     }
 
-    network.input_all(Input::Change(Change::Remove(NodeUid(0))));
-
-    fn has_remove(node: &TestNode<UsizeDhb>) -> bool {
+    fn has_remove(node: &TestNode<QueueingHoneyBadger<usize, NodeUid>>) -> bool {
         node.outputs()
             .iter()
             .any(|batch| batch.change == ChangeState::Complete(Change::Remove(NodeUid(0))))
     }
 
-    fn has_add(node: &TestNode<UsizeDhb>) -> bool {
+    fn has_add(node: &TestNode<QueueingHoneyBadger<usize, NodeUid>>) -> bool {
         node.outputs().iter().any(|batch| match batch.change {
             ChangeState::Complete(Change::Add(ref id, _)) => *id == NodeUid(0),
             _ => false,
@@ -54,7 +51,7 @@ where
 
     // Returns `true` if the node has not output all transactions yet.
     // If it has, and has advanced another epoch, it clears all messages for later epochs.
-    let node_busy = |node: &mut TestNode<UsizeDhb>| {
+    let node_busy = |node: &mut TestNode<QueueingHoneyBadger<usize, NodeUid>>| {
         if !has_remove(node) || !has_add(node) {
             return true;
         }
@@ -79,15 +76,11 @@ where
     let mut input_add = false;
     // Handle messages in random order until all nodes have output all transactions.
     while network.nodes.values_mut().any(node_busy) {
-        let id = network.step();
-        if !network.nodes[&id].instance().has_input() {
-            queues
-                .get_mut(&id)
-                .unwrap()
-                .remove_all(network.nodes[&id].outputs().iter().flat_map(Batch::iter));
-            network.input(id, Input::User(queues[&id].choose(3, 10)));
-        }
+        network.step();
         if !input_add && network.nodes.values().all(has_remove) {
+            for tx in (num_txs / 2)..num_txs {
+                network.input_all(Input::User(tx));
+            }
             let pk = network.pk_set.public_key_share(0);
             network.input_all(Input::Change(Change::Add(NodeUid(0), pk)));
             info!("Input!");
@@ -100,9 +93,9 @@ where
 /// Verifies that all instances output the same sequence of batches. We already know that all of
 /// them have output all transactions and events, but some may have advanced a few empty batches
 /// more than others, so we ignore those.
-fn verify_output_sequence<A>(network: &TestNetwork<A, UsizeDhb>)
+fn verify_output_sequence<A>(network: &TestNetwork<A, QueueingHoneyBadger<usize, NodeUid>>)
 where
-    A: Adversary<UsizeDhb>,
+    A: Adversary<QueueingHoneyBadger<usize, NodeUid>>,
 {
     let expected = network.nodes[&NodeUid(0)].outputs().to_vec();
     assert!(!expected.is_empty());
@@ -114,13 +107,15 @@ where
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-fn new_dynamic_hb(netinfo: Rc<NetworkInfo<NodeUid>>) -> UsizeDhb {
-    DynamicHoneyBadger::builder((*netinfo).clone()).build()
+fn new_queueing_hb(netinfo: Rc<NetworkInfo<NodeUid>>) -> QueueingHoneyBadger<usize, NodeUid> {
+    QueueingHoneyBadger::builder((*netinfo).clone())
+        .batch_size(12)
+        .build()
 }
 
-fn test_dynamic_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
+fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
 where
-    A: Adversary<UsizeDhb>,
+    A: Adversary<QueueingHoneyBadger<usize, NodeUid>>,
     F: Fn(usize, usize, BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>) -> A,
 {
     // This returns an error in all but the first test.
@@ -137,19 +132,19 @@ where
             num_good_nodes, num_adv_nodes
         );
         let adversary = |adv_nodes| new_adversary(num_good_nodes, num_adv_nodes, adv_nodes);
-        let network = TestNetwork::new(num_good_nodes, num_adv_nodes, adversary, new_dynamic_hb);
-        test_dynamic_honey_badger(network, num_txs);
+        let network = TestNetwork::new(num_good_nodes, num_adv_nodes, adversary, new_queueing_hb);
+        test_queueing_honey_badger(network, num_txs);
     }
 }
 
 #[test]
-fn test_dynamic_honey_badger_random_delivery_silent() {
+fn test_queueing_honey_badger_random_delivery_silent() {
     let new_adversary = |_: usize, _: usize, _| SilentAdversary::new(MessageScheduler::Random);
-    test_dynamic_honey_badger_different_sizes(new_adversary, 10);
+    test_queueing_honey_badger_different_sizes(new_adversary, 10);
 }
 
 #[test]
-fn test_dynamic_honey_badger_first_delivery_silent() {
+fn test_queueing_honey_badger_first_delivery_silent() {
     let new_adversary = |_: usize, _: usize, _| SilentAdversary::new(MessageScheduler::First);
-    test_dynamic_honey_badger_different_sizes(new_adversary, 10);
+    test_queueing_honey_badger_different_sizes(new_adversary, 10);
 }

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -1,9 +1,9 @@
 //! Network tests for Queueing Honey Badger.
 
+extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
-extern crate env_logger;
 extern crate pairing;
 extern crate rand;
 #[macro_use]
@@ -16,10 +16,9 @@ use std::collections::BTreeMap;
 use std::iter::once;
 use std::rc::Rc;
 
-use rand::Rng;
-
 use hbbft::messaging::NetworkInfo;
 use hbbft::queueing_honey_badger::{Change, ChangeState, Input, QueueingHoneyBadger};
+use rand::Rng;
 
 use network::{Adversary, MessageScheduler, NodeUid, SilentAdversary, TestNetwork, TestNode};
 


### PR DESCRIPTION
This makes Honey Badger a bit more complicated but a lot more flexible:
It is now unaware of transactions and basically just runs one Subset
instance per epoch.

That way, users can use any kind of external queue, control throttling
and prioritization.