### PR TITLE
Added mlocking for secret types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "poanetwork/hbbft" }
 bincode = "1.0.0"
 byteorder = "1.2.3"
 env_logger = "0.5.10"
+errno = "0.2.4"
 error-chain = "0.11.0"
 init_with = "1.1.0"
 itertools = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ error-chain = "0.11.0"
 init_with = "1.1.0"
 itertools = "0.7"
 log = "0.4.1"
+memsec = "0.5.4"
 merkle = { git = "https://github.com/afck/merkle.rs", branch = "public-proof", features = [ "serialization-serde" ] }
 pairing = { version = "0.14.2", features = ["u128-support"] }
 protobuf = { version = "2.0.0", optional = true }

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -106,8 +106,8 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
         // required by the interface to all algorithms in Honey Badger. Therefore we set placeholder
         // keys here. A fully-featured application would need to take appropriately initialized keys
         // from elsewhere.
-        let secret_key_set = SecretKeySet::from(Poly::zero());
-        let sk_share = secret_key_set.secret_key_share(our_id);
+        let secret_key_set = SecretKeySet::from(Poly::zero().unwrap());
+        let sk_share = secret_key_set.secret_key_share(our_id).unwrap();
         let pub_key_set = secret_key_set.public_keys();
         let sk = SecretKey::default();
         let pub_keys = all_ids

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -268,7 +268,7 @@ where
     where
         F: Fn(NetworkInfo<NodeUid>) -> (D, Step<D>),
     {
-        let netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid));
+        let netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid)).unwrap();
         let new_node = |(uid, netinfo): (NodeUid, NetworkInfo<_>)| {
             (uid, TestNode::new(new_algo(netinfo), hw_quality))
         };

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -70,7 +70,7 @@
 //!     let mut rng = thread_rng();
 //!
 //!     // Create a random set of keys for testing.
-//!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES);
+//!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES).unwrap();
 //!
 //!     // Create initial nodes by instantiating a `Broadcast` for each.
 //!     let mut nodes = BTreeMap::new();

--- a/src/crypto/error.rs
+++ b/src/crypto/error.rs
@@ -6,5 +6,13 @@ error_chain! {
         DuplicateEntry {
             description("signature shares contain a duplicated index")
         }
+        MlockFailed(desc: String) {
+            description("failed mlock a region of memory")
+            display("{}", desc)
+        }
+        MunlockFailed(desc: String) {
+            description("failed munlock a region of memory")
+            display("{}", desc)
+        }
     }
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -15,6 +15,7 @@ use std::mem::size_of_val;
 use std::ptr::{copy_nonoverlapping, write_volatile};
 
 use byteorder::{BigEndian, ByteOrder};
+use errno::errno;
 use init_with::InitWith;
 use memsec::{memzero, mlock, munlock};
 use pairing::bls12_381::{Bls12, Fr, G1, G1Affine, G2, G2Affine};
@@ -230,7 +231,7 @@ impl ContainsSecret for SecretKey {
         if mlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to mlock `SecretKey` memory".to_string();
+            let msg = format!("failed to mlock `SecretKey` memory ({:?})", errno());
             Err(ErrorKind::MlockFailed(msg).into())
         }
     }
