### PR TITLE
Fix clippy lints.

### DIFF
--- a/src/agreement/bin_values.rs
+++ b/src/agreement/bin_values.rs
@@ -63,7 +63,7 @@ impl BinValues {
         }
     }
 
-    pub fn contains(&self, b: bool) -> bool {
+    pub fn contains(self, b: bool) -> bool {
         match self {
             BinValues::None => false,
             BinValues::Both => true,
@@ -73,7 +73,7 @@ impl BinValues {
         }
     }
 
-    pub fn is_subset(&self, other: BinValues) -> bool {
+    pub fn is_subset(self, other: BinValues) -> bool {
         match self {
             BinValues::None => true,
             BinValues::False if other == BinValues::False || other == BinValues::Both => true,
@@ -83,7 +83,7 @@ impl BinValues {
         }
     }
 
-    pub fn definite(&self) -> Option<bool> {
+    pub fn definite(self) -> Option<bool> {
         match self {
             BinValues::False => Some(false),
             BinValues::True => Some(true),

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -89,7 +89,7 @@ where
 
     /// Returns an iterator over all pending votes that are newer than their voter's committed
     /// vote.
-    pub fn pending_votes<'a>(&'a self) -> impl Iterator<Item = &'a SignedVote<NodeUid>> {
+    pub fn pending_votes(&self) -> impl Iterator<Item = &SignedVote<NodeUid>> {
         self.pending.values().filter(move |signed_vote| {
             self.committed
                 .get(&signed_vote.voter)


### PR DESCRIPTION
Extra lints have been added in the latest version of clippy; this fixes four instances of two of the new lints.

Before:

```
error: this argument is passed by reference, but would be more efficient if passed by value                     
  --> src/agreement/bin_values.rs:66:21
   |
66 |     pub fn contains(&self, b: bool) -> bool {
   |                     ^^^^^ help: consider passing by value instead: `self`
   |
   = note: `-D trivially-copy-pass-by-ref` implied by `-D clippy`
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.211/index.html#trivially_copy_pass_by_ref

error: this argument is passed by reference, but would be more efficient if passed by value
  --> src/agreement/bin_values.rs:76:22
   |
76 |     pub fn is_subset(&self, other: BinValues) -> bool {
   |                      ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.211/index.html#trivially_copy_pass_by_ref

error: this argument is passed by reference, but would be more efficient if passed by value
  --> src/agreement/bin_values.rs:86:21
   |
86 |     pub fn definite(&self) -> Option<bool> {
   |                     ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.211/index.html#trivially_copy_pass_by_ref

error: explicit lifetimes given in parameter types where they could be elided
  --> src/dynamic_honey_badger/votes.rs:92:5
   |
92 | /     pub fn pending_votes<'a>(&'a self) -> impl Iterator<Item = &'a SignedVote<NodeUid>> {
93 | |         self.pending.values().filter(move |signed_vote| {
94 | |             self.committed
95 | |                 .get(&signed_vote.voter)
96 | |                 .map_or(true, |vote| vote.num < signed_vote.vote.num)
97 | |         })
98 | |     }
   | |_____^
   |
   = note: `-D needless-lifetimes` implied by `-D clippy`
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.211/index.html#needless_lifetimes

error: aborting due to 4 previous errors

```