### PR TITLE
Minor fixes and simplifications.

### DIFF
--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -13,7 +13,6 @@ mod network;
 
 use std::cmp;
 use std::collections::BTreeMap;
-use std::iter::once;
 use std::sync::Arc;
 
 use rand::Rng;
@@ -59,11 +58,9 @@ where
             return true;
         }
         let mut min_missing = 0;
-        for batch in node.outputs() {
-            for tx in batch.iter() {
-                if *tx >= min_missing {
-                    min_missing = tx + 1;
-                }
+        for tx in node.outputs().iter().flat_map(Batch::iter) {
+            if *tx >= min_missing {
+                min_missing = tx + 1;
             }
         }
         if min_missing < num_txs {
@@ -76,17 +73,28 @@ where
         false
     };
 
+    let mut rng = rand::thread_rng();
+
     let mut input_add = false;
     // Handle messages in random order until all nodes have output all transactions.
     while network.nodes.values_mut().any(node_busy) {
-        let id = network.step();
-        if !network.nodes[&id].instance().has_input() {
-            queues
-                .get_mut(&id)
-                .unwrap()
-                .remove_all(network.nodes[&id].outputs().iter().flat_map(Batch::iter));
-            network.input(id, Input::User(queues[&id].choose(3, 10)));
+        // If a node is expecting input, take it from the queue. Otherwise handle a message.
+        let input_ids: Vec<_> = network
+            .nodes
+            .iter()
+            .filter(|(_, node)| {
+                !node.instance().has_input() && node.instance().netinfo().is_validator()
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        if let Some(id) = rng.choose(&input_ids) {
+            let queue = queues.get_mut(id).unwrap();
+            queue.remove_all(network.nodes[id].outputs().iter().flat_map(Batch::iter));
+            network.input(*id, Input::User(queue.choose(3, 10)));
+        } else {
+            network.step();
         }
+        // Once all nodes have processed the removal of node 0, add it again.
         if !input_add && network.nodes.values().all(has_remove) {
             let pk = network.pk_set.public_key_share(0);
             network.input_all(Input::Change(Change::Add(NodeUid(0), pk)));
@@ -127,7 +135,8 @@ where
     let _ = env_logger::try_init();
 
     let mut rng = rand::thread_rng();
-    let sizes = (3..5).chain(once(rng.gen_range(6, 10)));
+    // TODO: This should also work with two nodes.
+    let sizes = vec![3, 5, rng.gen_range(6, 10)];
     for size in sizes {
         // The test is removing one correct node, so we allow fewer faulty ones.
         let num_adv_nodes = (size - 2) / 3;

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -13,11 +13,10 @@ mod network;
 
 use std::cmp;
 use std::collections::BTreeMap;
-use std::iter::once;
 use std::sync::Arc;
 
 use hbbft::messaging::NetworkInfo;
-use hbbft::queueing_honey_badger::{Change, ChangeState, Input, QueueingHoneyBadger};
+use hbbft::queueing_honey_badger::{Batch, Change, ChangeState, Input, QueueingHoneyBadger};
 use rand::Rng;
 
 use network::{Adversary, MessageScheduler, NodeUid, SilentAdversary, TestNetwork, TestNode};
@@ -55,11 +54,9 @@ fn test_queueing_honey_badger<A>(
             return true;
         }
         let mut min_missing = 0;
-        for batch in node.outputs() {
-            for tx in batch.iter() {
-                if *tx >= min_missing {
-                    min_missing = tx + 1;
-                }
+        for tx in node.outputs().iter().flat_map(Batch::iter) {
+            if *tx >= min_missing {
+                min_missing = tx + 1;
             }
         }
         if min_missing < num_txs {
@@ -108,7 +105,7 @@ where
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn new_queueing_hb(netinfo: Arc<NetworkInfo<NodeUid>>) -> QueueingHoneyBadger<usize, NodeUid> {
     QueueingHoneyBadger::builder((*netinfo).clone())
-        .batch_size(12)
+        .batch_size(3)
         .build()
 }
 
@@ -121,7 +118,7 @@ where
     let _ = env_logger::try_init();
 
     let mut rng = rand::thread_rng();
-    let sizes = (3..5).chain(once(rng.gen_range(6, 10)));
+    let sizes = vec![3, 5, rng.gen_range(6, 10)];
     for size in sizes {
         // The test is removing one correct node, so we allow fewer faulty ones.
         let num_adv_nodes = (size - 2) / 3;
@@ -139,11 +136,11 @@ where
 #[test]
 fn test_queueing_honey_badger_random_delivery_silent() {
     let new_adversary = |_: usize, _: usize, _| SilentAdversary::new(MessageScheduler::Random);
-    test_queueing_honey_badger_different_sizes(new_adversary, 10);
+    test_queueing_honey_badger_different_sizes(new_adversary, 30);
 }
 
 #[test]
 fn test_queueing_honey_badger_first_delivery_silent() {
     let new_adversary = |_: usize, _: usize, _| SilentAdversary::new(MessageScheduler::First);
-    test_queueing_honey_badger_different_sizes(new_adversary, 10);
+    test_queueing_honey_badger_different_sizes(new_adversary, 30);
 }


### PR DESCRIPTION
* Clear outdated key gen messages from the buffer.
* Process output after proposing, to make `HoneyBadger` work with a
  single validator.
* Print an error if threshold decryption fails.
* Verify decryption shares with the correct ciphertext.
* Insert all ciphertexts from an epoch at once; otherwise contributions
  can be omitted from a batch.
* Remove `BoolWithFaultLog`: It's easier to return a tuple, and it's
  used only in one place now.
* Avoid redundant signature verification in `VoteCounter`.
* Fix the tests for `QueueingHoneyBadger`.
* Use fewer network sizes to speed up tests a bit.