### PR TITLE
Replace `chain_error` with `failure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "poanetwork/hbbft" }
 bincode = "1.0.0"
 byteorder = "1.2.3"
 env_logger = "0.5.10"
-error-chain = "0.11.0"
+failure = "0.1"
 init_with = "1.1.0"
 itertools = "0.7"
 log = "0.4.1"

--- a/src/crypto/error.rs
+++ b/src/crypto/error.rs
@@ -1,10 +1,13 @@
-error_chain! {
-    errors {
-        NotEnoughShares {
-            description("not enough signature shares")
-        }
-        DuplicateEntry {
-            description("signature shares contain a duplicated index")
-        }
-    }
+//! Crypto errors.
+
+/// A crypto error.
+#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+pub enum Error {
+    #[fail(display = "Not enough signature shares")]
+    NotEnoughShares,
+    #[fail(display = "Signature shares contain a duplicated index")]
+    DuplicateEntry,
 }
+
+/// A crypto result.
+pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -20,7 +20,7 @@ use pairing::{CurveAffine, CurveProjective, Engine, Field};
 use rand::{ChaChaRng, OsRng, Rng, SeedableRng};
 use ring::digest;
 
-use self::error::{ErrorKind, Result};
+use self::error::{Error, Result};
 use self::into_fr::IntoFr;
 use self::poly::{Commitment, Poly};
 use fmt::HexBytes;
@@ -459,13 +459,13 @@ where
         .map(|(i, sample)| (into_fr_plus_1(i), sample))
         .collect();
     if samples.len() < t {
-        return Err(ErrorKind::NotEnoughShares.into());
+        return Err(Error::NotEnoughShares);
     }
     let mut result = C::zero();
     let mut indexes = Vec::new();
     for (x, sample) in samples.iter().take(t) {
         if indexes.contains(x) {
-            return Err(ErrorKind::DuplicateEntry.into());
+            return Err(Error::DuplicateEntry);
         }
         indexes.push(x.clone());
         // Compute the value at 0 of the Lagrange polynomial that is `0` at the other data

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -1,17 +1,70 @@
 use bincode;
-
+use failure::{Backtrace, Context, Fail};
 use honey_badger;
+use std::fmt::{self, Display};
 
-error_chain!{
-    links {
-        HoneyBadger(honey_badger::Error, honey_badger::ErrorKind);
+/// Dynamic honey badger error variants.
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "SendTransactionBincode error: {}", _0)]
+    SendTransactionBincode(bincode::ErrorKind),
+    #[fail(display = "VerifySignatureBincode error: {}", _0)]
+    VerifySignatureBincode(bincode::ErrorKind),
+    #[fail(display = "SignVoteForBincode error: {}", _0)]
+    SignVoteForBincode(bincode::ErrorKind),
+    #[fail(display = "ValidateBincode error: {}", _0)]
+    ValidateBincode(bincode::ErrorKind),
+    #[fail(display = "ProposeHoneyBadger error: {}", _0)]
+    ProposeHoneyBadger(honey_badger::Error),
+    #[fail(
+        display = "HandleHoneyBadgerMessageHoneyBadger error: {}",
+        _0
+    )]
+    HandleHoneyBadgerMessageHoneyBadger(honey_badger::Error),
+    #[fail(display = "Unknown sender")]
+    UnknownSender,
+}
+
+/// A dynamic honey badger error.
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
     }
 
-    foreign_links {
-        Bincode(Box<bincode::ErrorKind>);
-    }
-
-    errors {
-        UnknownSender
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
     }
 }
+
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 extern crate bincode;
 extern crate byteorder;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 extern crate init_with;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
### Changes

* Remove `error_chain` and convert errors to `failure` types.
* Add variants for each possible error generation point.
    * Allows the user to programatically determine the precise origin of each error.
    * Obviates the need for backtraces. 

### Other Possibilities

* The verbose Error + ErrorKind (E + EK) failure pattern has been used for 'top-level' error-returning modules (`*honey_badger`) as a convenience to the user (it includes backtraces automatically). These are not strictly necessary and the simpler (Error only) pattern could be used instead. The E + EK pattern, though more cumbersome, is also more future-proof and versatile.

### Unfinished

- [ ] Come up with more meaningful / permanent names and display messages for the following error variants (also see [this comment](https://github.com/poanetwork/hbbft/pull/166#issuecomment-409027594)):
  * `agreement::Error::HandleCoinCommonCoin`, `TryFinishConfRoundCommonCoin`
  * `broadcast::Error::CodingNewReedSolomon`, `CodingEncodeReedSolomon`, 
`CodingReconstructShardsReedSolomon`, `CodingReconstructShardsTrivialReedSolomon`
  * `common_coin::Error::CombineAndVerifySigCrypto`
  * `common_subset::Error::NewAgreement`, `ProcessAgreementAgreement0`, `ProcessAgreementAgreement1`, `NewBroadcast`, `ProcessBroadcastBroadcast`
  * `honey_badger::Error::ProposeBincode`, `ProposeCommonSubset0`, `ProposeCommonSubset1`, `HandleCommonMessageCommonSubset0`, `HandleCommonMessageCommonSubset1`
  * `dynamic_honey_badger::Error::SendTransactionBincode`, `VerifySignatureBincode`, `SignVoteForBincode`, `ValidateBincode`, `ProposeHoneyBadger`, `HandleHoneyBadgerMessageHoneyBadger`
- [x] Simple documentation on each type and variant (pending renaming of variants, etc.).
- [ ] Decide whether or not to apply the E + EK (+ Context) pattern to more error types. The advantage to this pattern is mainly automatic creation of backtraces. (Conversions to E + EK errors is another benefit but I argue that we should stray from the norm and not use on non-contextual conversions.)
- [x] Squash commits.

Closes #142 