### PR TITLE
Tweak CI, now runs stable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 language: rust
 rust:
-    - nightly-2018-05-19
-cache: cargo
+    - stable
+cache:
+  cargo: true
+  timeout: 1200
 addons:
   apt:
     packages:
       - unzip
 before_install:
-  - rustup component add rustfmt-preview
-  - rustfmt --version
-  - cargo install clippy -f --vers=0.0.202
+  # The Rust stable toolchain is already installed, ${RUST_NEXT} is added to
+  # provide `cargo clippy` and `cargo fmt`.
+  - rustup toolchain install ${RUST_NEXT}
+  - rustup component add --toolchain=${RUST_NEXT} rustfmt-preview clippy-preview
+  # Some symlinking is still necessary for clippy to function properly.
+  - ln -s ${HOME}/.rustup/toolchains/${RUST_NEXT}-x86_64-unknown-linux-gnu/bin/clippy-driver ${HOME}/.rustup/toolchains/${RUST_NEXT}-x86_64-unknown-linux-gnu/bin/cargo-clippy $HOME/.cargo/bin/
 env:
   global:
     - RUST_BACKTRACE=1
     - RUSTFLAGS="-D warnings"
+    # Note: Currently (as of 2018-07-13), `clippy-preview` is only in the nightly
+    #       release. A version of `rustfmt` that supports the `--check` option
+    #       is also not in stable yet.
+    #
+    #       A Clear migration path is swapping out `nightly-2018-07-13` with
+    #       `beta` after the stable release of Rust 1.28; and finally migrating
+    #       everything to `stable` at Rust 1.29.
+    - RUST_NEXT=nightly-2018-07-13
 script:
-  - cargo clippy -- -D clippy
-  - cargo clippy --tests -- -D clippy
-  - cargo clippy --all-features -- -D clippy
-  - cargo clippy --all-features --tests -- -D clippy
-  - cargo fmt -- --check
-  - cargo check --tests --all-features
+  - cargo +${RUST_NEXT} clippy -- --deny clippy
+  - cargo +${RUST_NEXT} clippy --tests -- --deny clippy
+  - cargo +${RUST_NEXT} clippy --all-features -- --deny clippy
+  - cargo +${RUST_NEXT} clippy --all-features --tests -- --deny clippy
+  - cargo +${RUST_NEXT} fmt -- --check
   - cargo test --all-features --release


### PR DESCRIPTION
The following changes have been made to the Travis CI:

* The cache timeout has been increased, before builds would spend three minutes trying to cache something before giving up.
* The toolchain for building and testing has been switched to stable. A nightly version is still used to run `clippy` and `rustfmt`; however in both cases the toolchain binaries are used instead of compiling them from scratch.
* The `cargo check` pass has been removed; it simply tested whether or not the crate compiled against stable before compiling again against release. As there very, very few bugs that will cause a mismatch here (differences will be in execution), a trade-off was made in favor of compiling only once.

The CI is currently backed up with jobs for at least another hour or two; hopefully this will pass. If so, I would like to see it merged; otherwise expect incoming fixes.

Ideally, this will speed up the CI by a couple of minutes as well. 34 to 41 minutes is the current time to beat.