### PR TITLE
Separate keys and key shares.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - RUST_NEXT=nightly-2018-07-13
 script:
   - cargo +${RUST_NEXT} clippy -- --deny clippy
-  - cargo +${RUST_NEXT} clippy --tests -- --deny clippy
+  - cargo +${RUST_NEXT} clippy --tests --examples -- --deny clippy
   - cargo +${RUST_NEXT} clippy --all-features -- --deny clippy
   - cargo +${RUST_NEXT} clippy --all-features --tests -- --deny clippy
   - cargo +${RUST_NEXT} fmt -- --check

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -44,7 +44,7 @@ use std::{io, iter, process, thread, time};
 
 use hbbft::broadcast::{Broadcast, BroadcastMessage};
 use hbbft::crypto::poly::Poly;
-use hbbft::crypto::SecretKeySet;
+use hbbft::crypto::{SecretKey, SecretKeySet};
 use hbbft::messaging::{DistAlgorithm, NetworkInfo, SourcedMessage};
 use hbbft::proto::message::BroadcastProto;
 use network::commst;
@@ -107,10 +107,15 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
         // keys here. A fully-featured application would need to take appropriately initialized keys
         // from elsewhere.
         let secret_key_set = SecretKeySet::from(Poly::zero());
-        let secret_key = secret_key_set.secret_key_share(our_id as u64);
-        let public_key_set = secret_key_set.public_keys();
+        let sk_share = secret_key_set.secret_key_share(our_id as u64);
+        let pub_key_set = secret_key_set.public_keys();
+        let sk = SecretKey::default();
+        let pub_keys = all_ids
+            .iter()
+            .map(|id| (*id, SecretKey::default().public_key()))
+            .collect();
 
