### PR TITLE
Accept more types in threshold crypto API.

### DIFF
--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -107,7 +107,7 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
         // keys here. A fully-featured application would need to take appropriately initialized keys
         // from elsewhere.
         let secret_key_set = SecretKeySet::from(Poly::zero());
-        let sk_share = secret_key_set.secret_key_share(our_id as u64);
+        let sk_share = secret_key_set.secret_key_share(our_id);
         let pub_key_set = secret_key_set.public_keys();
         let sk = SecretKey::default();
         let pub_keys = all_ids

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -207,16 +207,8 @@ where
 
     fn combine_and_verify_sig(&self) -> Result<Signature> {
         // Pass the indices of sender nodes to `combine_signatures`.
-        let ids_shares: BTreeMap<&NodeUid, &SignatureShare> = self.received_shares.iter().collect();
-        let ids_u64: BTreeMap<&NodeUid, u64> = ids_shares
-            .keys()
-            .map(|&id| (id, self.netinfo.node_index(id).unwrap() as u64))
-            .collect();
-        // Convert indices to `u64` which is an interface type for `pairing`.
-        let shares: BTreeMap<&u64, &SignatureShare> = ids_shares
-            .iter()
-            .map(|(id, &share)| (&ids_u64[id], share))
-            .collect();
+        let to_idx = |(id, share)| (self.netinfo.node_index(id).unwrap(), share);
+        let shares = self.received_shares.iter().map(to_idx);
         let sig = self.netinfo.public_key_set().combine_signatures(shares)?;
         if !self
             .netinfo

--- a/src/crypto/into_fr.rs
+++ b/src/crypto/into_fr.rs
@@ -1,0 +1,55 @@
+use pairing::bls12_381::Fr;
+use pairing::{Field, PrimeField};
+
+/// A conversion into an element of the field `Fr`.
+pub trait IntoFr: Copy {
+    fn into_fr(self) -> Fr;
+}
+
+impl IntoFr for Fr {
+    fn into_fr(self) -> Fr {
+        self
+    }
+}
+
+impl IntoFr for u64 {
+    fn into_fr(self) -> Fr {
+        Fr::from_repr(self.into()).expect("modulus is greater than u64::MAX")
+    }
+}
+
+impl IntoFr for usize {
+    fn into_fr(self) -> Fr {
+        (self as u64).into_fr()
+    }
+}
+
+impl IntoFr for i32 {
+    fn into_fr(self) -> Fr {
+        if self >= 0 {
+            (self as u64).into_fr()
+        } else {
+            let mut result = ((-self) as u64).into_fr();
+            result.negate();
+            result
+        }
+    }
+}
+
+impl IntoFr for i64 {
+    fn into_fr(self) -> Fr {
+        if self >= 0 {
+            (self as u64).into_fr()
+        } else {
+            let mut result = ((-self) as u64).into_fr();
+            result.negate();
+            result
+        }
+    }
+}
+
+impl<'a, T: IntoFr> IntoFr for &'a T {
+    fn into_fr(self) -> Fr {
+        (*self).into_fr()
+    }
+}

--- a/src/honey_badger.rs
+++ b/src/honey_badger.rs
@@ -435,19 +435,11 @@ where
             .get(&self.epoch)
             .and_then(|cts| cts.get(&proposer_id))
         {
-            let ids_u64: BTreeMap<&NodeUid, u64> = shares
-                .keys()
-                .map(|id| (id, self.netinfo.node_index(id).unwrap() as u64))
-                .collect();
-            let indexed_shares: BTreeMap<&u64, _> = shares
-                .into_iter()
-                .map(|(id, share)| (&ids_u64[id], share))
-                .collect();
-            match self
-                .netinfo
-                .public_key_set()
-                .decrypt(indexed_shares, ciphertext)
-            {
+            match {
+                let to_idx = |(id, share)| (self.netinfo.node_index(id).unwrap(), share);
+                let share_itr = shares.into_iter().map(to_idx);
+                self.netinfo.public_key_set().decrypt(share_itr, ciphertext)
+            } {
                 Ok(contrib) => {
                     self.decrypted_contributions.insert(proposer_id, contrib);
                 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -233,7 +233,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
             .collect();
         let public_key_shares = node_indices
             .iter()
-            .map(|(id, idx)| (id.clone(), public_key_set.public_key_share(*idx as u64)))
+            .map(|(id, idx)| (id.clone(), public_key_set.public_key_share(*idx)))
             .collect();
         NetworkInfo {
             our_uid,
@@ -362,7 +362,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
         let create_netinfo = |(i, uid): (usize, NodeUid)| {
             let netinfo = NetworkInfo::new(
                 uid.clone(),
-                sk_set.secret_key_share(i as u64),
+                sk_set.secret_key_share(i),
                 pk_set.clone(),
                 sec_keys[&uid].clone(),
                 pub_keys.clone(),

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -106,18 +106,18 @@
 //!     let (pks, opt_sks) = node.generate();
 //!     assert_eq!(pks, pub_key_set); // All nodes now know the public keys and public key shares.
 //!     let sks = opt_sks.expect("Not an observer node: We receive a secret key share.");
-//!     secret_key_shares.insert(id as u64, sks);
+//!     secret_key_shares.insert(id, sks);
 //! }
 //!
 //! // Three out of four nodes can now sign a message. Each share can be verified individually.
 //! let msg = "Nodes 0 and 1 does not agree with this.";
-//! let mut sig_shares: BTreeMap<u64, SignatureShare> = BTreeMap::new();
+//! let mut sig_shares: BTreeMap<usize, SignatureShare> = BTreeMap::new();
 //! for (&id, sks) in &secret_key_shares {
 //!     if id != 0 && id != 1 {
 //!         let sig_share = sks.sign(msg);
-//!         let pks = pub_key_set.public_key_share(id as u64);
+//!         let pks = pub_key_set.public_key_share(id);
 //!         assert!(pks.verify(&sig_share, msg));
-//!         sig_shares.insert(id as u64, sig_share);
+//!         sig_shares.insert(id, sig_share);
 //!     }
 //! }
 //!
@@ -286,7 +286,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
         let our_part = BivarPoly::random(threshold, &mut rng);
         let commit = our_part.commitment();
         let encrypt = |(i, pk): (usize, &PublicKey)| {
-            let row = our_part.row(i as u64 + 1);
+            let row = our_part.row(i + 1);
             let bytes = bincode::serialize(&row).expect("failed to serialize row");
             pk.encrypt(&bytes)
         };
@@ -334,7 +334,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
         }
         // The row is valid: now encrypt one value for each node.
         let encrypt = |(idx, pk): (usize, &PublicKey)| {
-            let val = row.evaluate(idx as u64 + 1);
+            let val = row.evaluate(idx + 1);
             let wrap = FieldWrap::new(val);
             // TODO: Handle errors.
             let ser_val = bincode::serialize(&wrap).expect("failed to serialize value");

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -68,8 +68,8 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
             let sk = opt_sk.expect("new secret key");
             assert_eq!(pks, pub_key_set);
             let sig = sk.sign(msg);
-            assert!(pks.public_key_share(idx as u64).verify(&sig, msg));
-            (idx as u64, sig)
+            assert!(pks.public_key_share(idx).verify(&sig, msg));
+            (idx, sig)
         })
         .collect();
     let sig = pub_key_set


### PR DESCRIPTION
This removes some unnecessary allocation and conversion by accepting
more primitive types and references as the index in threshold decryption
and signing, and as the argument to a polynomial.

It also adds scalar multiplication, addition and subtraction to `Poly` for convenience.