### PR TITLE
Replaced clear-on-drop with 'std::ptr::write_volatile'.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ travis-ci = { repository = "poanetwork/hbbft" }
 [dependencies]
 bincode = "1.0.0"
 byteorder = "1.2.3"
-clear_on_drop = "0.2.3"
 derive_deref = "1.0.1"
 env_logger = "0.5.10"
 error-chain = "0.11.0"

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -44,12 +44,10 @@
 //! ## Example usage
 //!
 //! ```rust
-//!# extern crate clear_on_drop;
 //!# extern crate hbbft;
 //!# extern crate rand;
 //!# fn main() {
 //!#
-//! use clear_on_drop::ClearOnDrop;
 //! use hbbft::broadcast::Broadcast;
 //! use hbbft::crypto::SecretKeySet;
 //! use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@
 
 extern crate bincode;
 extern crate byteorder;
-extern crate clear_on_drop;
 #[macro_use(Deref, DerefMut)]
 extern crate derive_deref;
 #[macro_use]

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,8 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 
-use clear_on_drop::ClearOnDrop;
-
 use crypto::{PublicKey, PublicKeySet, SecretKey};
 use fault_log::FaultLog;
 
@@ -131,12 +129,6 @@ impl<'a, D: DistAlgorithm + 'a> Iterator for OutputIter<'a, D> {
 }
 
 /// Common data shared between algorithms.
-///
-/// *NOTE* `NetworkInfo` requires its `secret_key` to be heap allocated and
-/// wrapped by the `ClearOnDrop` type from the `clear_on_drop` crate. We
-/// use this construction to zero out the section of heap memory that is
-/// allocated for `secret_key` when the corresponding instance of
-/// `NetworkInfo` goes out of scope.
 #[derive(Debug, Clone)]
 pub struct NetworkInfo<NodeUid> {
     our_uid: NodeUid,
@@ -144,7 +136,7 @@ pub struct NetworkInfo<NodeUid> {
     num_nodes: usize,
     num_faulty: usize,
     is_validator: bool,
-    secret_key: ClearOnDrop<Box<SecretKey>>,
+    secret_key: SecretKey,
     public_key_set: PublicKeySet,
     public_keys: BTreeMap<NodeUid, PublicKey>,
     node_indices: BTreeMap<NodeUid, usize>,
@@ -154,7 +146,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
     pub fn new(
         our_uid: NodeUid,
         all_uids: BTreeSet<NodeUid>,
-        secret_key: ClearOnDrop<Box<SecretKey>>,
+        secret_key: SecretKey,
         public_key_set: PublicKeySet,
     ) -> Self {
         let num_nodes = all_uids.len();

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -37,7 +37,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
 
 use bincode;
-use clear_on_drop::ClearOnDrop;
 use pairing::bls12_381::{Fr, G1Affine};
 use pairing::{CurveAffine, Field};
 use rand::OsRng;
@@ -238,7 +237,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
     ///
     /// These are only secure if `is_ready` returned `true`. Otherwise it is not guaranteed that
     /// none of the nodes knows the secret master key.
-    pub fn generate(&self) -> (PublicKeySet, Option<ClearOnDrop<Box<SecretKey>>>) {
+    pub fn generate(&self) -> (PublicKeySet, Option<SecretKey>) {
         let mut pk_commit = Poly::zero().commitment();
         let mut opt_sk_val = self.our_idx.map(|_| Fr::zero());
         let is_complete = |proposal: &&ProposalState| proposal.is_complete(self.threshold);
@@ -249,8 +248,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
                 sk_val.add_assign(&row.evaluate(0));
             }
         }
-        let opt_sk =
-            opt_sk_val.map(|sk_val| ClearOnDrop::new(Box::new(SecretKey::from_value(sk_val))));
+        let opt_sk = opt_sk_val.map(SecretKey::from_value);
         (pk_commit.into(), opt_sk)
     }
 


### PR DESCRIPTION
- Removes the need to wrap `SecretKey`s in `ClearOnDrop<Box<...>>`.
- Allows for stack allocated `SecretKey`s.
- Zeros out the memory occupied by each `SecretKey` on drop.
- Ensures that the clearing of `SecretKey`s is not elided.
- Works on stable.

Closes Issues #89 and #90