-        let netinfo = NetworkInfo::new(our_id, all_ids.clone(), secret_key, public_key_set);
+        let netinfo = NetworkInfo::new(our_id, sk_share, pub_key_set, sk, pub_keys);
 
         if value.is_some() != (our_id == 0) {
             panic!("Exactly the first node must propose a value.");

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -271,7 +271,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         proposer_id: NodeUid,
     ) -> AgreementResult<Self> {
         let invocation_id = netinfo.invocation_id();
-        if let Some(&proposer_i) = netinfo.node_index(&proposer_id) {
+        if let Some(proposer_i) = netinfo.node_index(&proposer_id) {
             Ok(Agreement {
                 netinfo: netinfo.clone(),
                 session_id,
@@ -670,7 +670,7 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         let nonce = Nonce::new(
             self.netinfo.invocation_id().as_ref(),
             self.session_id,
-            *self.netinfo.node_index(&self.proposer_id).unwrap(),
+            self.netinfo.node_index(&self.proposer_id).unwrap(),
             self.epoch,
         );
         // TODO: Don't spend time creating a `CommonCoin` instance in epochs where the common coin

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -159,10 +159,10 @@ impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
 
         // Create all agreement instances.
         let mut agreement_instances: BTreeMap<NodeUid, Agreement<NodeUid>> = BTreeMap::new();
-        for proposer_id in netinfo.all_uids().iter().cloned() {
+        for proposer_id in netinfo.all_uids() {
             agreement_instances.insert(
                 proposer_id.clone(),
-                Agreement::new(netinfo.clone(), session_id, proposer_id)?,
+                Agreement::new(netinfo.clone(), session_id, proposer_id.clone())?,
             );
         }
 

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -45,7 +45,7 @@
 //! pending change.
 
 use rand::Rand;
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
@@ -55,7 +55,7 @@ use bincode;
 use serde::{Deserialize, Serialize};
 
 use self::votes::{SignedVote, VoteCounter};
-use crypto::{PublicKeySet, SecretKey, Signature};
+use crypto::{PublicKey, PublicKeySet, SecretKey, SecretKeyShare, Signature};
 use fault_log::{FaultKind, FaultLog};
 use honey_badger::{HoneyBadger, HoneyBadgerStep, Message as HbMessage};
 use messaging::{DistAlgorithm, NetworkInfo, Step, Target, TargetedMessage};
@@ -72,7 +72,7 @@ mod change;
 mod error;
 mod votes;
 
-type KeyGenOutput = (PublicKeySet, Option<SecretKey>);
+type KeyGenOutput = (PublicKeySet, Option<SecretKeyShare>);
 
 /// The user input for `DynamicHoneyBadger`.
 #[derive(Clone, Debug)]
@@ -84,11 +84,7 @@ pub enum Input<C, NodeUid> {
 }
 
 /// A Honey Badger instance that can handle adding and removing nodes.
-pub struct DynamicHoneyBadger<C, NodeUid: Rand>
-where
-    C: Eq + Serialize + for<'r> Deserialize<'r> + Debug + Hash,
-    NodeUid: Ord + Clone + Serialize + for<'r> Deserialize<'r> + Debug,
-{
+pub struct DynamicHoneyBadger<C, NodeUid: Rand> {
     /// Shared network data.
     netinfo: NetworkInfo<NodeUid>,
     /// The maximum number of future epochs for which we handle messages simultaneously.
@@ -245,7 +241,7 @@ where
         sender_id: &NodeUid,
         message: HbMessage<NodeUid>,
     ) -> Result<FaultLog<NodeUid>> {
-        if !self.netinfo.all_uids().contains(sender_id) {
+        if !self.netinfo.is_node_validator(sender_id) {
             info!("Unknown sender {:?} of message {:?}", sender_id, message);
             return Err(ErrorKind::UnknownSender.into());
         }
@@ -312,7 +308,7 @@ where
                 // If DKG completed, apply the change.
                 debug!("{:?} DKG for {:?} complete!", self.our_id(), change);
                 // If we are a validator, we received a new secret key. Otherwise keep the old one.
-                let sk = sk.unwrap_or_else(|| self.netinfo.secret_key().clone());
+                let sk = sk.unwrap_or_else(|| self.netinfo.secret_key_share().clone());
                 // Restart Honey Badger in the next epoch, and inform the user about the change.
                 self.apply_change(&change, pub_key_set, sk, batch.epoch + 1)?;
                 batch.set_change(ChangeState::Complete(change), &self.netinfo);
@@ -344,19 +340,22 @@ where
         &mut self,
         change: &Change<NodeUid>,
         pub_key_set: PublicKeySet,
-        sk: SecretKey,
+        sk_share: SecretKeyShare,
         epoch: u64,
     ) -> Result<()> {
         self.key_gen = None;
-        let mut all_uids = self.netinfo.all_uids().clone();
-        if !match *change {
-            Change::Remove(ref id) => all_uids.remove(id),
-            Change::Add(ref id, _) => all_uids.insert(id.clone()),
+        let mut pub_keys = self.netinfo.public_key_map().clone();
+        if match *change {
+            Change::Remove(ref id) => pub_keys.remove(id).is_none(),
+            Change::Add(ref id, ref pub_key) => {
+                pub_keys.insert(id.clone(), pub_key.clone()).is_some()
+            }
         } {
             info!("No-op change: {:?}", change);
         }
-        let netinfo = NetworkInfo::new(self.our_id().clone(), all_uids, sk, pub_key_set);
-        self.netinfo = netinfo;
+        let sk = self.netinfo.secret_key().clone();
+        let our_id = self.our_id().clone();
+        self.netinfo = NetworkInfo::new(our_id, sk_share, pub_key_set, sk, pub_keys);
         self.restart_honey_badger(epoch)
     }
 
@@ -475,7 +474,7 @@ where
         kg_msg: &KeyGenMessage,
     ) -> Result<bool> {
         let ser = bincode::serialize(kg_msg)?;
-        let pk_opt = (self.netinfo.public_key_share(node_id)).or_else(|| {
+        let pk_opt = (self.netinfo.public_key(node_id)).or_else(|| {
             self.key_gen
                 .iter()
                 .filter_map(|&(_, ref change): &(_, Change<_>)| match *change {
@@ -573,8 +572,8 @@ pub struct JoinPlan<NodeUid: Ord> {
     epoch: u64,
     /// The current change. If `InProgress`, key generation for it is beginning at `epoch`.
     change: ChangeState<NodeUid>,
-    /// The set of all validators' node IDs.
-    all_uids: BTreeSet<NodeUid>,
     /// The current public key set for threshold cryptography.
     pub_key_set: PublicKeySet,
+    /// The public keys of the nodes taking part in key generation.
+    pub_keys: BTreeMap<NodeUid, PublicKey>,
 }

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -133,7 +133,7 @@ where
         sender_id: &NodeUid,
         message: Self::Message,
     ) -> HoneyBadgerResult<HoneyBadgerStep<C, NodeUid>> {
-        if !self.netinfo.all_uids().contains(sender_id) {
+        if !self.netinfo.is_node_validator(sender_id) {
             return Err(ErrorKind::UnknownSender.into());
         }
         let Message { epoch, content } = message;
@@ -428,7 +428,7 @@ where
         {
             let ids_u64: BTreeMap<&NodeUid, u64> = shares
                 .keys()
-                .map(|id| (id, *self.netinfo.node_index(id).unwrap() as u64))
+                .map(|id| (id, self.netinfo.node_index(id).unwrap() as u64))
                 .collect();
             let indexed_shares: BTreeMap<&u64, _> = shares
                 .into_iter()
@@ -492,7 +492,7 @@ where
         if !self.netinfo.is_validator() {
             return Ok((ciphertext.verify(), FaultLog::new()));
         }
-        let share = match self.netinfo.secret_key().decrypt_share(&ciphertext) {
+        let share = match self.netinfo.secret_key_share().decrypt_share(&ciphertext) {
             None => return Ok((false, FaultLog::new())),
             Some(share) => share,
         };

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -43,7 +43,7 @@ use rand::OsRng;
 
 use crypto::poly::{BivarCommitment, BivarPoly, Poly};
 use crypto::serde_impl::field_vec::FieldWrap;
-use crypto::{Ciphertext, PublicKey, PublicKeySet, SecretKey};
+use crypto::{Ciphertext, PublicKey, PublicKeySet, SecretKey, SecretKeyShare};
 use fault_log::{FaultKind, FaultLog};
 
 // TODO: No need to send our own row and value to ourselves.
@@ -237,7 +237,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
     ///
     /// These are only secure if `is_ready` returned `true`. Otherwise it is not guaranteed that
     /// none of the nodes knows the secret master key.
-    pub fn generate(&self) -> (PublicKeySet, Option<SecretKey>) {
+    pub fn generate(&self) -> (PublicKeySet, Option<SecretKeyShare>) {
         let mut pk_commit = Poly::zero().commitment();
         let mut opt_sk_val = self.our_idx.map(|_| Fr::zero());
         let is_complete = |proposal: &&ProposalState| proposal.is_complete(self.threshold);
@@ -248,7 +248,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
                 sk_val.add_assign(&row.evaluate(0));
             }
         }
-        let opt_sk = opt_sk_val.map(SecretKey::from_value);
+        let opt_sk = opt_sk_val.map(SecretKeyShare::from_value);
         (pk_commit.into(), opt_sk)
     }
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use rand::Rng;
 
 use hbbft::broadcast::{Broadcast, BroadcastMessage};
-use hbbft::crypto::SecretKeySet;
 use hbbft::messaging::{DistAlgorithm, NetworkInfo, Target, TargetedMessage};
 use network::{
     Adversary, MessageScheduler, MessageWithSender, NodeUid, RandomAdversary, SilentAdversary,
@@ -78,16 +77,7 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         };
 
         // FIXME: Take the correct, known keys from the network.
-        let mut rng = rand::thread_rng();
-        let sk_set = SecretKeySet::random(self.adv_nodes.len(), &mut rng);
-        let pk_set = sk_set.public_keys();
-
-        let netinfo = Arc::new(NetworkInfo::new(
-            id,
-            node_ids,
-            sk_set.secret_key_share(0),
-            pk_set,
-        ));
+        let netinfo = Arc::new(NetworkInfo::generate_map(node_ids).remove(&id).unwrap());
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
         // FIXME: Use the output.
         let _ = bc.input(b"Fake news".to_vec()).expect("propose");

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -97,7 +97,11 @@ where
         network.step();
         // Once all nodes have processed the removal of node 0, add it again.
         if !input_add && network.nodes.values().all(has_remove) {
-            let pk = network.pk_set.public_key_share(0);
+            let pk = network.nodes[&NodeUid(0)]
+                .instance()
+                .netinfo()
+                .secret_key()
+                .public_key();
             network.input_all(Input::Change(Change::Add(NodeUid(0), pk)));
             input_add = true;
         }

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -100,7 +100,7 @@ impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
                         .public_key()
                         .encrypt(fake_proposal);
                     let share = adv_node
-                        .secret_key()
+                        .secret_key_share()
                         .decrypt_share(&fake_ciphertext)
                         .expect("decryption share");
                     // Send the share to remote nodes.

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -16,7 +16,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
     let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| rand::random()).collect();
     let pub_keys: BTreeMap<usize, PublicKey> = sec_keys
         .iter()
-        .map(|sk| sk.public_key())
+        .map(SecretKey::public_key)
         .enumerate()
         .collect();
 


### PR DESCRIPTION
This adds another map of public keys to `NetworkInfo`: It is unsafe to use key _shares_ as keys.

Since creating a new `NetworkInfo` is even more complicated now, `NetworkInfo::generate_map` creates a set of matching instances for testing.

(I also noticed that Clippy wasn't applied to the example, so I added it and fixed the lints.)

Closes #131 