### PR TITLE
Make `*HoneyBadger` types thread safe.

### DIFF
--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -39,7 +39,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::fmt::Debug;
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::{io, iter, process, thread, time};
 
 use hbbft::broadcast::{Broadcast, BroadcastMessage};
@@ -135,7 +135,7 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
             // node index is 0.
             let broadcast_handle = scope.spawn(move || {
                 let mut broadcast =
-                    Broadcast::new(Rc::new(netinfo), 0).expect("failed to instantiate broadcast");
+                    Broadcast::new(Arc::new(netinfo), 0).expect("failed to instantiate broadcast");
 
                 if let Some(v) = value {
                     broadcast.input(v.clone().into()).expect("propose value");

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -68,7 +68,7 @@ pub mod bin_values;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::mem::replace;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use itertools::Itertools;
 
@@ -139,7 +139,7 @@ enum CoinSchedule {
 /// Binary Agreement instance
 pub struct Agreement<NodeUid> {
     /// Shared network information.
-    netinfo: Rc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<NodeUid>>,
     /// Session ID, e.g, the Honey Badger algorithm epoch.
     session_id: u64,
     /// The ID of the proposer of the value for this agreement instance.
@@ -248,7 +248,7 @@ impl<NodeUid: Clone + Debug + Ord> DistAlgorithm for Agreement<NodeUid> {
 
 impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
     pub fn new(
-        netinfo: Rc<NetworkInfo<NodeUid>>,
+        netinfo: Arc<NetworkInfo<NodeUid>>,
         session_id: u64,
         proposer_id: NodeUid,
     ) -> AgreementResult<Self> {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -44,7 +44,7 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::{self, Debug};
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use byteorder::{BigEndian, ByteOrder};
 use merkle::{MerkleTree, Proof};
@@ -97,7 +97,7 @@ impl Debug for BroadcastMessage {
 /// Reliable Broadcast algorithm instance.
 pub struct Broadcast<NodeUid> {
     /// Shared network data.
-    netinfo: Rc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<NodeUid>>,
     /// The UID of the sending node.
     proposer_id: NodeUid,
     data_shard_num: usize,
@@ -176,7 +176,7 @@ impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
 impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     /// Creates a new broadcast instance to be used by node `our_id` which expects a value proposal
     /// from node `proposer_id`.
-    pub fn new(netinfo: Rc<NetworkInfo<NodeUid>>, proposer_id: NodeUid) -> BroadcastResult<Self> {
+    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>, proposer_id: NodeUid) -> BroadcastResult<Self> {
         let parity_shard_num = 2 * netinfo.num_faulty();
         let data_shard_num = netinfo.num_nodes() - parity_shard_num;
         let coding = Coding::new(data_shard_num, parity_shard_num)?;

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -23,7 +23,7 @@
 
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crypto::error as cerror;
 use crypto::Signature;
@@ -63,7 +63,7 @@ impl CommonCoinMessage {
 /// signature is valid, the instance outputs it and terminates; otherwise the instance aborts.
 #[derive(Debug)]
 pub struct CommonCoin<NodeUid, T> {
-    netinfo: Rc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<NodeUid>>,
     /// The name of this common coin. It is required to be unique for each common coin round.
     nonce: T,
     /// The result of combination of at least `num_faulty + 1` threshold signature shares.
@@ -139,7 +139,7 @@ where
     NodeUid: Clone + Debug + Ord,
     T: Clone + AsRef<[u8]>,
 {
-    pub fn new(netinfo: Rc<NetworkInfo<NodeUid>>, nonce: T) -> Self {
+    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>, nonce: T) -> Self {
         CommonCoin {
             netinfo,
             nonce,

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -25,7 +25,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use agreement::{self, Agreement, AgreementMessage, AgreementResult};
 use broadcast::{self, Broadcast, BroadcastMessage, BroadcastResult};
@@ -88,7 +88,7 @@ impl<NodeUid: Clone + Debug + Ord> MessageQueue<NodeUid> {
 /// Asynchronous Common Subset algorithm instance
 pub struct CommonSubset<NodeUid> {
     /// Shared network information.
-    netinfo: Rc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<NodeUid>>,
     broadcast_instances: BTreeMap<NodeUid, Broadcast<NodeUid>>,
     agreement_instances: BTreeMap<NodeUid, Agreement<NodeUid>>,
     broadcast_results: BTreeMap<NodeUid, ProposedValue>,
@@ -146,7 +146,7 @@ impl<NodeUid: Clone + Debug + Ord> DistAlgorithm for CommonSubset<NodeUid> {
 }
 
 impl<NodeUid: Clone + Debug + Ord> CommonSubset<NodeUid> {
-    pub fn new(netinfo: Rc<NetworkInfo<NodeUid>>, session_id: u64) -> CommonSubsetResult<Self> {
+    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>, session_id: u64) -> CommonSubsetResult<Self> {
         // Create all broadcast instances.
         let mut broadcast_instances: BTreeMap<NodeUid, Broadcast<NodeUid>> = BTreeMap::new();
         for proposer_id in netinfo.all_uids() {

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +54,7 @@ where
 
     /// Creates a new Dynamic Honey Badger instance with an empty buffer.
     pub fn build(&self) -> DynamicHoneyBadger<C, NodeUid> {
-        let honey_badger = HoneyBadger::builder(Rc::new(self.netinfo.clone()))
+        let honey_badger = HoneyBadger::builder(Arc::new(self.netinfo.clone()))
             .max_future_epochs(self.max_future_epochs)
             .build();
         DynamicHoneyBadger {

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -48,7 +48,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use bincode;
 use clear_on_drop::ClearOnDrop;
@@ -367,7 +367,7 @@ where
         self.messages
             .extend_with_epoch(self.start_epoch, &mut self.honey_badger);
         self.start_epoch = epoch;
-        self.honey_badger = HoneyBadger::builder(Rc::new(self.netinfo.clone()))
+        self.honey_badger = HoneyBadger::builder(Arc::new(self.netinfo.clone()))
             .max_future_epochs(self.max_future_epochs)
             .build();
         Ok(())

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::ops::Not;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use bincode;
 use itertools::Itertools;
@@ -36,7 +36,7 @@ error_chain!{
 /// A Honey Badger builder, to configure the parameters and create new instances of `HoneyBadger`.
 pub struct HoneyBadgerBuilder<C, NodeUid> {
     /// Shared network data.
-    netinfo: Rc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<NodeUid>>,
     /// The maximum number of future epochs for which we handle messages simultaneously.
     max_future_epochs: usize,
     _phantom: PhantomData<C>,
@@ -49,7 +49,7 @@ where
 {
     /// Returns a new `HoneyBadgerBuilder` configured to use the node IDs and cryptographic keys
     /// specified by `netinfo`.
-    pub fn new(netinfo: Rc<NetworkInfo<NodeUid>>) -> Self {
+    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>) -> Self {
         HoneyBadgerBuilder {
             netinfo,
             max_future_epochs: 3,
@@ -84,7 +84,7 @@ where
 /// An instance of the Honey Badger Byzantine fault tolerant consensus algorithm.
 pub struct HoneyBadger<C, NodeUid> {
     /// Shared network data.
-    netinfo: Rc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<NodeUid>>,
     /// The earliest epoch from which we have not yet received output.
     epoch: u64,
     /// Whether we have already submitted a proposal for the current epoch.
@@ -173,7 +173,7 @@ where
 {
     /// Returns a new `HoneyBadgerBuilder` configured to use the node IDs and cryptographic keys
     /// specified by `netinfo`.
-    pub fn builder(netinfo: Rc<NetworkInfo<NodeUid>>) -> HoneyBadgerBuilder<C, NodeUid> {
+    pub fn builder(netinfo: Arc<NetworkInfo<NodeUid>>) -> HoneyBadgerBuilder<C, NodeUid> {
         HoneyBadgerBuilder::new(netinfo)
     }
 

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -25,7 +25,7 @@ extern crate serde_derive;
 mod network;
 
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rand::Rng;
 
@@ -81,7 +81,7 @@ where
         );
         for &input in &[None, Some(false), Some(true)] {
             let adversary = |_| new_adversary(num_good_nodes, num_faulty_nodes);
-            let new_agreement = |netinfo: Rc<NetworkInfo<NodeUid>>| {
+            let new_agreement = |netinfo: Arc<NetworkInfo<NodeUid>>| {
                 Agreement::new(netinfo, 0, NodeUid(0)).expect("agreement instance")
             };
             let network =

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -13,7 +13,7 @@ mod network;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rand::Rng;
 
@@ -76,7 +76,7 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         let sk_set = SecretKeySet::random(self.adv_nodes.len(), &mut rng);
         let pk_set = sk_set.public_keys();
 
-        let netinfo = Rc::new(NetworkInfo::new(
+        let netinfo = Arc::new(NetworkInfo::new(
             id,
             node_ids,
             sk_set.secret_key_share(0),
@@ -110,7 +110,7 @@ fn test_broadcast<A: Adversary<Broadcast<NodeUid>>>(
     assert!(once(&proposed_value.to_vec()).eq(network.observer.outputs()));
 }
 
-fn new_broadcast(netinfo: Rc<NetworkInfo<NodeUid>>) -> Broadcast<NodeUid> {
+fn new_broadcast(netinfo: Arc<NetworkInfo<NodeUid>>) -> Broadcast<NodeUid> {
     Broadcast::new(netinfo, NodeUid(0)).expect("Instantiate broadcast")
 }
 

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -13,7 +13,7 @@ mod network;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use hbbft::common_subset::CommonSubset;
 use hbbft::messaging::NetworkInfo;
@@ -66,12 +66,12 @@ fn new_network<A, F>(
 ) -> TestNetwork<A, CommonSubset<NodeUid>>
 where
     A: Adversary<CommonSubset<NodeUid>>,
-    F: Fn(BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>) -> A,
+    F: Fn(BTreeMap<NodeUid, Arc<NetworkInfo<NodeUid>>>) -> A,
 {
     // This returns an error in all but the first test.
     let _ = env_logger::try_init();
 
-    let new_common_subset = |netinfo: Rc<NetworkInfo<NodeUid>>| {
+    let new_common_subset = |netinfo: Arc<NetworkInfo<NodeUid>>| {
         CommonSubset::new(netinfo, 0).expect("new Common Subset instance")
     };
     TestNetwork::new(good_num, bad_num, adversary, new_common_subset)

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -14,7 +14,7 @@ mod network;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rand::Rng;
 
@@ -114,14 +114,14 @@ where
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-fn new_dynamic_hb(netinfo: Rc<NetworkInfo<NodeUid>>) -> UsizeDhb {
+fn new_dynamic_hb(netinfo: Arc<NetworkInfo<NodeUid>>) -> UsizeDhb {
     DynamicHoneyBadger::builder((*netinfo).clone()).build()
 }
 
 fn test_dynamic_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
 where
     A: Adversary<UsizeDhb>,
-    F: Fn(usize, usize, BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>) -> A,
+    F: Fn(usize, usize, BTreeMap<NodeUid, Arc<NetworkInfo<NodeUid>>>) -> A,
 {
     // This returns an error in all but the first test.
     let _ = env_logger::try_init();

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -14,7 +14,7 @@ mod network;
 
 use std::collections::BTreeMap;
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rand::Rng;
 
@@ -32,7 +32,7 @@ type UsizeHoneyBadger = HoneyBadger<Vec<usize>, NodeUid>;
 pub struct FaultyShareAdversary {
     num_good: usize,
     num_adv: usize,
-    adv_nodes: BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>,
+    adv_nodes: BTreeMap<NodeUid, Arc<NetworkInfo<NodeUid>>>,
     scheduler: MessageScheduler,
     share_triggers: BTreeMap<u64, bool>,
 }
@@ -42,7 +42,7 @@ impl FaultyShareAdversary {
     pub fn new(
         num_good: usize,
         num_adv: usize,
-        adv_nodes: BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>,
+        adv_nodes: BTreeMap<NodeUid, Arc<NetworkInfo<NodeUid>>>,
         scheduler: MessageScheduler,
     ) -> FaultyShareAdversary {
         FaultyShareAdversary {
@@ -189,14 +189,14 @@ where
     }
 }
 
-fn new_honey_badger(netinfo: Rc<NetworkInfo<NodeUid>>) -> UsizeHoneyBadger {
+fn new_honey_badger(netinfo: Arc<NetworkInfo<NodeUid>>) -> UsizeHoneyBadger {
     HoneyBadger::builder(netinfo).build()
 }
 
 fn test_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
 where
     A: Adversary<UsizeHoneyBadger>,
-    F: Fn(usize, usize, BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>) -> A,
+    F: Fn(usize, usize, BTreeMap<NodeUid, Arc<NetworkInfo<NodeUid>>>) -> A,
 {
     // This returns an error in all but the first test.
     let _ = env_logger::try_init();

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rand::{self, Rng};
 
@@ -155,7 +155,7 @@ where
 {
     pub nodes: BTreeMap<D::NodeUid, TestNode<D>>,
     pub observer: TestNode<D>,
-    pub adv_nodes: BTreeMap<D::NodeUid, Rc<NetworkInfo<D::NodeUid>>>,
+    pub adv_nodes: BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>,
     pub pk_set: PublicKeySet,
     adversary: A,
 }
@@ -173,8 +173,8 @@ where
         new_algo: F,
     ) -> TestNetwork<A, D>
     where
-        F: Fn(Rc<NetworkInfo<NodeUid>>) -> D,
-        G: Fn(BTreeMap<D::NodeUid, Rc<NetworkInfo<D::NodeUid>>>) -> A,
+        F: Fn(Arc<NetworkInfo<NodeUid>>) -> D,
+        G: Fn(BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>) -> A,
     {
         let mut rng = rand::thread_rng();
         let sk_set = SecretKeySet::random(adv_num, &mut rng);
@@ -184,7 +184,7 @@ where
         let new_node_by_id = |NodeUid(i): NodeUid| {
             (
                 NodeUid(i),
-                TestNode::new(new_algo(Rc::new(NetworkInfo::new(
+                TestNode::new(new_algo(Arc::new(NetworkInfo::new(
                     NodeUid(i),
                     node_ids.clone(),
                     sk_set.secret_key_share(i as u64),
@@ -195,7 +195,7 @@ where
         let new_adv_node_by_id = |NodeUid(i): NodeUid| {
             (
                 NodeUid(i),
-                Rc::new(NetworkInfo::new(
+                Arc::new(NetworkInfo::new(
                     NodeUid(i),
                     node_ids.clone(),
                     sk_set.secret_key_share(i as u64),
@@ -203,7 +203,7 @@ where
                 )),
             )
         };
-        let adv_nodes: BTreeMap<D::NodeUid, Rc<NetworkInfo<D::NodeUid>>> = (good_num
+        let adv_nodes: BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>> = (good_num
             ..(good_num + adv_num))
             .map(NodeUid)
             .map(new_adv_node_by_id)

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -14,7 +14,7 @@ mod network;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::iter::once;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use hbbft::messaging::NetworkInfo;
 use hbbft::queueing_honey_badger::{Change, ChangeState, Input, QueueingHoneyBadger};
@@ -106,7 +106,7 @@ where
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-fn new_queueing_hb(netinfo: Rc<NetworkInfo<NodeUid>>) -> QueueingHoneyBadger<usize, NodeUid> {
+fn new_queueing_hb(netinfo: Arc<NetworkInfo<NodeUid>>) -> QueueingHoneyBadger<usize, NodeUid> {
     QueueingHoneyBadger::builder((*netinfo).clone())
         .batch_size(12)
         .build()
@@ -115,7 +115,7 @@ fn new_queueing_hb(netinfo: Rc<NetworkInfo<NodeUid>>) -> QueueingHoneyBadger<usi
 fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
 where
     A: Adversary<QueueingHoneyBadger<usize, NodeUid>>,
-    F: Fn(usize, usize, BTreeMap<NodeUid, Rc<NetworkInfo<NodeUid>>>) -> A,
+    F: Fn(usize, usize, BTreeMap<NodeUid, Arc<NetworkInfo<NodeUid>>>) -> A,
 {
     // This returns an error in all but the first test.
     let _ = env_logger::try_init();


### PR DESCRIPTION
Replaces `Rc` with `Arc`. This allows usage from different threads
which will be necessary for use with Parity.

The additional runtime performance cost is virtually zero (the tiny extra cost of an atomic read/write is only incurred when cloning/dropping).