@@ -242,7 +243,7 @@ impl ContainsSecret for SecretKey {
         if munlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to munlock `SecretKey` memory".to_string();
+            let msg = format!("failed to munlock `SecretKey` memory ({:?})", errno());
             Err(ErrorKind::MunlockFailed(msg).into())
         }
     }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -226,9 +226,7 @@ impl ContainsSecret for SecretKey {
     fn mlock_secret_memory(&self) -> Result<()> {
         let ptr = &*self.0 as *const Fr as *mut u8;
         let n_bytes = size_of_val(&*self.0);
-        let mlock_succeeded = unsafe {
-            mlock(ptr, n_bytes)
-        };
+        let mlock_succeeded = unsafe { mlock(ptr, n_bytes) };
         if mlock_succeeded {
             Ok(())
         } else {
@@ -240,9 +238,7 @@ impl ContainsSecret for SecretKey {
     fn munlock_secret_memory(&self) -> Result<()> {
         let ptr = &*self.0 as *const Fr as *mut u8;
         let n_bytes = size_of_val(&*self.0);
-        let munlock_succeeded = unsafe {
-            munlock(ptr, n_bytes)
-        };
+        let munlock_succeeded = unsafe { munlock(ptr, n_bytes) };
         if munlock_succeeded {
             Ok(())
         } else {
@@ -644,9 +640,18 @@ mod tests {
         assert_ne!(pk_set.public_key(), pk_set.public_key_share(2).0);
 
         // Make sure we don't hand out the main secret key to anyone.
-        assert_ne!(sk_set.secret_key().unwrap(), sk_set.secret_key_share(0).unwrap().0);
-        assert_ne!(sk_set.secret_key().unwrap(), sk_set.secret_key_share(1).unwrap().0);
-        assert_ne!(sk_set.secret_key().unwrap(), sk_set.secret_key_share(2).unwrap().0);
+        assert_ne!(
+            sk_set.secret_key().unwrap(),
+            sk_set.secret_key_share(0).unwrap().0
+        );
+        assert_ne!(
+            sk_set.secret_key().unwrap(),
+            sk_set.secret_key_share(1).unwrap().0
+        );
+        assert_ne!(
+            sk_set.secret_key().unwrap(),
+            sk_set.secret_key_share(2).unwrap().0
+        );
 
         let msg = "Totally real news";
 

--- a/src/crypto/poly.rs
+++ b/src/crypto/poly.rs
@@ -22,6 +22,7 @@ use std::hash::{Hash, Hasher};
 use std::mem::{size_of, size_of_val};
 use std::{cmp, iter, ops};
 
+use errno::errno;
 use memsec::{memzero, mlock, munlock};
 use pairing::bls12_381::{Fr, G1, G1Affine};
 use pairing::{CurveAffine, CurveProjective, Field};
@@ -258,7 +259,7 @@ impl ContainsSecret for Poly {
         if mlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to mlock `Poly` coefficients".to_string();
+            let msg = format!("failed to mlock `Poly` coefficients ({:?})", errno());
             Err(ErrorKind::MlockFailed(msg).into())
         }
     }
@@ -270,7 +271,7 @@ impl ContainsSecret for Poly {
         if munlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to munlock `Poly` coefficients".to_string();
+            let msg = format!("failed to munlock `Poly` coefficients ({:?})", errno());
             Err(ErrorKind::MunlockFailed(msg).into())
         }
     }
@@ -386,7 +387,7 @@ impl Poly {
         if munlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to munlock truncated `Poly`".to_string();
+            let msg = format!("failed to munlock truncated `Poly` ({:?})", errno());
             Err(ErrorKind::MunlockFailed(msg).into())
         }
     }
@@ -395,16 +396,14 @@ impl Poly {
     fn extend_mlock(&self, len: usize) -> Result<()> {
         let n_bytes_extended = len * size_of::<Fr>();
         let offset = (self.coeff.len() - len) as isize;
-
         let mlock_succeeded = unsafe {
             let ptr = self.coeff.as_ptr().offset(offset) as *mut u8;
             mlock(ptr, n_bytes_extended)
         };
-
         if mlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to extend `Poly` mlock".to_string();
+            let msg = format!("failed to extend `Poly` mlock ({:?})", errno());
             Err(ErrorKind::MlockFailed(msg).into())
         }
     }
@@ -570,7 +569,7 @@ impl ContainsSecret for BivarPoly {
         if mlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to mlock `BivarPoly` coefficients".to_string();
+            let msg = format!("failed to mlock `BivarPoly` coefficients ({:?})", errno());
             Err(ErrorKind::MlockFailed(msg).into())
         }
     }
@@ -582,7 +581,7 @@ impl ContainsSecret for BivarPoly {
         if munlock_succeeded {
             Ok(())
         } else {
-            let msg = "failed to munlock `BivarPoly` coefficients".to_string();
+            let msg = format!("failed to munlock `BivarPoly` coefficients ({:?})", errno());
             Err(ErrorKind::MlockFailed(msg).into())
         }
     }

--- a/src/crypto/poly.rs
+++ b/src/crypto/poly.rs
@@ -41,7 +41,7 @@ impl Clone for Poly {
     fn clone(&self) -> Self {
         match Poly::new(self.coeff.clone()) {
             Ok(poly) => poly,
-            Err(e) =>  panic!("{}", e),
+            Err(e) => panic!("{}", e),
         }
     }
 }
@@ -54,6 +54,7 @@ impl fmt::Debug for Poly {
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(suspicious_op_assign_impl))]
 impl<B: Borrow<Poly>> ops::AddAssign<B> for Poly {
     fn add_assign(&mut self, rhs: B) {
         let len = self.coeff.len();
@@ -193,10 +194,10 @@ impl<'a, B: Borrow<Poly>> ops::Mul<B> for &'a Poly {
                 c
             })
             .collect();
-    
+
         match Poly::new(coeff) {
             Ok(poly) => poly,
-            Err(e) => panic!("{}", e)
+            Err(e) => panic!("{}", e),
         }
     }
 }
@@ -243,7 +244,7 @@ impl<'a> ops::Mul<u64> for Poly {
 impl Drop for Poly {
     fn drop(&mut self) {
         self.zero_secret_memory();
-        if let Err(e) =  self.munlock_secret_memory() {
+        if let Err(e) = self.munlock_secret_memory() {
             panic!("{}", e);
         }
     }
@@ -253,9 +254,7 @@ impl ContainsSecret for Poly {
     fn mlock_secret_memory(&self) -> Result<()> {
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
-        let mlock_succeeded = unsafe {
-            mlock(ptr, n_bytes)
-        };
+        let mlock_succeeded = unsafe { mlock(ptr, n_bytes) };
         if mlock_succeeded {
             Ok(())
         } else {
@@ -267,9 +266,7 @@ impl ContainsSecret for Poly {
     fn munlock_secret_memory(&self) -> Result<()> {
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
-        let munlock_succeeded = unsafe {
-            munlock(ptr, n_bytes)
-        };
+        let munlock_succeeded = unsafe { munlock(ptr, n_bytes) };
         if munlock_succeeded {
             Ok(())
         } else {
@@ -383,9 +380,7 @@ impl Poly {
     fn truncate_mlock(&self, len: usize) -> Result<()> {
         let n_bytes_truncated = len * size_of::<Fr>();
         let munlock_succeeded = unsafe {
-            let ptr = self.coeff.as_ptr()
-                .offset(self.coeff.len() as isize)
-                as *mut u8;
+            let ptr = self.coeff.as_ptr().offset(self.coeff.len() as isize) as *mut u8;
             munlock(ptr, n_bytes_truncated)
         };
         if munlock_succeeded {
@@ -405,7 +400,7 @@ impl Poly {
             let ptr = self.coeff.as_ptr().offset(offset) as *mut u8;
             mlock(ptr, n_bytes_extended)
         };
-        
+
         if mlock_succeeded {
             Ok(())
         } else {
@@ -543,7 +538,7 @@ impl Clone for BivarPoly {
             degree: self.degree,
             coeff: self.coeff.clone(),
         };
-        if let Err(e) =  self.mlock_secret_memory() {
+        if let Err(e) = self.mlock_secret_memory() {
             panic!("{}", e);
         }
         poly
@@ -571,9 +566,7 @@ impl ContainsSecret for BivarPoly {
     fn mlock_secret_memory(&self) -> Result<()> {
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
-        let mlock_succeeded = unsafe {
-            mlock(ptr, n_bytes)
-        };
+        let mlock_succeeded = unsafe { mlock(ptr, n_bytes) };
         if mlock_succeeded {
             Ok(())
         } else {
@@ -585,9 +578,7 @@ impl ContainsSecret for BivarPoly {
     fn munlock_secret_memory(&self) -> Result<()> {
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
-        let munlock_succeeded = unsafe {
-            munlock(ptr, n_bytes)
-        };
+        let munlock_succeeded = unsafe { munlock(ptr, n_bytes) };
         if munlock_succeeded {
             Ok(())
         } else {
@@ -843,7 +834,8 @@ mod tests {
                 }
 
                 // A cheating dealer who modified the polynomial would be detected.
-                let wrong_poly = row_poly.clone() + Poly::monomial(2).unwrap() * Poly::constant(5.into_fr()).unwrap();
+                let wrong_poly = row_poly.clone()
+                    + Poly::monomial(2).unwrap() * Poly::constant(5.into_fr()).unwrap();
                 assert_ne!(wrong_poly.commitment(), row_commit);
 
                 // If `2 * faulty_num + 1` nodes confirm that they received a valid row, then at

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -67,15 +67,15 @@ where
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
-    pub fn build_first_node(&self, our_uid: NodeUid) -> DynamicHoneyBadger<C, NodeUid> {
+    pub fn build_first_node(&self, our_uid: NodeUid) -> Result<DynamicHoneyBadger<C, NodeUid>> {
         let mut rng = rand::thread_rng();
-        let sk_set = SecretKeySet::random(0, &mut rng);
+        let sk_set = SecretKeySet::random(0, &mut rng)?;
         let pk_set = sk_set.public_keys();
-        let sks = sk_set.secret_key_share(0);
+        let sks = sk_set.secret_key_share(0)?;
         let sk: SecretKey = rng.gen();
         let pub_keys = once((our_uid.clone(), sk.public_key())).collect();
         let netinfo = NetworkInfo::new(our_uid, sks, pk_set, sk, pub_keys);
-        self.build(netinfo)
+        Ok(self.build(netinfo))
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to join the network at the epoch specified in

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -1,9 +1,11 @@
 use bincode;
 
+use crypto;
 use honey_badger;
 
 error_chain!{
     links {
+        Crypto(crypto::Error, crypto::ErrorKind);
         HoneyBadger(honey_badger::Error, honey_badger::ErrorKind);
     }
 

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -290,7 +290,7 @@ where
             if let Some((key_gen, change)) = self.take_ready_key_gen() {
                 // If DKG completed, apply the change, restart Honey Badger, and inform the user.
                 debug!("{:?} DKG for {:?} complete!", self.our_id(), change);
-                self.netinfo = key_gen.into_network_info();
+                self.netinfo = key_gen.into_network_info()?;
                 self.restart_honey_badger(batch.epoch + 1);
                 batch.set_change(ChangeState::Complete(change), &self.netinfo);
             } else if let Some(change) = self.vote_counter.compute_majority().cloned() {
@@ -331,7 +331,7 @@ where
         let threshold = (pub_keys.len() - 1) / 3;
         let sk = self.netinfo.secret_key().clone();
         let our_uid = self.our_id().clone();
-        let (key_gen, part) = SyncKeyGen::new(our_uid, sk, pub_keys, threshold);
+        let (key_gen, part) = SyncKeyGen::new(our_uid, sk, pub_keys, threshold)?;
         self.key_gen = Some((key_gen, change.clone()));
         if let Some(part) = part {
             self.send_transaction(KeyGenMessage::Part(part))

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -195,7 +195,7 @@ mod tests {
     /// order.
     fn setup(node_num: usize, era: u64) -> (Vec<VoteCounter<usize>>, Vec<Vec<SignedVote<usize>>>) {
         // Create keys for threshold cryptography.
-        let netinfos = NetworkInfo::generate_map(0..node_num);
+        let netinfos = NetworkInfo::generate_map(0..node_num).unwrap();
 
         // Create a `VoteCounter` instance for each node.
         let create_counter =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@
 
 extern crate bincode;
 extern crate byteorder;
+extern crate errno;
 #[macro_use]
 extern crate error_chain;
 extern crate init_with;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ extern crate init_with;
 #[macro_use]
 extern crate log;
 extern crate itertools;
+extern crate memsec;
 extern crate merkle;
 extern crate pairing;
 #[cfg(feature = "serialization-protobuf")]

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -402,7 +402,7 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
                 sk_val.add_assign(&row.evaluate(0));
             }
         }
-        let opt_sk = opt_sk_val.map(SecretKeyShare::from_value);
+        let opt_sk = opt_sk_val.map(|mut fr| SecretKeyShare::from_mut_ptr(&mut fr as *mut Fr));
         (pk_commit.into(), opt_sk)
     }
 

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -292,7 +292,8 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
             let bytes = bincode::serialize(&row).expect("failed to serialize row");
             Ok(pk.encrypt(&bytes))
         };
-        let rows = key_gen.pub_keys
+        let rows = key_gen
+            .pub_keys
             .values()
             .enumerate()
             .map(encrypt)
@@ -406,10 +407,9 @@ impl<NodeUid: Ord + Clone + Debug> SyncKeyGen<NodeUid> {
                 sk_val.add_assign(&row.evaluate(0));
             }
         }
-        let opt_sk = opt_sk_val.map_or(
-            Ok(None),
-            |mut fr| SecretKeyShare::from_mut_ptr(&mut fr as *mut Fr).map(Some)
-        )?;
+        let opt_sk = opt_sk_val.map_or(Ok(None), |mut fr| {
+            SecretKeyShare::from_mut_ptr(&mut fr as *mut Fr).map(Some)
+        })?;
         Ok((pk_commit.into(), opt_sk))
     }
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -77,7 +77,12 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         };
 
         // FIXME: Take the correct, known keys from the network.
-        let netinfo = Arc::new(NetworkInfo::generate_map(node_ids).unwrap().remove(&id).unwrap());
+        let netinfo = Arc::new(
+            NetworkInfo::generate_map(node_ids)
+                .unwrap()
+                .remove(&id)
+                .unwrap(),
+        );
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
         // FIXME: Use the output.
         let step = bc.input(b"Fake news".to_vec()).expect("propose");

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -77,7 +77,7 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         };
 
         // FIXME: Take the correct, known keys from the network.
-        let netinfo = Arc::new(NetworkInfo::generate_map(node_ids).remove(&id).unwrap());
+        let netinfo = Arc::new(NetworkInfo::generate_map(node_ids).unwrap().remove(&id).unwrap());
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
         // FIXME: Use the output.
         let step = bc.input(b"Fake news".to_vec()).expect("propose");

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -398,7 +398,7 @@ where
         G: Fn(BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>) -> A,
     {
         let mut rng = rand::thread_rng();
-        let mut netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid));
+        let mut netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid)).unwrap();
         let obs_netinfo = {
             let node_ni = netinfos.values().next().unwrap();
             NetworkInfo::new(

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -398,7 +398,8 @@ where
         G: Fn(BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>) -> A,
     {
         let mut rng = rand::thread_rng();
-        let mut netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid)).unwrap();
+        let mut netinfos =
+            NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid)).unwrap();
         let obs_netinfo = {
             let node_ni = netinfos.values().next().unwrap();
             NetworkInfo::new(

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -26,7 +26,8 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
         .into_iter()
         .enumerate()
         .map(|(id, sk)| {
-            let (sync_key_gen, proposal) = SyncKeyGen::new(id, sk, pub_keys.clone(), threshold).unwrap();
+            let (sync_key_gen, proposal) =
+                SyncKeyGen::new(id, sk, pub_keys.clone(), threshold).unwrap();
             nodes.push(sync_key_gen);
             proposal
         })

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -13,7 +13,7 @@ use hbbft::sync_key_gen::{PartOutcome, SyncKeyGen};
 
 fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
     // Generate individual key pairs for encryption. These are not suitable for threshold schemes.
-    let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| rand::random()).collect();
+    let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| SecretKey::random()).collect();
     let pub_keys: BTreeMap<usize, PublicKey> = sec_keys
         .iter()
         .map(SecretKey::public_key)
@@ -26,7 +26,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
         .into_iter()
         .enumerate()
         .map(|(id, sk)| {
-            let (sync_key_gen, proposal) = SyncKeyGen::new(id, sk, pub_keys.clone(), threshold);
+            let (sync_key_gen, proposal) = SyncKeyGen::new(id, sk, pub_keys.clone(), threshold).unwrap();
             nodes.push(sync_key_gen);
             proposal
         })
@@ -58,13 +58,13 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
 
     // Compute the keys and test a threshold signature.
     let msg = "Help I'm trapped in a unit test factory";
-    let pub_key_set = nodes[0].generate().0;
+    let pub_key_set = nodes[0].generate().unwrap().0;
     let sig_shares: BTreeMap<_, _> = nodes
         .iter()
         .enumerate()
         .map(|(idx, node)| {
             assert!(node.is_ready());
-            let (pks, opt_sk) = node.generate();
+            let (pks, opt_sk) = node.generate().unwrap();
             let sk = opt_sk.expect("new secret key");
             assert_eq!(pks, pub_key_set);
             let sig = sk.sign(msg);


### PR DESCRIPTION
- Added trait `ContainsSecret`.
- Added `mlock` and `munlock` for secret types.
- Removed stack copying of secret prime field elements.
- Changed `SecretKey(Fr)` to `SecretKey(Box<Fr>)`.
- Added [`memsec`](https://crates.io/crates/memsec) dependency.
- Redacted `Debug` implementations of secrets.

Closes Issue #89

# Request for Comments

@vkomenda @afck @c0gent @mbr

Regarding the recent error handling debates, I'm not sure how to handle errors from syscalls. You will see in places where `ContainsSecret` is implemented that I just print out when an `mlock` or `munlock` call fails. 2/3rds of the `ContainsSecret` trait methods are only called from the `drop()` method, which can't return an error. Is this a case for `panic()`?

This PR is **NOT** ready to be merged until this is discussed because `println!("You're crypto is broke")` is probably not the ideal way to handle memory errors.