### PR TITLE
Add `From<SecretKey>` impl for `SecretKeyShare`.

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -255,6 +255,12 @@ impl SecretKeyShare {
     }
 }
 
+impl From<SecretKey> for SecretKeyShare {
+    fn from(sk: SecretKey) -> SecretKeyShare {
+        SecretKeyShare(sk)
+    }
+}
+
 /// An encrypted message.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Ciphertext(


### PR DESCRIPTION
I have no idea what the implications of this are, security wise, nor do I know if it's a silly way to create a `SecretKeyShare` from a `SecretKey` but this appears to be necessary for me to create a `NetworkInfo` when spawning a new node joining an existing network.

I'm rushing trying to get things working so please let me know if I've missed something and this is unnecessary!