### PR TITLE
Fix agreement bugs, and refactor a few fields.

### DIFF
--- a/src/agreement/bin_values.rs
+++ b/src/agreement/bin_values.rs
@@ -1,5 +1,6 @@
 use std::iter::FromIterator;
 use std::mem::replace;
+use std::vec;
 
 /// A lattice-valued description of the state of `bin_values`, essentially the same as the set of
 /// subsets of `bool`.
@@ -107,5 +108,19 @@ impl FromIterator<BinValues> for BinValues {
         }
 
         v
+    }
+}
+
+impl IntoIterator for BinValues {
+    type Item = bool;
+    type IntoIter = vec::IntoIter<bool>;
+
+    fn into_iter(self) -> vec::IntoIter<bool> {
+        match self {
+            BinValues::None => vec![].into_iter(),
+            BinValues::False => vec![false].into_iter(),
+            BinValues::True => vec![true].into_iter(),
+            BinValues::Both => vec![false, true].into_iter(),
+        }
     }
 }

--- a/src/agreement/bin_values.rs
+++ b/src/agreement/bin_values.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 use std::mem::replace;
-use std::vec;
+use std::slice;
 
 /// A lattice-valued description of the state of `bin_values`, essentially the same as the set of
 /// subsets of `bool`.
@@ -111,16 +111,23 @@ impl FromIterator<BinValues> for BinValues {
     }
 }
 
-impl IntoIterator for BinValues {
-    type Item = bool;
-    type IntoIter = vec::IntoIter<bool>;
+// Statically allocated slices for constructing `BinValues` iterators:
 
-    fn into_iter(self) -> vec::IntoIter<bool> {
+const NONE: &[bool] = &[];
+const FALSE: &[bool] = &[false];
+const TRUE: &[bool] = &[true];
+const BOTH: &[bool] = &[false, true];
+
+impl IntoIterator for BinValues {
+    type Item = &'static bool;
+    type IntoIter = slice::Iter<'static, bool>;
+
+    fn into_iter(self) -> Self::IntoIter {
         match self {
-            BinValues::None => vec![].into_iter(),
-            BinValues::False => vec![false].into_iter(),
-            BinValues::True => vec![true].into_iter(),
-            BinValues::Both => vec![false, true].into_iter(),
+            BinValues::None => NONE.into_iter(),
+            BinValues::False => FALSE.into_iter(),
+            BinValues::True => TRUE.into_iter(),
+            BinValues::Both => BOTH.into_iter(),
         }
     }
 }

--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -594,9 +594,9 @@ impl<NodeUid: Clone + Debug + Ord> Agreement<NodeUid> {
         let mut values = BinValues::None;
         let mut count = 0;
         for b in self.bin_values {
-            let b_count = self.received_aux.get(&b).map_or(0, BTreeSet::len);
+            let b_count = self.received_aux.get(b).map_or(0, BTreeSet::len);
             if b_count > 0 {
-                values.insert(b);
+                values.insert(*b);
                 count += b_count;
             }
         }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -444,9 +444,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
         // Save the proof for reconstructing the tree later.
         self.echos.insert(sender_id.clone(), p);
 
-        if self.ready_sent
-            || self.count_echos(&hash) < self.netinfo.num_nodes() - self.netinfo.num_faulty()
-        {
+        if self.ready_sent || self.count_echos(&hash) < self.netinfo.num_correct() {
             return self.compute_output(&hash);
         }
 

--- a/src/common_coin.rs
+++ b/src/common_coin.rs
@@ -166,20 +166,20 @@ where
     }
 
     fn try_output(&mut self) -> Result<Step<NodeUid, T>> {
-        let received_shares = &self.received_shares;
         debug!(
             "{:?} received {} shares, had_input = {}",
             self.netinfo.our_uid(),
-            received_shares.len(),
+            self.received_shares.len(),
             self.had_input
         );
-        if self.had_input && received_shares.len() > self.netinfo.num_faulty() {
+        if self.had_input && self.received_shares.len() > self.netinfo.num_faulty() {
             let sig = self.combine_and_verify_sig()?;
             // Output the parity of the verified signature.
             let parity = sig.parity();
             debug!("{:?} output {}", self.netinfo.our_uid(), parity);
             self.terminated = true;
-            Ok(Step::default().with_output(parity))
+            let step = self.input(())?; // Before terminating, make sure we sent our share.
+            Ok(step.with_output(parity))
         } else {
             Ok(Step::default())
         }

--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -247,7 +247,7 @@ impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
             self.agreement_results
         );
 
-        if value && self.count_true() == self.netinfo.num_nodes() - self.netinfo.num_faulty() {
+        if value && self.count_true() == self.netinfo.num_correct() {
             // Upon delivery of value 1 from at least N − f instances of BA, provide
             // input 0 to each instance of BA that has not yet been provided input.
             for (uid, agreement) in &mut self.agreement_instances {
@@ -271,8 +271,7 @@ impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
     }
 
     fn try_agreement_completion(&mut self) -> Option<BTreeMap<NodeUid, ProposedValue>> {
-        if self.decided || self.count_true() < self.netinfo.num_nodes() - self.netinfo.num_faulty()
-        {
+        if self.decided || self.count_true() < self.netinfo.num_correct() {
             return None;
         }
         // Once all instances of BA have completed, let C ⊂ [1..N] be

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -37,6 +37,10 @@ pub enum FaultKind {
     InvalidVoteSignature,
     /// A validator committed an invalid vote in `DynamicHoneyBadger`.
     InvalidCommittedVote,
+    /// `Agreement` received a duplicate `BVal` message.
+    DuplicateBVal,
+    /// `Agreement` received a duplicate `Aux` message.
+    DuplicateAux,
 }
 
 /// A structure representing the context of a faulty node. This structure

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -275,15 +275,21 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
         self.public_keys.keys()
     }
 
-    /// The total number of nodes.
+    /// The total number _N_ of nodes.
     pub fn num_nodes(&self) -> usize {
         self.num_nodes
     }
 
-    /// The maximum number of faulty, Byzantine nodes up to which Honey Badger is guaranteed to be
-    /// correct.
+    /// The maximum number _f_ of faulty, Byzantine nodes up to which Honey Badger is guaranteed to
+    /// be correct.
     pub fn num_faulty(&self) -> usize {
         self.num_faulty
+    }
+
+    /// The minimum number _N - f_ of correct nodes with which Honey Badger is guaranteed to be
+    /// correct.
+    pub fn num_correct(&self) -> usize {
+        self.num_nodes - self.num_faulty
     }
 
     /// Returns our secret key share for threshold cryptography.


### PR DESCRIPTION
* Don't drop `Term` messages from previous epochs. They are still
  relevant for all future epochs.
* Restructure some fields to avoid unnecessary iteration and counting.
* Simplify the fields related to the common coin.
* Reorder the methods, so that the message handlers are all in one
  place.
* Handle the case where the coin value arrives before the required
  number of `Conf` messages.