### PR TITLE
Add QueueingHoneyBadger::dyn_hb.

### DIFF
--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -189,6 +189,11 @@ where
         QueueingHoneyBadgerBuilder::new(netinfo)
     }
 
+    /// Returns a reference to the internal `DynamicHoneyBadger` instance.
+    pub fn dyn_hb(&self) -> &DynamicHoneyBadger<Vec<Tx>, NodeUid> {
+        &self.dyn_hb
+    }
+
     /// Initiates the next epoch by proposing a batch from the queue.
     fn propose(&mut self) -> Result<FaultLog<NodeUid>> {
         let amount = self.batch_size / self.dyn_hb.netinfo().num_nodes();


### PR DESCRIPTION
Needed to retrieve netinfo.

I'm not sure about the name or if we want it to be a permanent method at all but please add this so I don't have to keep cherry-picking it onto my updated branch every day :)