### PR TITLE
Change the QHB criterion for moving on to the next epoch.

### DIFF
--- a/src/common_subset.rs
+++ b/src/common_subset.rs
@@ -164,6 +164,11 @@ impl<NodeUid: Clone + Debug + Ord + Rand> CommonSubset<NodeUid> {
         self.process_broadcast(&uid, |bc| bc.input(value))
     }
 
+    /// Returns the number of validators from which we have already received a proposal.
+    pub(crate) fn received_proposals(&self) -> usize {
+        self.broadcast_results.len()
+    }
+
     /// Receives a broadcast message from a remote node `sender_id` concerning a
     /// value proposed by the node `proposer_id`.
     fn handle_broadcast(

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -61,7 +61,7 @@ where
             vote_counter: VoteCounter::new(arc_netinfo, 0),
             key_gen_msg_buffer: Vec::new(),
             honey_badger,
-            key_gen: None,
+            key_gen_state: None,
             incoming_queue: Vec::new(),
         }
     }
@@ -104,7 +104,7 @@ where
             vote_counter: VoteCounter::new(arc_netinfo, join_plan.epoch),
             key_gen_msg_buffer: Vec::new(),
             honey_badger,
-            key_gen: None,
+            key_gen_state: None,
             incoming_queue: Vec::new(),
         };
         let step = match join_plan.change {

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -26,6 +26,11 @@ pub enum FaultKind {
     /// `DynamicHoneyBadger` received a key generation message with an invalid
     /// signature.
     InvalidKeyGenMessageSignature,
+    /// `DynamicHoneyBadger` received a key generation message when there was no key generation in
+    /// progress.
+    UnexpectedKeyGenMessage,
+    /// `DynamicHoneyBadger` received more key generation messages from the candidate than expected.
+    TooManyCandidateKeyGenMessages,
     /// `DynamicHoneyBadger` received a message (Accept, Propose, or Change)
     /// with an invalid signature.
     IncorrectPayloadSignature,

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -132,6 +132,14 @@ where
         !self.netinfo.is_validator() || self.has_input
     }
 
+    /// Returns the number of validators from which we have already received a proposal for the
+    /// current epoch.
+    pub(crate) fn received_proposals(&self) -> usize {
+        self.common_subsets
+            .get(&self.epoch)
+            .map_or(0, CommonSubset::received_proposals)
+    }
+
     /// Handles a message for the given epoch.
     fn handle_message_content(
         &mut self,

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -70,12 +70,6 @@ where
 
     // Handle messages in random order until all nodes have output all transactions.
     while network.nodes.values().any(node_busy) {
-        // Remove all messages belonging to epochs after all expected outputs.
-        for node in network.nodes.values_mut().filter(|node| !node_busy(node)) {
-            if let Some(last) = node.outputs().last().map(Batch::epoch) {
-                node.queue.retain(|(_, ref msg)| msg.epoch() < last);
-            }
-        }
         // If a node is expecting input, take it from the queue. Otherwise handle a message.
         let input_ids: Vec<_> = network
             .nodes

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -134,14 +134,7 @@ where
     // Returns `true` if the node has not output all transactions yet.
     // If it has, and has advanced another epoch, it clears all messages for later epochs.
     let node_busy = |node: &mut TestNode<UsizeHoneyBadger>| {
-        if node.outputs().iter().flat_map(Batch::iter).unique().count() < num_txs {
-            return true;
-        }
-        if node.outputs().last().unwrap().is_empty() {
-            let last = node.outputs().last().unwrap().epoch;
-            node.queue.retain(|(_, ref msg)| msg.epoch() < last);
-        }
-        false
+        node.outputs().iter().flat_map(Batch::iter).unique().count() < num_txs
     };
 
     let mut rng = rand::thread_rng();

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -63,10 +63,6 @@ fn test_queueing_honey_badger<A>(
         if node.outputs().iter().flat_map(Batch::iter).unique().count() < num_txs {
             return true;
         }
-        if node.outputs().last().unwrap().is_empty() {
-            let last = node.outputs().last().unwrap().epoch();
-            node.queue.retain(|(_, ref msg)| msg.epoch() < last);
-        }
         false
     };
 


### PR DESCRIPTION
`QueueingHoneyBadger` now waits after an output, and only makes its
proposal for the next epoch when:

* there are pending transactions in the queue,
* there are pending key generation or vote messages, or
* _f + 1_ other validators have already made their proposal.

This rule should work well for small networks: With 1 - 3 nodes, it will
produce a new batch whenever at least one of them has transactions to
contribute. In larger networks, it prevents an adversary controlling _f_
nodes from producing lots of empty epochs.

An exception is made for a currently joining validator: We will commit
up to _(N + 1)² + 1_ key generation messages for them, which is the
maximum number a correct node will send.

Closes #147.