### PR TITLE
Output API refactored

### DIFF
--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -149,14 +149,14 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                     let message = rx_to_algo.recv().expect("receive from algo");
                     let SourcedMessage { source: i, message } = message;
                     debug!("{} received from {}: {:?}", our_id, i, message);
-                    broadcast
+                    let step = broadcast
                         .handle_message(&i, message)
                         .expect("handle broadcast message");
                     for msg in broadcast.message_iter() {
                         debug!("{} sending to {:?}: {:?}", our_id, msg.target, msg.message);
                         tx_from_algo.send(msg).expect("send from algo");
                     }
-                    if let Some(output) = broadcast.next_output() {
+                    if let Some(output) = step.output.into_iter().next() {
                         println!(
                             "Broadcast succeeded! Node {} output: {}",
                             our_id,

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -138,7 +138,8 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                     Broadcast::new(Arc::new(netinfo), 0).expect("failed to instantiate broadcast");
 
                 if let Some(v) = value {
-                    broadcast.input(v.clone().into()).expect("propose value");
+                    // FIXME: Use the output.
+                    let _ = broadcast.input(v.clone().into()).expect("propose value");
                     for msg in broadcast.message_iter() {
                         tx_from_algo.send(msg).expect("send from algo");
                     }

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 use signifix::{metric, TryFrom};
 
 use hbbft::crypto::SecretKeySet;
-use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target};
+use hbbft::messaging::{DistAlgorithm, NetworkInfo, Step, Target};
 use hbbft::queueing_honey_badger::{Batch, QueueingHoneyBadger};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -153,7 +153,7 @@ where
             message_size: 0,
             hw_quality,
         };
-        node.send_output_and_msgs();
+        node.send_output_and_msgs(Step::default());
         node
     }
 
@@ -165,15 +165,19 @@ where
         self.message_size += ts_msg.message.len() as u64;
         let start = Instant::now();
         let msg = bincode::deserialize::<D::Message>(&ts_msg.message).expect("deserialize");
-        self.algo
+        let step = self
+            .algo
             .handle_message(&ts_msg.sender_id, msg)
             .expect("handling message");
         self.time += start.elapsed() * self.hw_quality.cpu_factor / 100;
-        self.send_output_and_msgs()
+        self.send_output_and_msgs(step)
     }
 
     /// Handles the algorithm's output and messages.
