### PR TITLE
Add `Copy` to `PublicKey` derived impls.

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -29,7 +29,7 @@ const CHACHA_RNG_SEED_SIZE: usize = 8;
 const ERR_OS_RNG: &str = "could not initialize the OS random number generator";
 
 /// A public key, or a public key share.
-#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
 pub struct PublicKey(#[serde(with = "serde_impl::projective")] G1);
 
 impl Hash for PublicKey {


### PR DESCRIPTION
Just for convenience and consistency. The underlying type (`pairing::bls12_381::G1`, a `[u64; 6]`) already impls. `Copy`.