### PR TITLE
Extend DKG docs, rename messages, add into_network_info.

### DIFF
--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -106,7 +106,7 @@ where
             output: VecDeque::new(),
         };
         if let ChangeState::InProgress(ref change) = self.change {
-            dhb.update_key_gen(self.start_epoch, change.clone())?;
+            dhb.update_key_gen(self.start_epoch, change)?;
         }
         Ok(dhb)
     }

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -29,10 +29,10 @@ pub enum FaultKind {
     /// `DynamicHoneyBadger` received a message (Accept, Propose, or Change)
     /// with an invalid signature.
     IncorrectPayloadSignature,
-    /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Accept message.
-    InvalidAcceptMessage,
-    /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Propose message.
-    InvalidProposeMessage,
+    /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Ack message.
+    InvalidAckMessage,
+    /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Part message.
+    InvalidPartMessage,
     /// `DynamicHoneyBadger` received a change vote with an invalid signature.
     InvalidVoteSignature,
     /// A validator committed an invalid vote in `DynamicHoneyBadger`.

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -26,7 +26,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
         .into_iter()
         .enumerate()
         .map(|(id, sk)| {
-            let (sync_key_gen, proposal) = SyncKeyGen::new(&id, sk, pub_keys.clone(), threshold);
+            let (sync_key_gen, proposal) = SyncKeyGen::new(id, sk, pub_keys.clone(), threshold);
             nodes.push(sync_key_gen);
             proposal
         })

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -9,7 +9,7 @@ extern crate rand;
 use std::collections::BTreeMap;
 
 use hbbft::crypto::{PublicKey, SecretKey};
-use hbbft::sync_key_gen::{ProposeOutcome, SyncKeyGen};
+use hbbft::sync_key_gen::{PartOutcome, SyncKeyGen};
 
 fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
     // Generate individual key pairs for encryption. These are not suitable for threshold schemes.
@@ -33,26 +33,26 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
         .collect();
 
     // Handle the first `threshold + 1` proposals. Those should suffice for key generation.
-    let mut accepts = Vec::new();
+    let mut acks = Vec::new();
     for (sender_id, proposal) in proposals[..=threshold].iter().enumerate() {
         for (node_id, node) in nodes.iter_mut().enumerate() {
             let proposal = proposal.clone().expect("proposal");
-            let accept = match node.handle_propose(&sender_id, proposal) {
-                Some(ProposeOutcome::Valid(accept)) => accept,
+            let ack = match node.handle_part(&sender_id, proposal) {
+                Some(PartOutcome::Valid(ack)) => ack,
                 _ => panic!("invalid proposal"),
             };
-            // Only the first `threshold + 1` manage to commit their `Accept`s.
+            // Only the first `threshold + 1` manage to commit their `Ack`s.
             if node_id <= 2 * threshold {
-                accepts.push((node_id, accept));
+                acks.push((node_id, ack));
             }
         }
     }
 
-    // Handle the `Accept`s from `2 * threshold + 1` nodes.
-    for (sender_id, accept) in accepts {
+    // Handle the `Ack`s from `2 * threshold + 1` nodes.
+    for (sender_id, ack) in acks {
         for node in &mut nodes {
-            assert!(!node.is_ready()); // Not enough `Accept`s yet.
-            node.handle_accept(&sender_id, accept.clone());
+            assert!(!node.is_ready()); // Not enough `Ack`s yet.
+            node.handle_ack(&sender_id, ack.clone());
         }
     }
 


### PR DESCRIPTION
This adds a "Usage" section to the `sync_key_gen` module and extends some item documentation, too.

The new `SyncKeyGen::into_network_info` method avoids cloning the (non-threshold) keys and helps simplify `DynamicHoneyBadger` a bit.

Finally, `Propose` and `Accept` are renamed to `Part` and `Ack`:
* Structs ideally shouldn't have verbs as their name.
* "`Proposal`"/"`Propose`" suggests that it's a proposal for the actual final keys, but in fact it's just a summand for them. Every node is supposed to contribute a `Part`, and in the ideal case, every node's `Part` will be used.
* "`Ack`" is much shorter than "`Acceptance`" or "`Acknowledgement`".