-    fn send_output_and_msgs(&mut self) {
+    fn send_output_and_msgs(
+        &mut self,
+        step: Step<<D as DistAlgorithm>::NodeUid, <D as DistAlgorithm>::Output>,
+    ) {
         let start = Instant::now();
         let out_msgs: Vec<_> = self
             .algo
@@ -188,7 +192,7 @@ where
         self.time += start.elapsed() * self.hw_quality.cpu_factor / 100;
         let time = self.time;
         self.outputs
-            .extend(self.algo.output_iter().map(|out| (time, out)));
+            .extend(step.output.into_iter().map(|out| (time, out)));
         self.sent_time = cmp::max(self.time, self.sent_time);
         for (target, message) in out_msgs {
             self.sent_time += self.hw_quality.inv_bw * message.len() as u32;

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -502,8 +502,11 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         &mut self,
         coin_step: CommonCoinStep<NodeUid>,
     ) -> AgreementResult<FaultLog<NodeUid>> {
-        let mut fault_log = coin_step.fault_log.clone();
-        if let Some(coin) = coin_step.output.into_iter().next() {
+        let Step {
+            output,
+            mut fault_log,
+        } = coin_step;
+        if let Some(coin) = output.into_iter().next() {
             let def_bin_value = self.count_conf().1.definite();
             fault_log.extend(self.on_coin(coin, def_bin_value)?);
         }

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -600,7 +600,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         if self.conf_round
             && self.count_conf().0 >= self.netinfo.num_nodes() - self.netinfo.num_faulty()
         {
-            // Invoke the comon coin.
+            // Invoke the common coin.
             let coin_step = self.common_coin.input(())?;
             self.extend_common_coin();
             self.on_coin_step(coin_step)

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -43,6 +43,7 @@
 //!
 //! ## Example usage
 //!
+//! FIXME: Fix the test for the new API (Issue #135).
 //! ```ignore
 //!# extern crate clear_on_drop;
 //!# extern crate hbbft;

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -44,6 +44,7 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::{self, Debug};
 use std::iter::once;
+use std::mem::replace;
 use std::sync::Arc;
 
 use byteorder::{BigEndian, ByteOrder};
@@ -54,7 +55,7 @@ use ring::digest;
 
 use fault_log::{FaultKind, FaultLog};
 use fmt::{HexBytes, HexList, HexProof};
-use messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
+use messaging::{DistAlgorithm, NetworkInfo, Step, Target, TargetedMessage};
 
 error_chain!{
     types {
@@ -118,6 +119,8 @@ pub struct Broadcast<NodeUid> {
     output: Option<Vec<u8>>,
 }
 
+pub type BroadcastStep<N> = Step<N, Vec<u8>>;
+
 impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
     type NodeUid = NodeUid;
     // TODO: Allow anything serializable and deserializable, i.e. make this a type parameter
@@ -127,7 +130,7 @@ impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
     type Message = BroadcastMessage;
     type Error = Error;
 
-    fn input(&mut self, input: Self::Input) -> BroadcastResult<FaultLog<NodeUid>> {
+    fn input(&mut self, input: Self::Input) -> BroadcastResult<BroadcastStep<NodeUid>> {
         if *self.netinfo.our_uid() != self.proposer_id {
             return Err(ErrorKind::InstanceCannotPropose.into());
         }
@@ -136,32 +139,30 @@ impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
         // from this tree and send them, each to its own node.
         let proof = self.send_shards(input)?;
         let our_uid = &self.netinfo.our_uid().clone();
-        self.handle_value(our_uid, proof)
+        let fault_log = self.handle_value(our_uid, proof)?;
+        self.step().with_fault_log(fault_log)
     }
 
     fn handle_message(
         &mut self,
         sender_id: &NodeUid,
         message: Self::Message,
-    ) -> BroadcastResult<FaultLog<NodeUid>> {
+    ) -> BroadcastResult<BroadcastStep<NodeUid>> {
         if !self.netinfo.all_uids().contains(sender_id) {
             return Err(ErrorKind::UnknownSender.into());
         }
-        match message {
-            BroadcastMessage::Value(p) => self.handle_value(sender_id, p),
-            BroadcastMessage::Echo(p) => self.handle_echo(sender_id, p),
-            BroadcastMessage::Ready(ref hash) => {
-                self.handle_ready(sender_id, hash).map(|()| FaultLog::new())
-            }
-        }
+        let fault_log = match message {
+            BroadcastMessage::Value(p) => self.handle_value(sender_id, p)?,
+            BroadcastMessage::Echo(p) => self.handle_echo(sender_id, p)?,
+            BroadcastMessage::Ready(ref hash) => self
+                .handle_ready(sender_id, hash)?
+                .map(|()| FaultLog::new()),
+        };
+        self.step().with_fault_log(fault_log)
     }
 
     fn next_message(&mut self) -> Option<TargetedMessage<Self::Message, NodeUid>> {
         self.messages.pop_front()
-    }
-
-    fn next_output(&mut self) -> Option<Self::Output> {
-        self.output.take()
     }
 
     fn terminated(&self) -> bool {
@@ -194,6 +195,10 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
             messages: VecDeque::new(),
             output: None,
         })
+    }
+
+    fn step(&mut self) -> BroadcastResult<BroadcastStep<NodeUid>> {
+        Ok(Step::new(replace(&mut self.output, None)))
     }
 
     /// Breaks the input value into shards of equal length and encodes them --

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -43,7 +43,7 @@
 //!
 //! ## Example usage
 //!
-//! ```rust
+//! ```ignore
 //!# extern crate clear_on_drop;
 //!# extern crate hbbft;
 //!# extern crate rand;

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -99,7 +99,7 @@ where
         } else {
             FaultLog::new()
         };
-        self.step().with_fault_log(fault_log)
+        self.step(fault_log)
     }
 
     /// Receives input from a remote node.
@@ -114,7 +114,7 @@ where
         } else {
             FaultLog::default()
         };
-        self.step().with_fault_log(fault_log)
+        self.step(fault_log)
     }
 
     /// Takes the next share of a threshold signature message for multicasting to all other nodes.
@@ -151,8 +151,11 @@ where
         }
     }
 
-    fn step(&mut self) -> Result<CommonCoinStep<NodeUid>> {
-        Ok(Step::new(self.output.take()))
+    fn step(&mut self, fault_log: FaultLog<NodeUid>) -> Result<CommonCoinStep<NodeUid>> {
+        Ok(Step::new(
+            self.output.take().into_iter().collect(),
+            fault_log,
+        ))
     }
 
     fn get_coin(&mut self) -> Result<FaultLog<NodeUid>> {

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -78,7 +78,7 @@ pub struct CommonCoin<NodeUid, T> {
     terminated: bool,
 }
 
-pub type CommonCoinStep<N> = Step<N, bool>;
+pub type CommonCoinStep<NodeUid> = Step<NodeUid, bool>;
 
 impl<NodeUid, T> DistAlgorithm for CommonCoin<NodeUid, T>
 where
@@ -112,7 +112,7 @@ where
             let CommonCoinMessage(share) = message;
             self.handle_share(sender_id, share)?
         } else {
-            FaultLog::default()
+            FaultLog::new()
         };
         self.step(fault_log)
     }

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -258,7 +258,7 @@ impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
                 // FIXME: Use the result.
                 agreement.input(true)
             } else {
-                Ok(Default::default())
+                Ok(Step::default())
             }
         };
         self.process_agreement(proposer_id, set_agreement_input)?

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -255,7 +255,6 @@ impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
         self.broadcast_results.insert(proposer_id.clone(), value);
         let set_agreement_input = |agreement: &mut Agreement<NodeUid>| {
             if agreement.accepts_input() {
-                // FIXME: Use the result.
                 agreement.input(true)
             } else {
                 Ok(Step::default())

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -265,9 +265,7 @@ where
         self.verify_signature(sender_id, &sig, &kg_msg)?;
         let tx = SignedKeyGenMsg(self.start_epoch, sender_id.clone(), kg_msg, sig);
         self.key_gen_msg_buffer.push(tx);
-        // FIXME: Remove the call to `process_output`. There wasn't any output from HB in this
-        // function.
-        self.process_output(Step::default())
+        Ok(FaultLog::default())
     }
 
     /// Processes all pending batches output by Honey Badger.

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -184,7 +184,7 @@ where
     NodeUid: Eq + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r> + Hash + Rand,
 {
     fn step(&mut self, fault_log: FaultLog<NodeUid>) -> Result<DynamicHoneyBadgerStep<C, NodeUid>> {
-        Ok(Step::new(self.output.drain(0..).collect(), fault_log))
+        Ok(Step::new(self.output.drain(..).collect(), fault_log))
     }
 
     /// Returns a new `DynamicHoneyBadgerBuilder` configured to use the node IDs and cryptographic
@@ -252,7 +252,7 @@ where
         self.key_gen_msg_buffer.push(tx);
         // FIXME: Remove the call to `process_output`. There wasn't any output from HB in this
         // function.
-        self.process_output(Default::default())
+        self.process_output(Step::default())
     }
 
     /// Processes all pending batches output by Honey Badger.

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -42,13 +42,13 @@ pub enum FaultKind {
 /// A structure representing the context of a faulty node. This structure
 /// describes which node is faulty (`node_id`) and which faulty behavior
 /// that the node exhibited ('kind').
-#[derive(Clone, Debug, PartialEq)]
-pub struct Fault<NodeUid: Clone> {
+#[derive(Debug, PartialEq)]
+pub struct Fault<NodeUid> {
     pub node_id: NodeUid,
     pub kind: FaultKind,
 }
 
-impl<NodeUid: Clone> Fault<NodeUid> {
+impl<NodeUid> Fault<NodeUid> {
     pub fn new(node_id: NodeUid, kind: FaultKind) -> Self {
         Fault { node_id, kind }
     }
@@ -56,17 +56,17 @@ impl<NodeUid: Clone> Fault<NodeUid> {
 
 /// Creates a new `FaultLog` where `self` is the first element in the log
 /// vector.
-impl<NodeUid: Clone> Into<FaultLog<NodeUid>> for Fault<NodeUid> {
+impl<NodeUid> Into<FaultLog<NodeUid>> for Fault<NodeUid> {
     fn into(self) -> FaultLog<NodeUid> {
         FaultLog(vec![self])
     }
 }
 
 /// A structure used to contain reports of faulty node behavior.
-#[derive(Clone, Debug, PartialEq)]
-pub struct FaultLog<NodeUid: Clone>(pub Vec<Fault<NodeUid>>);
+#[derive(Debug, PartialEq)]
+pub struct FaultLog<NodeUid>(pub Vec<Fault<NodeUid>>);
 
-impl<NodeUid: Clone> FaultLog<NodeUid> {
+impl<NodeUid> FaultLog<NodeUid> {
     /// Creates an empty `FaultLog`.
     pub fn new() -> Self {
         FaultLog::default()
@@ -98,7 +98,7 @@ impl<NodeUid: Clone> FaultLog<NodeUid> {
     }
 }
 
-impl<NodeUid: Clone> Default for FaultLog<NodeUid> {
+impl<NodeUid> Default for FaultLog<NodeUid> {
     fn default() -> Self {
         FaultLog(vec![])
     }

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -97,7 +97,7 @@ pub struct HoneyBadger<C, NodeUid: Rand> {
     /// The messages that need to be sent to other nodes.
     messages: MessageQueue<NodeUid>,
     /// The outputs from completed epochs.
-    pub(crate) output: Vec<Batch<C, NodeUid>>,
+    output: Vec<Batch<C, NodeUid>>,
     /// Messages for future epochs that couldn't be handled yet.
     incoming_queue: BTreeMap<u64, Vec<(NodeUid, MessageContent<NodeUid>)>>,
     /// Received decryption shares for an epoch. Each decryption share has a sender and a

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -179,7 +179,7 @@ where
         &mut self,
         fault_log: FaultLog<NodeUid>,
     ) -> HoneyBadgerResult<HoneyBadgerStep<C, NodeUid>> {
-        Ok(Step::new(self.output.drain(0..).collect(), fault_log))
+        Ok(Step::new(self.output.drain(..).collect(), fault_log))
     }
 
     /// Proposes a new item in the current epoch.
@@ -554,8 +554,7 @@ where
         &mut self,
         step: CommonSubsetStep<NodeUid>,
     ) -> HoneyBadgerResult<FaultLog<NodeUid>> {
-        let mut fault_log = FaultLog::new();
-        fault_log.extend(step.fault_log);
+        let mut fault_log = step.fault_log.clone();
         for cs_output in step.output {
             fault_log.extend(self.send_decryption_shares(cs_output)?);
             // TODO: May also check that there is no further output from Common Subset.

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
+use std::mem::replace;
 use std::ops::Not;
 use std::sync::Arc;
 
@@ -10,10 +11,10 @@ use bincode;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use common_subset::{self, CommonSubset};
+use common_subset::{self, CommonSubset, CommonSubsetStep};
 use crypto::{Ciphertext, DecryptionShare};
 use fault_log::{FaultKind, FaultLog};
-use messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
+use messaging::{DistAlgorithm, NetworkInfo, Step, Target, TargetedMessage};
 
 error_chain!{
     types {
@@ -72,7 +73,7 @@ where
             common_subsets: BTreeMap::new(),
             max_future_epochs: self.max_future_epochs as u64,
             messages: MessageQueue(VecDeque::new()),
-            output: VecDeque::new(),
+            output: None,
             incoming_queue: BTreeMap::new(),
             received_shares: BTreeMap::new(),
             decrypted_contributions: BTreeMap::new(),
@@ -96,8 +97,8 @@ pub struct HoneyBadger<C, NodeUid> {
     max_future_epochs: u64,
     /// The messages that need to be sent to other nodes.
     messages: MessageQueue<NodeUid>,
-    /// The outputs from completed epochs.
-    output: VecDeque<Batch<C, NodeUid>>,
+    /// The output from a completed epoch.
+    output: Option<Batch<C, NodeUid>>,
     /// Messages for future epochs that couldn't be handled yet.
     incoming_queue: BTreeMap<u64, Vec<(NodeUid, MessageContent<NodeUid>)>>,
     /// Received decryption shares for an epoch. Each decryption share has a sender and a
@@ -110,6 +111,8 @@ pub struct HoneyBadger<C, NodeUid> {
     ciphertexts: BTreeMap<u64, BTreeMap<NodeUid, Ciphertext>>,
 }
 
+pub type HoneyBadgerStep<C, NodeUid> = Step<NodeUid, Batch<C, NodeUid>>;
+
 impl<C, NodeUid> DistAlgorithm for HoneyBadger<C, NodeUid>
 where
     C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
@@ -121,40 +124,35 @@ where
     type Message = Message<NodeUid>;
     type Error = Error;
 
-    fn input(&mut self, input: Self::Input) -> HoneyBadgerResult<FaultLog<NodeUid>> {
-        Ok(self.propose(&input)?)
+    fn input(&mut self, input: Self::Input) -> HoneyBadgerResult<HoneyBadgerStep<C, NodeUid>> {
+        let fault_log = self.propose(&input)?;
+        self.step().with_fault_log(fault_log)
     }
 
     fn handle_message(
         &mut self,
         sender_id: &NodeUid,
         message: Self::Message,
-    ) -> HoneyBadgerResult<FaultLog<NodeUid>> {
+    ) -> HoneyBadgerResult<HoneyBadgerStep<C, NodeUid>> {
         if !self.netinfo.all_uids().contains(sender_id) {
             return Err(ErrorKind::UnknownSender.into());
         }
         let Message { epoch, content } = message;
-        if epoch < self.epoch {
-            // Ignore all messages from past epochs.
-            return Ok(FaultLog::new());
-        }
+        let mut fault_log = FaultLog::new();
         if epoch > self.epoch + self.max_future_epochs {
             // Postpone handling this message.
             self.incoming_queue
                 .entry(epoch)
                 .or_insert_with(Vec::new)
                 .push((sender_id.clone(), content));
-            return Ok(FaultLog::new());
-        }
-        self.handle_message_content(sender_id, epoch, content)
+        } else if epoch == self.epoch {
+            fault_log.extend(self.handle_message_content(sender_id, epoch, content)?);
+        } // And ignore all messages from past epochs.
+        self.step().with_fault_log(fault_log)
     }
 
     fn next_message(&mut self) -> Option<TargetedMessage<Self::Message, NodeUid>> {
         self.messages.pop_front()
-    }
-
-    fn next_output(&mut self) -> Option<Self::Output> {
-        self.output.pop_front()
     }
 
     fn terminated(&self) -> bool {
@@ -175,6 +173,10 @@ where
     /// specified by `netinfo`.
     pub fn builder(netinfo: Arc<NetworkInfo<NodeUid>>) -> HoneyBadgerBuilder<C, NodeUid> {
         HoneyBadgerBuilder::new(netinfo)
+    }
+
+    fn step(&mut self) -> HoneyBadgerResult<HoneyBadgerStep<C, NodeUid>> {
+        Ok(Step::new(replace(&mut self.output, Default::default())))
     }
 
     /// Proposes a new item in the current epoch.
@@ -226,7 +228,7 @@ where
         message: common_subset::Message<NodeUid>,
     ) -> HoneyBadgerResult<FaultLog<NodeUid>> {
         let mut fault_log = FaultLog::new();
-        {
+        let step = {
             // Borrow the instance for `epoch`, or create it.
             let cs = match self.common_subsets.entry(epoch) {
                 Entry::Occupied(entry) => entry.into_mut(),
@@ -240,13 +242,14 @@ where
                 }
             };
             // Handle the message and put the outgoing messages into the queue.
-            cs.handle_message(sender_id, message)?
-                .merge_into(&mut fault_log);
+            let step = cs.handle_message(sender_id, message)?;
+            fault_log.extend(step.fault_log);
             self.messages.extend_with_epoch(epoch, cs);
-        }
+            step
+        };
         // If this is the current epoch, the message could cause a new output.
         if epoch == self.epoch {
-            self.process_output()?.merge_into(&mut fault_log);
+            fault_log.extend(self.process_output(step)?);
         }
         self.remove_terminated(epoch);
         Ok(fault_log)
@@ -344,8 +347,8 @@ where
             batch.contributions
         );
         // Queue the output and advance the epoch.
-        self.output.push_back(batch);
-        self.update_epoch()?.merge_into(&mut fault_log);
+        self.output = Some(batch);
+        fault_log.extend(self.update_epoch()?);
         Ok(fault_log)
     }
 
@@ -544,21 +547,16 @@ where
     }
 
     /// Checks whether the current epoch has output, and if it does, sends out our decryption shares.
-    fn process_output(&mut self) -> HoneyBadgerResult<FaultLog<NodeUid>> {
+    fn process_output(
+        &mut self,
+        step: CommonSubsetStep<NodeUid>,
+    ) -> HoneyBadgerResult<FaultLog<NodeUid>> {
         let mut fault_log = FaultLog::new();
-        if let Some(cs_output) = self.take_current_output() {
-            self.send_decryption_shares(cs_output)?
-                .merge_into(&mut fault_log);
+        if let Some(cs_output) = step.output {
+            fault_log.extend(self.send_decryption_shares(cs_output)?);
             // TODO: May also check that there is no further output from Common Subset.
         }
         Ok(fault_log)
-    }
-
-    /// Returns the output of the current epoch's `CommonSubset` instance, if any.
-    fn take_current_output(&mut self) -> Option<BTreeMap<NodeUid, Vec<u8>>> {
-        self.common_subsets
-            .get_mut(&self.epoch)
-            .and_then(CommonSubset::next_output)
     }
 
     /// Removes all `CommonSubset` instances from _past_ epochs that have terminated.

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -554,8 +554,11 @@ where
         &mut self,
         step: CommonSubsetStep<NodeUid>,
     ) -> HoneyBadgerResult<FaultLog<NodeUid>> {
-        let mut fault_log = step.fault_log.clone();
-        for cs_output in step.output {
+        let Step {
+            output,
+            mut fault_log,
+        } = step;
+        for cs_output in output {
             fault_log.extend(self.send_decryption_shares(cs_output)?);
             // TODO: May also check that there is no further output from Common Subset.
         }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -78,10 +78,7 @@ where
     N: Clone,
 {
     pub fn new(output: VecDeque<O>, fault_log: FaultLog<N>) -> Self {
-        Step {
-            output,
-            fault_log,
-        }
+        Step { output, fault_log }
     }
 }
 

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 
 use clear_on_drop::ClearOnDrop;
@@ -57,7 +57,7 @@ pub struct Step<N, O>
 where
     N: Clone,
 {
-    pub output: Option<O>,
+    pub output: VecDeque<O>,
     pub fault_log: FaultLog<N>,
 }
 
@@ -67,7 +67,7 @@ where
 {
     fn default() -> Step<N, O> {
         Step {
-            output: None,
+            output: Default::default(),
             fault_log: FaultLog::default(),
         }
     }
@@ -77,16 +77,11 @@ impl<N, O> Step<N, O>
 where
     N: Clone,
 {
-    pub fn new(output: Option<O>) -> Self {
+    pub fn new(output: VecDeque<O>, fault_log: FaultLog<N>) -> Self {
         Step {
             output,
-            fault_log: FaultLog::default(),
+            fault_log,
         }
-    }
-
-    pub fn with_fault_log(&mut self, fault_log: FaultLog<N>) -> &mut Self {
-        self.fault_log = fault_log;
-        self
     }
 }
 

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -53,6 +53,7 @@ impl<M, N> TargetedMessage<M, N> {
 
 /// Result of one step of the local state machine of a distributed algorithm. Such a result should
 /// be used and never discarded by the client of the algorithm.
+#[must_use = "The algorithm step result must be used."]
 pub struct Step<N, O>
 where
     N: Clone,
@@ -97,14 +98,12 @@ pub trait DistAlgorithm {
     type Error: Debug;
 
     /// Handles an input provided by the user, and returns
-    #[must_use]
     fn input(
         &mut self,
         input: Self::Input,
     ) -> Result<Step<Self::NodeUid, Self::Output>, Self::Error>;
 
     /// Handles a message received from node `sender_id`.
-    #[must_use]
     fn handle_message(
         &mut self,
         sender_id: &Self::NodeUid,

--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -158,8 +158,7 @@ where
         message: Self::Message,
     ) -> Result<QueueingHoneyBadgerStep<Tx, NodeUid>> {
         let step = self.dyn_hb.handle_message(sender_id, message)?;
-        let mut fault_log = FaultLog::new();
-        fault_log.extend(step.fault_log);
+        let mut fault_log = step.fault_log.clone();
         for batch in step.output {
             self.queue.remove_all(batch.iter());
             self.output.push_back(batch);
@@ -198,7 +197,7 @@ where
         &mut self,
         fault_log: FaultLog<NodeUid>,
     ) -> Result<QueueingHoneyBadgerStep<Tx, NodeUid>> {
-        Ok(Step::new(self.output.drain(0..).collect(), fault_log))
+        Ok(Step::new(self.output.drain(..).collect(), fault_log))
     }
 
     /// Returns a reference to the internal `DynamicHoneyBadger` instance.

--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -157,9 +157,11 @@ where
         sender_id: &NodeUid,
         message: Self::Message,
     ) -> Result<QueueingHoneyBadgerStep<Tx, NodeUid>> {
-        let step = self.dyn_hb.handle_message(sender_id, message)?;
-        let mut fault_log = step.fault_log.clone();
-        for batch in step.output {
+        let Step {
+            output,
+            mut fault_log,
+        } = self.dyn_hb.handle_message(sender_id, message)?;
+        for batch in output {
             self.queue.remove_all(batch.iter());
             self.output.push_back(batch);
         }

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Tests of the Binary Byzantine Agreement protocol. Only one proposer instance
 //! is tested. Each of the nodes in the simulated network run only one instance
 //! of Agreement. This way we only test correctness of the protocol and not

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -75,11 +75,11 @@ where
     for size in sizes {
         let num_faulty_nodes = (size - 1) / 3;
         let num_good_nodes = size - num_faulty_nodes;
-        info!(
-            "Network size: {} good nodes, {} faulty nodes",
-            num_good_nodes, num_faulty_nodes
-        );
         for &input in &[None, Some(false), Some(true)] {
+            info!(
+                "Test start: {} good nodes and {} faulty nodes, input: {:?}",
+                num_good_nodes, num_faulty_nodes, input
+            );
             let adversary = |_| new_adversary(num_good_nodes, num_faulty_nodes);
             let new_agreement = |netinfo: Arc<NetworkInfo<NodeUid>>| {
                 Agreement::new(netinfo, 0, NodeUid(0)).expect("agreement instance")
@@ -87,6 +87,10 @@ where
             let network =
                 TestNetwork::new(num_good_nodes, num_faulty_nodes, adversary, new_agreement);
             test_agreement(network, input);
+            info!(
+                "Test success: {} good nodes and {} faulty nodes, input: {:?}",
+                num_good_nodes, num_faulty_nodes, input
+            );
         }
     }
 }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -88,7 +88,8 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
             pk_set,
         ));
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
-        bc.input(b"Fake news".to_vec()).expect("propose");
+        // FIXME: Use the output.
+        let _ = bc.input(b"Fake news".to_vec()).expect("propose");
         bc.message_iter()
             .map(|msg| MessageWithSender::new(id, msg))
             .collect()

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Integration test of the reliable broadcast protocol.
 
 extern crate hbbft;

--- a/tests/common_coin.rs
+++ b/tests/common_coin.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Common Coin tests
 
 extern crate env_logger;

--- a/tests/common_subset.rs
+++ b/tests/common_subset.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Integration tests of the Asynchronous Common Subset protocol.
 
 extern crate env_logger;

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -66,6 +66,10 @@ where
                 }
             }
         }
+        debug!(
+            "{:?} min_missing {}, num_txs {}",
+            node.id, min_missing, num_txs
+        );
         if min_missing < num_txs {
             return true;
         }

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Network tests for Dynamic Honey Badger.
 
 extern crate hbbft;

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Network tests for Honey Badger.
 
 extern crate bincode;

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -38,8 +38,8 @@ impl<D: DistAlgorithm> TestNode<D> {
 
     /// Inputs a value into the instance.
     pub fn input(&mut self, input: D::Input) {
-        self.algo.input(input).expect("input");
-        self.outputs.extend(self.algo.output_iter());
+        let step = self.algo.input(input).expect("input");
+        self.outputs.extend(step.output);
     }
 
     /// Returns the internal algorithm's instance.
@@ -49,13 +49,12 @@ impl<D: DistAlgorithm> TestNode<D> {
     }
 
     /// Creates a new test node with the given broadcast instance.
-    fn new(mut algo: D) -> TestNode<D> {
-        let outputs = algo.output_iter().collect();
+    fn new(algo: D) -> TestNode<D> {
         TestNode {
             id: algo.our_id().clone(),
             algo,
             queue: VecDeque::new(),
-            outputs,
+            outputs: Vec::new(),
         }
     }
 
@@ -63,10 +62,11 @@ impl<D: DistAlgorithm> TestNode<D> {
     fn handle_message(&mut self) {
         let (from_id, msg) = self.queue.pop_front().expect("message not found");
         debug!("Handling {:?} -> {:?}: {:?}", from_id, self.id, msg);
-        self.algo
+        let step = self
+            .algo
             .handle_message(&from_id, msg)
             .expect("handling message");
-        self.outputs.extend(self.algo.output_iter());
+        self.outputs.extend(step.output);
     }
 }
 

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -15,7 +15,7 @@ pub struct NodeUid(pub usize);
 /// A "node" running an instance of the algorithm `D`.
 pub struct TestNode<D: DistAlgorithm> {
     /// This node's own ID.
-    id: D::NodeUid,
+    pub id: D::NodeUid,
     /// The instance of the broadcast algorithm.
     algo: D,
     /// Incoming messages from other nodes that this node has not yet handled.

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Network tests for Queueing Honey Badger.
 
 extern crate env_logger;

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -1,3 +1,4 @@
+#![deny(unused_must_use)]
 //! Tests for synchronous distributed key generation.
 
 extern crate env_logger;


### PR DESCRIPTION
This is a part of the refactoring undertaken to fix #66. It includes:

* the new algorithm output value API,

* integration with the earlier `FaultLog` functionality.

It does not include a new outgoing message API which will be included in a different PR considering the number of files involved in the refactoring and possible work on fixing tests.