### PR TITLE
Add common supertraits and rename related type parameters.

### DIFF
--- a/src/agreement/mod.rs
+++ b/src/agreement/mod.rs
@@ -92,7 +92,7 @@ pub enum Error {
 /// An agreement result.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
-pub type Step<NodeUid> = messaging::Step<Agreement<NodeUid>>;
+pub type Step<N> = messaging::Step<Agreement<N>>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum AgreementContent {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -163,6 +163,7 @@ use ring::digest;
 use fault_log::{Fault, FaultKind};
 use fmt::{HexBytes, HexList, HexProof};
 use messaging::{self, DistAlgorithm, NetworkInfo, Target};
+use traits::NodeUidT;
 
 /// A broadcast error.
 #[derive(Clone, PartialEq, Debug, Fail)]
@@ -239,11 +240,11 @@ impl Debug for BroadcastMessage {
 
 /// Reliable Broadcast algorithm instance.
 #[derive(Debug)]
-pub struct Broadcast<NodeUid> {
+pub struct Broadcast<N> {
     /// Shared network data.
-    netinfo: Arc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<N>>,
     /// The UID of the sending node.
-    proposer_id: NodeUid,
+    proposer_id: N,
     data_shard_num: usize,
     coding: Coding,
     /// Whether we have already multicast `Echo`.
@@ -253,15 +254,15 @@ pub struct Broadcast<NodeUid> {
     /// Whether we have already output a value.
     decided: bool,
     /// The proofs we have received via `Echo` messages, by sender ID.
-    echos: BTreeMap<NodeUid, Proof<Vec<u8>>>,
+    echos: BTreeMap<N, Proof<Vec<u8>>>,
     /// The root hashes we received via `Ready` messages, by sender ID.
-    readys: BTreeMap<NodeUid, Vec<u8>>,
+    readys: BTreeMap<N, Vec<u8>>,
 }
 
-pub type Step<NodeUid> = messaging::Step<Broadcast<NodeUid>>;
+pub type Step<N> = messaging::Step<Broadcast<N>>;
 
-impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
-    type NodeUid = NodeUid;
+impl<N: NodeUidT> DistAlgorithm for Broadcast<N> {
+    type NodeUid = N;
     // TODO: Allow anything serializable and deserializable, i.e. make this a type parameter
     // T: Serialize + DeserializeOwned
     type Input = Vec<u8>;
@@ -269,7 +270,7 @@ impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
     type Message = BroadcastMessage;
     type Error = Error;
 
-    fn input(&mut self, input: Self::Input) -> Result<Step<NodeUid>> {
+    fn input(&mut self, input: Self::Input) -> Result<Step<N>> {
         if *self.netinfo.our_uid() != self.proposer_id {
             return Err(Error::InstanceCannotPropose);
         }
@@ -282,11 +283,7 @@ impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
         Ok(step)
     }
 
-    fn handle_message(
-        &mut self,
-        sender_id: &NodeUid,
-        message: Self::Message,
-    ) -> Result<Step<NodeUid>> {
+    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<N>> {
         if !self.netinfo.is_node_validator(sender_id) {
             return Err(Error::UnknownSender);
         }
@@ -301,15 +298,15 @@ impl<NodeUid: Debug + Clone + Ord> DistAlgorithm for Broadcast<NodeUid> {
         self.decided
     }
 
-    fn our_id(&self) -> &NodeUid {
+    fn our_id(&self) -> &N {
         self.netinfo.our_uid()
     }
 }
 
-impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
+impl<N: NodeUidT> Broadcast<N> {
     /// Creates a new broadcast instance to be used by node `our_id` which expects a value proposal
     /// from node `proposer_id`.
-    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>, proposer_id: NodeUid) -> Result<Self> {
+    pub fn new(netinfo: Arc<NetworkInfo<N>>, proposer_id: N) -> Result<Self> {
         let parity_shard_num = 2 * netinfo.num_faulty();
         let data_shard_num = netinfo.num_nodes() - parity_shard_num;
         let coding = Coding::new(data_shard_num, parity_shard_num)?;
@@ -332,7 +329,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     /// scheme. The returned value contains the shard assigned to this
     /// node. That shard doesn't need to be sent anywhere. It gets recorded in
     /// the broadcast instance.
-    fn send_shards(&mut self, mut value: Vec<u8>) -> Result<(Proof<Vec<u8>>, Step<NodeUid>)> {
+    fn send_shards(&mut self, mut value: Vec<u8>) -> Result<(Proof<Vec<u8>>, Step<N>)> {
         let data_shard_num = self.coding.data_shard_count();
         let parity_shard_num = self.coding.parity_shard_count();
 
@@ -407,7 +404,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     }
 
     /// Handles a received echo and verifies the proof it contains.
-    fn handle_value(&mut self, sender_id: &NodeUid, p: Proof<Vec<u8>>) -> Result<Step<NodeUid>> {
+    fn handle_value(&mut self, sender_id: &N, p: Proof<Vec<u8>>) -> Result<Step<N>> {
         // If the sender is not the proposer or if this is not the first `Value`, ignore.
         if *sender_id != self.proposer_id {
             info!(
@@ -439,7 +436,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     }
 
     /// Handles a received `Echo` message.
-    fn handle_echo(&mut self, sender_id: &NodeUid, p: Proof<Vec<u8>>) -> Result<Step<NodeUid>> {
+    fn handle_echo(&mut self, sender_id: &N, p: Proof<Vec<u8>>) -> Result<Step<N>> {
         // If the sender has already sent `Echo`, ignore.
         if self.echos.contains_key(sender_id) {
             info!(
@@ -469,7 +466,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     }
 
     /// Handles a received `Ready` message.
-    fn handle_ready(&mut self, sender_id: &NodeUid, hash: &[u8]) -> Result<Step<NodeUid>> {
+    fn handle_ready(&mut self, sender_id: &N, hash: &[u8]) -> Result<Step<N>> {
         // If the sender has already sent a `Ready` before, ignore.
         if self.readys.contains_key(sender_id) {
             info!(
@@ -494,7 +491,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     }
 
     /// Sends an `Echo` message and handles it. Does nothing if we are only an observer.
-    fn send_echo(&mut self, p: Proof<Vec<u8>>) -> Result<Step<NodeUid>> {
+    fn send_echo(&mut self, p: Proof<Vec<u8>>) -> Result<Step<N>> {
         self.echo_sent = true;
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
@@ -507,7 +504,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
     }
 
     /// Sends a `Ready` message and handles it. Does nothing if we are only an observer.
-    fn send_ready(&mut self, hash: &[u8]) -> Result<Step<NodeUid>> {
+    fn send_ready(&mut self, hash: &[u8]) -> Result<Step<N>> {
         self.ready_sent = true;
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
@@ -521,7 +518,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
 
     /// Checks whether the conditions for output are met for this hash, and if so, sets the output
     /// value.
-    fn compute_output(&mut self, hash: &[u8]) -> Result<Step<NodeUid>> {
+    fn compute_output(&mut self, hash: &[u8]) -> Result<Step<N>> {
         if self.decided
             || self.count_readys(hash) <= 2 * self.netinfo.num_faulty()
             || self.count_echos(hash) < self.coding.data_shard_count()
@@ -555,7 +552,7 @@ impl<NodeUid: Debug + Clone + Ord> Broadcast<NodeUid> {
 
     /// Returns `true` if the proof is valid and has the same index as the node ID. Otherwise
     /// logs an info message.
-    fn validate_proof(&self, p: &Proof<Vec<u8>>, id: &NodeUid) -> bool {
+    fn validate_proof(&self, p: &Proof<Vec<u8>>, id: &N) -> bool {
         if !p.validate(&p.root_hash) {
             info!(
                 "Node {:?} received invalid proof: {:?}",

--- a/src/dynamic_honey_badger/change.rs
+++ b/src/dynamic_honey_badger/change.rs
@@ -2,16 +2,16 @@ use crypto::PublicKey;
 
 /// A node change action: adding or removing a node.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
-pub enum Change<NodeUid> {
+pub enum Change<N> {
     /// Add a node. The public key is used only temporarily, for key generation.
-    Add(NodeUid, PublicKey),
+    Add(N, PublicKey),
     /// Remove a node.
-    Remove(NodeUid),
+    Remove(N),
 }
 
-impl<NodeUid> Change<NodeUid> {
+impl<N> Change<N> {
     /// Returns the ID of the current candidate for being added, if any.
-    pub fn candidate(&self) -> Option<&NodeUid> {
+    pub fn candidate(&self) -> Option<&N> {
         match *self {
             Change::Add(ref id, _) => Some(id),
             Change::Remove(_) => None,
@@ -21,13 +21,13 @@ impl<NodeUid> Change<NodeUid> {
 
 /// A change status: whether a node addition or removal is currently in progress or completed.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
-pub enum ChangeState<NodeUid> {
+pub enum ChangeState<N> {
     /// No node is currently being considered for addition or removal.
     None,
     /// A change is currently in progress. If it is an addition, all broadcast messages must be
     /// sent to the new node, too.
-    InProgress(Change<NodeUid>),
+    InProgress(Change<N>),
     /// A change has been completed in this epoch. From the next epoch on, the new composition of
     /// the network will perform the consensus process.
-    Complete(Change<NodeUid>),
+    Complete(Change<N>),
 }

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -1,6 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Debug;
-use std::hash::Hash;
 use std::sync::Arc;
 
 use bincode;
@@ -10,30 +8,31 @@ use serde::{Deserialize, Serialize};
 use super::{Change, ErrorKind, Result};
 use fault_log::{FaultKind, FaultLog};
 use messaging::NetworkInfo;
+use traits::NodeUidT;
 
 /// A buffer and counter collecting pending and committed votes for validator set changes.
 ///
 /// This is reset whenever the set of validators changes or a change reaches _f + 1_ votes. We call
 /// the epochs since the last reset the current _era_.
 #[derive(Debug)]
-pub struct VoteCounter<NodeUid> {
+pub struct VoteCounter<N> {
     /// Shared network data.
-    netinfo: Arc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<N>>,
     /// The epoch when voting was reset.
     era: u64,
     /// Pending node transactions that we will propose in the next epoch.
-    pending: BTreeMap<NodeUid, SignedVote<NodeUid>>,
+    pending: BTreeMap<N, SignedVote<N>>,
     /// Collected votes for adding or removing nodes. Each node has one vote, and casting another
     /// vote revokes the previous one.
-    committed: BTreeMap<NodeUid, Vote<NodeUid>>,
+    committed: BTreeMap<N, Vote<N>>,
 }
 
-impl<NodeUid> VoteCounter<NodeUid>
+impl<N> VoteCounter<N>
 where
-    NodeUid: Eq + Hash + Ord + Clone + Debug + Serialize + for<'r> Deserialize<'r>,
+    N: NodeUidT + Serialize + for<'r> Deserialize<'r>,
 {
     /// Creates a new `VoteCounter` object with empty buffer and counter.
-    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>, era: u64) -> Self {
+    pub fn new(netinfo: Arc<NetworkInfo<N>>, era: u64) -> Self {
         VoteCounter {
             era,
             netinfo,
@@ -43,7 +42,7 @@ where
     }
 
     /// Creates a signed vote for the given change, and inserts it into the pending votes buffer.
-    pub fn sign_vote_for(&mut self, change: Change<NodeUid>) -> Result<&SignedVote<NodeUid>> {
+    pub fn sign_vote_for(&mut self, change: Change<N>) -> Result<&SignedVote<N>> {
         let voter = self.netinfo.our_uid().clone();
         let vote = Vote {
             change,
@@ -64,9 +63,9 @@ where
     /// Inserts a pending vote into the buffer, if it has a higher number than the existing one.
     pub fn add_pending_vote(
         &mut self,
-        sender_id: &NodeUid,
-        signed_vote: SignedVote<NodeUid>,
-    ) -> Result<FaultLog<NodeUid>> {
+        sender_id: &N,
+        signed_vote: SignedVote<N>,
+    ) -> Result<FaultLog<N>> {
         if signed_vote.vote.era != self.era
             || self
                 .pending
@@ -87,7 +86,7 @@ where
 
     /// Returns an iterator over all pending votes that are newer than their voter's committed
     /// vote.
-    pub fn pending_votes(&self) -> impl Iterator<Item = &SignedVote<NodeUid>> {
+    pub fn pending_votes(&self) -> impl Iterator<Item = &SignedVote<N>> {
         self.pending.values().filter(move |signed_vote| {
             self.committed
                 .get(&signed_vote.voter)
@@ -98,11 +97,11 @@ where
     // TODO: Document and return fault logs?
     pub fn add_committed_votes<I>(
         &mut self,
-        proposer_id: &NodeUid,
+        proposer_id: &N,
         signed_votes: I,
-    ) -> Result<FaultLog<NodeUid>>
+    ) -> Result<FaultLog<N>>
     where
-        I: IntoIterator<Item = SignedVote<NodeUid>>,
+        I: IntoIterator<Item = SignedVote<N>>,
     {
         let mut fault_log = FaultLog::new();
         for signed_vote in signed_votes {
@@ -114,9 +113,9 @@ where
     /// Inserts a committed vote into the counter, if it has a higher number than the existing one.
     pub fn add_committed_vote(
         &mut self,
-        proposer_id: &NodeUid,
-        signed_vote: SignedVote<NodeUid>,
-    ) -> Result<FaultLog<NodeUid>> {
+        proposer_id: &N,
+        signed_vote: SignedVote<N>,
+    ) -> Result<FaultLog<N>> {
         if self
             .committed
             .get(&signed_vote.voter)
@@ -135,8 +134,8 @@ where
     }
 
     /// Returns the change that has at least _f + 1_ votes, if any.
-    pub fn compute_winner(&self) -> Option<&Change<NodeUid>> {
-        let mut vote_counts: HashMap<&Change<NodeUid>, usize> = HashMap::new();
+    pub fn compute_winner(&self) -> Option<&Change<N>> {
+        let mut vote_counts: HashMap<&Change<N>, usize> = HashMap::new();
         for vote in self.committed.values() {
             let change = &vote.change;
             let entry = vote_counts.entry(change).or_insert(0);
@@ -149,7 +148,7 @@ where
     }
 
     /// Returns `true` if the signature is valid.
-    fn validate(&self, signed_vote: &SignedVote<NodeUid>) -> Result<bool> {
+    fn validate(&self, signed_vote: &SignedVote<N>) -> Result<bool> {
         let ser_vote =
             bincode::serialize(&signed_vote.vote).map_err(|err| ErrorKind::ValidateBincode(*err))?;
         let pk_opt = self.netinfo.public_key(&signed_vote.voter);
@@ -159,9 +158,9 @@ where
 
 /// A vote fore removing or adding a validator.
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Hash, Clone)]
-struct Vote<NodeUid> {
+struct Vote<N> {
     /// The change this vote is for.
-    change: Change<NodeUid>,
+    change: Change<N>,
     /// The epoch in which the current era began.
     era: u64,
     /// The vote number: VoteCounter can be changed by casting another vote with a higher number.
@@ -170,18 +169,18 @@ struct Vote<NodeUid> {
 
 /// A signed vote for removing or adding a validator.
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Hash, Clone)]
-pub struct SignedVote<NodeUid> {
-    vote: Vote<NodeUid>,
-    voter: NodeUid,
+pub struct SignedVote<N> {
+    vote: Vote<N>,
+    voter: N,
     sig: Signature,
 }
 
-impl<NodeUid> SignedVote<NodeUid> {
+impl<N> SignedVote<N> {
     pub fn era(&self) -> u64 {
         self.vote.era
     }
 
-    pub fn voter(&self) -> &NodeUid {
+    pub fn voter(&self) -> &N {
         &self.voter
     }
 }

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -52,52 +52,52 @@ pub enum FaultKind {
 /// describes which node is faulty (`node_id`) and which faulty behavior
 /// that the node exhibited ('kind').
 #[derive(Debug, PartialEq)]
-pub struct Fault<NodeUid> {
-    pub node_id: NodeUid,
+pub struct Fault<N> {
+    pub node_id: N,
     pub kind: FaultKind,
 }
 
-impl<NodeUid> Fault<NodeUid> {
-    pub fn new(node_id: NodeUid, kind: FaultKind) -> Self {
+impl<N> Fault<N> {
+    pub fn new(node_id: N, kind: FaultKind) -> Self {
         Fault { node_id, kind }
     }
 }
 
 /// Creates a new `FaultLog` where `self` is the first element in the log
 /// vector.
-impl<NodeUid> Into<FaultLog<NodeUid>> for Fault<NodeUid> {
-    fn into(self) -> FaultLog<NodeUid> {
+impl<N> Into<FaultLog<N>> for Fault<N> {
+    fn into(self) -> FaultLog<N> {
         FaultLog(vec![self])
     }
 }
 
 /// A structure used to contain reports of faulty node behavior.
 #[derive(Debug, PartialEq)]
-pub struct FaultLog<NodeUid>(pub Vec<Fault<NodeUid>>);
+pub struct FaultLog<N>(pub Vec<Fault<N>>);
 
-impl<NodeUid> FaultLog<NodeUid> {
+impl<N> FaultLog<N> {
     /// Creates an empty `FaultLog`.
     pub fn new() -> Self {
         FaultLog::default()
     }
 
     /// Creates a new `FaultLog` initialized with a single log.
-    pub fn init(node_id: NodeUid, kind: FaultKind) -> Self {
+    pub fn init(node_id: N, kind: FaultKind) -> Self {
         Fault::new(node_id, kind).into()
     }
 
     /// Creates a new `Fault` and pushes it onto the fault log.
-    pub fn append(&mut self, node_id: NodeUid, kind: FaultKind) {
+    pub fn append(&mut self, node_id: N, kind: FaultKind) {
         self.0.push(Fault::new(node_id, kind));
     }
 
     /// Consumes `new_logs`, appending its logs onto the end of `self`.
-    pub fn extend(&mut self, new_logs: FaultLog<NodeUid>) {
+    pub fn extend(&mut self, new_logs: FaultLog<N>) {
         self.0.extend(new_logs.0);
     }
 
     /// Consumes `self`, appending its logs onto the end of `logs`.
-    pub fn merge_into(self, logs: &mut FaultLog<NodeUid>) {
+    pub fn merge_into(self, logs: &mut FaultLog<N>) {
         logs.extend(self);
     }
 
@@ -107,7 +107,7 @@ impl<NodeUid> FaultLog<NodeUid> {
     }
 }
 
-impl<NodeUid> Default for FaultLog<NodeUid> {
+impl<N> Default for FaultLog<N> {
     fn default() -> Self {
         FaultLog(vec![])
     }

--- a/src/honey_badger/batch.rs
+++ b/src/honey_badger/batch.rs
@@ -1,13 +1,15 @@
 use std::collections::BTreeMap;
 
+use traits::NodeUidT;
+
 /// A batch of contributions the algorithm has output.
 #[derive(Clone, Debug)]
-pub struct Batch<C, NodeUid> {
+pub struct Batch<C, N> {
     pub epoch: u64,
-    pub contributions: BTreeMap<NodeUid, C>,
+    pub contributions: BTreeMap<N, C>,
 }
 
-impl<C, NodeUid: Ord> Batch<C, NodeUid> {
+impl<C, N: NodeUidT> Batch<C, N> {
     /// Returns an iterator over references to all transactions included in the batch.
     pub fn iter<'a>(&'a self) -> impl Iterator<Item = <&'a C as IntoIterator>::Item>
     where
@@ -25,25 +27,25 @@ impl<C, NodeUid: Ord> Batch<C, NodeUid> {
     }
 
     /// Returns the number of transactions in the batch (without detecting duplicates).
-    pub fn len<Tx>(&self) -> usize
+    pub fn len<T>(&self) -> usize
     where
-        C: AsRef<[Tx]>,
+        C: AsRef<[T]>,
     {
         self.contributions
             .values()
             .map(C::as_ref)
-            .map(<[Tx]>::len)
+            .map(<[T]>::len)
             .sum()
     }
 
     /// Returns `true` if the batch contains no transactions.
-    pub fn is_empty<Tx>(&self) -> bool
+    pub fn is_empty<T>(&self) -> bool
     where
-        C: AsRef<[Tx]>,
+        C: AsRef<[T]>,
     {
         self.contributions
             .values()
             .map(C::as_ref)
-            .all(<[Tx]>::is_empty)
+            .all(<[T]>::is_empty)
     }
 }

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-use std::fmt::Debug;
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -9,24 +7,25 @@ use serde::{Deserialize, Serialize};
 
 use super::HoneyBadger;
 use messaging::NetworkInfo;
+use traits::{Contribution, NodeUidT};
 
 /// A Honey Badger builder, to configure the parameters and create new instances of `HoneyBadger`.
-pub struct HoneyBadgerBuilder<C, NodeUid> {
+pub struct HoneyBadgerBuilder<C, N> {
     /// Shared network data.
-    netinfo: Arc<NetworkInfo<NodeUid>>,
+    netinfo: Arc<NetworkInfo<N>>,
     /// The maximum number of future epochs for which we handle messages simultaneously.
     max_future_epochs: usize,
     _phantom: PhantomData<C>,
 }
 
-impl<C, NodeUid> HoneyBadgerBuilder<C, NodeUid>
+impl<C, N> HoneyBadgerBuilder<C, N>
 where
-    C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
-    NodeUid: Ord + Clone + Debug + Rand,
+    C: Contribution + Serialize + for<'r> Deserialize<'r>,
+    N: NodeUidT + Rand,
 {
     /// Returns a new `HoneyBadgerBuilder` configured to use the node IDs and cryptographic keys
     /// specified by `netinfo`.
-    pub fn new(netinfo: Arc<NetworkInfo<NodeUid>>) -> Self {
+    pub fn new(netinfo: Arc<NetworkInfo<N>>) -> Self {
         HoneyBadgerBuilder {
             netinfo,
             max_future_epochs: 3,
@@ -41,7 +40,7 @@ where
     }
 
     /// Creates a new Honey Badger instance.
-    pub fn build(&self) -> HoneyBadger<C, NodeUid> {
+    pub fn build(&self) -> HoneyBadger<C, N> {
         HoneyBadger {
             netinfo: self.netinfo.clone(),
             epoch: 0,

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -1,7 +1,5 @@
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Debug;
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::mem;
 use std::sync::Arc;
@@ -16,57 +14,53 @@ use super::{Batch, Error, ErrorKind, HoneyBadgerBuilder, Message, MessageContent
 use common_subset::{self, CommonSubset};
 use fault_log::{Fault, FaultKind, FaultLog};
 use messaging::{self, DistAlgorithm, NetworkInfo, Target};
+use traits::{Contribution, NodeUidT};
 
 /// An instance of the Honey Badger Byzantine fault tolerant consensus algorithm.
 #[derive(Debug)]
-pub struct HoneyBadger<C, NodeUid: Rand> {
+pub struct HoneyBadger<C, N: Rand> {
     /// Shared network data.
-    pub(super) netinfo: Arc<NetworkInfo<NodeUid>>,
+    pub(super) netinfo: Arc<NetworkInfo<N>>,
     /// The earliest epoch from which we have not yet received output.
     pub(super) epoch: u64,
     /// Whether we have already submitted a proposal for the current epoch.
     pub(super) has_input: bool,
     /// The Asynchronous Common Subset instance that decides which nodes' transactions to include,
     /// indexed by epoch.
-    pub(super) common_subsets: BTreeMap<u64, CommonSubset<NodeUid>>,
+    pub(super) common_subsets: BTreeMap<u64, CommonSubset<N>>,
     /// The maximum number of `CommonSubset` instances that we run simultaneously.
     pub(super) max_future_epochs: u64,
     /// Messages for future epochs that couldn't be handled yet.
-    pub(super) incoming_queue: BTreeMap<u64, Vec<(NodeUid, MessageContent<NodeUid>)>>,
+    pub(super) incoming_queue: BTreeMap<u64, Vec<(N, MessageContent<N>)>>,
     /// Received decryption shares for an epoch. Each decryption share has a sender and a
     /// proposer. The outer `BTreeMap` has epochs as its key. The next `BTreeMap` has proposers as
     /// its key. The inner `BTreeMap` has the sender as its key.
-    pub(super) received_shares:
-        BTreeMap<u64, BTreeMap<NodeUid, BTreeMap<NodeUid, DecryptionShare>>>,
+    pub(super) received_shares: BTreeMap<u64, BTreeMap<N, BTreeMap<N, DecryptionShare>>>,
     /// Decoded accepted proposals.
-    pub(super) decrypted_contributions: BTreeMap<NodeUid, Vec<u8>>,
+    pub(super) decrypted_contributions: BTreeMap<N, Vec<u8>>,
     /// Ciphertexts output by Common Subset in an epoch.
-    pub(super) ciphertexts: BTreeMap<u64, BTreeMap<NodeUid, Ciphertext>>,
+    pub(super) ciphertexts: BTreeMap<u64, BTreeMap<N, Ciphertext>>,
     pub(super) _phantom: PhantomData<C>,
 }
 
-pub type Step<C, NodeUid> = messaging::Step<HoneyBadger<C, NodeUid>>;
+pub type Step<C, N> = messaging::Step<HoneyBadger<C, N>>;
 
-impl<C, NodeUid> DistAlgorithm for HoneyBadger<C, NodeUid>
+impl<C, N> DistAlgorithm for HoneyBadger<C, N>
 where
-    C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
-    NodeUid: Ord + Clone + Debug + Rand,
+    C: Contribution + Serialize + for<'r> Deserialize<'r>,
+    N: NodeUidT + Rand,
 {
-    type NodeUid = NodeUid;
+    type NodeUid = N;
     type Input = C;
-    type Output = Batch<C, NodeUid>;
-    type Message = Message<NodeUid>;
+    type Output = Batch<C, N>;
+    type Message = Message<N>;
     type Error = Error;
 
-    fn input(&mut self, input: Self::Input) -> Result<Step<C, NodeUid>> {
+    fn input(&mut self, input: Self::Input) -> Result<Step<C, N>> {
         self.propose(&input)
     }
 
-    fn handle_message(
-        &mut self,
-        sender_id: &NodeUid,
-        message: Self::Message,
-    ) -> Result<Step<C, NodeUid>> {
+    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<C, N>> {
         if !self.netinfo.is_node_validator(sender_id) {
             return Err(ErrorKind::UnknownSender.into());
         }
@@ -87,24 +81,24 @@ where
         false
     }
 
-    fn our_id(&self) -> &NodeUid {
+    fn our_id(&self) -> &N {
         self.netinfo.our_uid()
     }
 }
 
-impl<C, NodeUid> HoneyBadger<C, NodeUid>
+impl<C, N> HoneyBadger<C, N>
 where
-    C: Serialize + for<'r> Deserialize<'r> + Debug + Hash + Eq,
-    NodeUid: Ord + Clone + Debug + Rand,
+    C: Contribution + Serialize + for<'r> Deserialize<'r>,
+    N: NodeUidT + Rand,
 {
     /// Returns a new `HoneyBadgerBuilder` configured to use the node IDs and cryptographic keys
     /// specified by `netinfo`.
-    pub fn builder(netinfo: Arc<NetworkInfo<NodeUid>>) -> HoneyBadgerBuilder<C, NodeUid> {
+    pub fn builder(netinfo: Arc<NetworkInfo<N>>) -> HoneyBadgerBuilder<C, N> {
         HoneyBadgerBuilder::new(netinfo)
     }
 
     /// Proposes a new item in the current epoch.
-    pub fn propose(&mut self, proposal: &C) -> Result<Step<C, NodeUid>> {
+    pub fn propose(&mut self, proposal: &C) -> Result<Step<C, N>> {
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
         }
@@ -143,10 +137,10 @@ where
     /// Handles a message for the given epoch.
     fn handle_message_content(
         &mut self,
-        sender_id: &NodeUid,
+        sender_id: &N,
         epoch: u64,
-        content: MessageContent<NodeUid>,
-    ) -> Result<Step<C, NodeUid>> {
+        content: MessageContent<N>,
+    ) -> Result<Step<C, N>> {
         match content {
             MessageContent::CommonSubset(cs_msg) => {
                 self.handle_common_subset_message(sender_id, epoch, cs_msg)
@@ -160,10 +154,10 @@ where
     /// Handles a message for the common subset sub-algorithm.
     fn handle_common_subset_message(
         &mut self,
-        sender_id: &NodeUid,
+        sender_id: &N,
         epoch: u64,
-        message: common_subset::Message<NodeUid>,
-    ) -> Result<Step<C, NodeUid>> {
+        message: common_subset::Message<N>,
+    ) -> Result<Step<C, N>> {
         let cs_step = {
             // Borrow the instance for `epoch`, or create it.
             let cs = match self.common_subsets.entry(epoch) {
@@ -191,11 +185,11 @@ where
     /// Handles decryption shares sent by `HoneyBadger` instances.
     fn handle_decryption_share_message(
         &mut self,
-        sender_id: &NodeUid,
+        sender_id: &N,
         epoch: u64,
-        proposer_id: NodeUid,
+        proposer_id: N,
         share: DecryptionShare,
-    ) -> Result<Step<C, NodeUid>> {
+    ) -> Result<Step<C, N>> {
         if let Some(ciphertext) = self
             .ciphertexts
             .get(&epoch)
@@ -227,7 +221,7 @@ where
     /// has failed.
     fn verify_decryption_share(
         &self,
-        sender_id: &NodeUid,
+        sender_id: &N,
         share: &DecryptionShare,
         ciphertext: &Ciphertext,
     ) -> bool {
@@ -240,7 +234,7 @@ where
 
     /// When contributions of transactions have been decrypted for all valid proposers in this
     /// epoch, moves those contributions into a batch, outputs the batch and updates the epoch.
-    fn try_output_batch(&mut self) -> Result<Option<Step<C, NodeUid>>> {
+    fn try_output_batch(&mut self) -> Result<Option<Step<C, N>>> {
         // Return if we don't have ciphertexts yet.
         let proposer_ids = match self.ciphertexts.get(&self.epoch) {
             Some(cts) => cts.keys().cloned().collect_vec(),
@@ -258,7 +252,7 @@ where
         let mut step = Step::default();
 
         // Deserialize the output.
-        let contributions: BTreeMap<NodeUid, C> =
+        let contributions: BTreeMap<N, C> =
             mem::replace(&mut self.decrypted_contributions, BTreeMap::new())
                 .into_iter()
                 .flat_map(|(proposer_id, ser_contrib)| {
@@ -289,7 +283,7 @@ where
     }
 
     /// Increments the epoch number and clears any state that is local to the finished epoch.
-    fn update_epoch(&mut self) -> Result<Step<C, NodeUid>> {
+    fn update_epoch(&mut self) -> Result<Step<C, N>> {
         // Clear the state of the old epoch.
         self.ciphertexts.remove(&self.epoch);
         self.received_shares.remove(&self.epoch);
@@ -309,7 +303,7 @@ where
     }
 
     /// Tries to decrypt contributions from all proposers and output those in a batch.
-    fn try_output_batches(&mut self) -> Result<Step<C, NodeUid>> {
+    fn try_output_batches(&mut self) -> Result<Step<C, N>> {
         let mut step = Step::default();
         while let Some(new_step) = self.try_output_batch()? {
             step.extend(new_step);
@@ -318,7 +312,7 @@ where
     }
 
     /// Tries to decrypt the contribution from a given proposer.
-    fn try_decrypt_proposer_contribution(&mut self, proposer_id: NodeUid) -> bool {
+    fn try_decrypt_proposer_contribution(&mut self, proposer_id: N) -> bool {
         if self.decrypted_contributions.contains_key(&proposer_id) {
             return true; // Already decrypted.
         }
@@ -356,9 +350,9 @@ where
 
     fn send_decryption_shares(
         &mut self,
-        cs_output: BTreeMap<NodeUid, Vec<u8>>,
+        cs_output: BTreeMap<N, Vec<u8>>,
         epoch: u64,
-    ) -> Result<Step<C, NodeUid>> {
+    ) -> Result<Step<C, N>> {
         let mut step = Step::default();
         let mut ciphertexts = BTreeMap::new();
         for (proposer_id, v) in cs_output {
@@ -399,10 +393,10 @@ where
     /// Sends decryption shares without verifying the ciphertext.
     fn send_decryption_share(
         &mut self,
-        proposer_id: &NodeUid,
+        proposer_id: &N,
         ciphertext: &Ciphertext,
         epoch: u64,
-    ) -> Result<Step<C, NodeUid>> {
+    ) -> Result<Step<C, N>> {
         let share = self
             .netinfo
             .secret_key_share()
@@ -427,10 +421,10 @@ where
     /// senders with incorrect pending shares.
     fn verify_pending_decryption_shares(
         &self,
-        proposer_id: &NodeUid,
+        proposer_id: &N,
         ciphertext: &Ciphertext,
         epoch: u64,
-    ) -> (BTreeSet<NodeUid>, FaultLog<NodeUid>) {
+    ) -> (BTreeSet<N>, FaultLog<N>) {
         let mut incorrect_senders = BTreeSet::new();
         let mut fault_log = FaultLog::new();
         if let Some(sender_shares) = self
@@ -451,8 +445,8 @@ where
 
     fn remove_incorrect_decryption_shares(
         &mut self,
-        proposer_id: &NodeUid,
-        incorrect_senders: BTreeSet<NodeUid>,
+        proposer_id: &N,
+        incorrect_senders: BTreeSet<N>,
         epoch: u64,
     ) {
         if let Some(sender_shares) = self
@@ -472,9 +466,9 @@ where
     /// `epoch == Some(given_epoch)`.
     fn process_output(
         &mut self,
-        cs_step: common_subset::Step<NodeUid>,
+        cs_step: common_subset::Step<N>,
         epoch: u64,
-    ) -> Result<Step<C, NodeUid>> {
+    ) -> Result<Step<C, N>> {
         let mut step = Step::default();
         let mut cs_outputs = step.extend_with(cs_step, |cs_msg| {
             MessageContent::CommonSubset(cs_msg).with_epoch(epoch)

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -5,18 +5,18 @@ use common_subset;
 
 /// The content of a `HoneyBadger` message. It should be further annotated with an epoch.
 #[derive(Clone, Debug, Deserialize, Rand, Serialize)]
-pub enum MessageContent<NodeUid: Rand> {
+pub enum MessageContent<N: Rand> {
     /// A message belonging to the common subset algorithm in the given epoch.
-    CommonSubset(common_subset::Message<NodeUid>),
+    CommonSubset(common_subset::Message<N>),
     /// A decrypted share of the output of `proposer_id`.
     DecryptionShare {
-        proposer_id: NodeUid,
+        proposer_id: N,
         share: DecryptionShare,
     },
 }
 
-impl<NodeUid: Rand> MessageContent<NodeUid> {
-    pub fn with_epoch(self, epoch: u64) -> Message<NodeUid> {
+impl<N: Rand> MessageContent<N> {
+    pub fn with_epoch(self, epoch: u64) -> Message<N> {
         Message {
             epoch,
             content: self,
@@ -26,12 +26,12 @@ impl<NodeUid: Rand> MessageContent<NodeUid> {
 
 /// A message sent to or received from another node's Honey Badger instance.
 #[derive(Clone, Debug, Deserialize, Rand, Serialize)]
-pub struct Message<NodeUid: Rand> {
+pub struct Message<N: Rand> {
     pub(super) epoch: u64,
-    pub(super) content: MessageContent<NodeUid>,
+    pub(super) content: MessageContent<N>,
 }
 
-impl<NodeUid: Rand> Message<NodeUid> {
+impl<N: Rand> Message<N> {
     pub fn epoch(&self) -> u64 {
         self.epoch
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,3 +135,21 @@ pub mod messaging;
 pub mod queueing_honey_badger;
 pub mod sync_key_gen;
 pub mod transaction_queue;
+
+/// Common supertraits.
+pub mod traits {
+    use std::fmt::Debug;
+    use std::hash::Hash;
+
+    /// A transaction, user message, etc.
+    pub trait Contribution: Eq + Debug + Hash + Send + Sync {}
+    impl<C> Contribution for C where C: Eq + Debug + Hash + Send + Sync {}
+
+    /// A peer node's unique identifier.
+    pub trait NodeUidT: Eq + Ord + Clone + Debug + Hash + Send + Sync {}
+    impl<N> NodeUidT for N where N: Eq + Ord + Clone + Debug + Hash + Send + Sync {}
+
+    /// Messages.
+    pub trait Message: Debug + Send + Sync {}
+    impl<M> Message for M where M: Debug + Send + Sync {}
+}

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -4,6 +4,7 @@ use std::iter::once;
 
 use crypto::{PublicKey, PublicKeySet, PublicKeyShare, SecretKey, SecretKeyShare};
 use fault_log::{Fault, FaultLog};
+use traits::{Message, NodeUidT};
 
 /// Message sent by a given source.
 #[derive(Clone, Debug)]
@@ -57,7 +58,7 @@ impl<M, N> TargetedMessage<M, N> {
 pub struct Step<D>
 where
     D: DistAlgorithm,
-    <D as DistAlgorithm>::NodeUid: Clone,
+    <D as DistAlgorithm>::NodeUid: NodeUidT,
 {
     pub output: VecDeque<D::Output>,
     pub fault_log: FaultLog<D::NodeUid>,
@@ -67,7 +68,7 @@ where
 impl<D> Default for Step<D>
 where
     D: DistAlgorithm,
-    <D as DistAlgorithm>::NodeUid: Clone,
+    <D as DistAlgorithm>::NodeUid: NodeUidT,
 {
     fn default() -> Step<D> {
         Step {
@@ -80,7 +81,7 @@ where
 
 impl<D: DistAlgorithm> Step<D>
 where
-    <D as DistAlgorithm>::NodeUid: Clone,
+    <D as DistAlgorithm>::NodeUid: NodeUidT,
 {
     /// Creates a new `Step` from the given collections.
     pub fn new(
@@ -184,14 +185,14 @@ impl<D: DistAlgorithm> From<TargetedMessage<D::Message, D::NodeUid>> for Step<D>
 /// A distributed algorithm that defines a message flow.
 pub trait DistAlgorithm {
     /// Unique node identifier.
-    type NodeUid: Debug + Clone + Ord + Eq;
+    type NodeUid: NodeUidT;
     /// The input provided by the user.
     type Input;
     /// The output type. Some algorithms return an output exactly once, others return multiple
     /// times.
     type Output;
     /// The messages that need to be exchanged between the instances in the participating nodes.
-    type Message: Debug;
+    type Message: Message;
     /// The errors that can occur during execution.
     type Error: Debug;
 
@@ -218,8 +219,8 @@ pub trait DistAlgorithm {
 
 /// Common data shared between algorithms: the nodes' IDs and key shares.
 #[derive(Debug, Clone)]
-pub struct NetworkInfo<NodeUid> {
-    our_uid: NodeUid,
+pub struct NetworkInfo<N> {
+    our_uid: N,
     num_nodes: usize,
     num_faulty: usize,
     is_validator: bool,
@@ -227,22 +228,22 @@ pub struct NetworkInfo<NodeUid> {
     secret_key_share: SecretKeyShare,
     secret_key: SecretKey,
     public_key_set: PublicKeySet,
-    public_key_shares: BTreeMap<NodeUid, PublicKeyShare>,
-    public_keys: BTreeMap<NodeUid, PublicKey>,
-    node_indices: BTreeMap<NodeUid, usize>,
+    public_key_shares: BTreeMap<N, PublicKeyShare>,
+    public_keys: BTreeMap<N, PublicKey>,
+    node_indices: BTreeMap<N, usize>,
 }
 
-impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
+impl<N: NodeUidT> NetworkInfo<N> {
     pub fn new(
-        our_uid: NodeUid,
+        our_uid: N,
         secret_key_share: SecretKeyShare,
         public_key_set: PublicKeySet,
         secret_key: SecretKey,
-        public_keys: BTreeMap<NodeUid, PublicKey>,
+        public_keys: BTreeMap<N, PublicKey>,
     ) -> Self {
         let num_nodes = public_keys.len();
         let is_validator = public_keys.contains_key(&our_uid);
-        let node_indices: BTreeMap<NodeUid, usize> = public_keys
+        let node_indices: BTreeMap<N, usize> = public_keys
             .keys()
             .enumerate()
             .map(|(n, id)| (id.clone(), n))
@@ -266,12 +267,12 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
     }
 
     /// The ID of the node the algorithm runs on.
-    pub fn our_uid(&self) -> &NodeUid {
+    pub fn our_uid(&self) -> &N {
         &self.our_uid
     }
 
     /// ID of all nodes in the network.
-    pub fn all_uids(&self) -> impl Iterator<Item = &NodeUid> {
+    pub fn all_uids(&self) -> impl Iterator<Item = &N> {
         self.public_keys.keys()
     }
 
@@ -308,27 +309,27 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
     }
 
     /// Returns the public key share if a node with that ID exists, otherwise `None`.
-    pub fn public_key_share(&self, id: &NodeUid) -> Option<&PublicKeyShare> {
+    pub fn public_key_share(&self, id: &N) -> Option<&PublicKeyShare> {
         self.public_key_shares.get(id)
     }
 
     /// Returns a map of all node IDs to their public key shares.
-    pub fn public_key_share_map(&self) -> &BTreeMap<NodeUid, PublicKeyShare> {
+    pub fn public_key_share_map(&self) -> &BTreeMap<N, PublicKeyShare> {
         &self.public_key_shares
     }
 
     /// Returns a map of all node IDs to their public keys.
-    pub fn public_key(&self, id: &NodeUid) -> Option<&PublicKey> {
+    pub fn public_key(&self, id: &N) -> Option<&PublicKey> {
         self.public_keys.get(id)
     }
 
     /// Returns a map of all node IDs to their public keys.
-    pub fn public_key_map(&self) -> &BTreeMap<NodeUid, PublicKey> {
+    pub fn public_key_map(&self) -> &BTreeMap<N, PublicKey> {
         &self.public_keys
     }
 
     /// The index of a node in a canonical numbering of all nodes.
-    pub fn node_index(&self, id: &NodeUid) -> Option<usize> {
+    pub fn node_index(&self, id: &N) -> Option<usize> {
         self.node_indices.get(id).cloned()
     }
 
@@ -350,14 +351,14 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
 
     /// Returns `true` if the given node takes part in the consensus itself. If not, it is only an
     /// observer.
-    pub fn is_node_validator(&self, uid: &NodeUid) -> bool {
+    pub fn is_node_validator(&self, uid: &N) -> bool {
         self.public_keys.contains_key(uid)
     }
 
     /// Generates a map of matching `NetworkInfo`s for testing.
-    pub fn generate_map<I>(uids: I) -> BTreeMap<NodeUid, NetworkInfo<NodeUid>>
+    pub fn generate_map<I>(uids: I) -> BTreeMap<N, NetworkInfo<N>>
     where
-        I: IntoIterator<Item = NodeUid>,
+        I: IntoIterator<Item = N>,
     {
         use rand::{self, Rng};
 
@@ -365,7 +366,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
 
         let mut rng = rand::thread_rng();
 
-        let all_uids: BTreeSet<NodeUid> = uids.into_iter().collect();
+        let all_uids: BTreeSet<N> = uids.into_iter().collect();
         let num_faulty = (all_uids.len() - 1) / 3;
 
         // Generate the keys for threshold cryptography.
@@ -381,7 +382,7 @@ impl<NodeUid: Clone + Ord> NetworkInfo<NodeUid> {
             .collect();
 
         // Create the corresponding `NetworkInfo` for each node.
-        let create_netinfo = |(i, uid): (usize, NodeUid)| {
+        let create_netinfo = |(i, uid): (usize, N)| {
             let netinfo = NetworkInfo::new(
                 uid.clone(),
                 sk_set.secret_key_share(i),

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -1,19 +1,20 @@
 use std::cmp;
 use std::collections::{HashSet, VecDeque};
-use std::hash::Hash;
 
 use rand;
 
+use traits::Contribution;
+
 /// A wrapper providing a few convenience methods for a queue of pending transactions.
 #[derive(Debug)]
-pub struct TransactionQueue<Tx>(pub VecDeque<Tx>);
+pub struct TransactionQueue<T>(pub VecDeque<T>);
 
-impl<Tx: Clone> TransactionQueue<Tx> {
+impl<T: Clone> TransactionQueue<T> {
     /// Removes the given transactions from the queue.
     pub fn remove_all<'a, I>(&mut self, txs: I)
     where
-        I: IntoIterator<Item = &'a Tx>,
-        Tx: Eq + Hash + 'a,
+        I: IntoIterator<Item = &'a T>,
+        T: 'a + Contribution,
     {
         let tx_set: HashSet<_> = txs.into_iter().collect();
         self.0.retain(|tx| !tx_set.contains(tx));
@@ -22,7 +23,7 @@ impl<Tx: Clone> TransactionQueue<Tx> {
     /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
     /// No transactions are removed from the queue.
     // TODO: Return references, once the `HoneyBadger` API accepts them. Remove `Clone` bound.
-    pub fn choose(&self, amount: usize, batch_size: usize) -> Vec<Tx> {
+    pub fn choose(&self, amount: usize, batch_size: usize) -> Vec<T> {
         let mut rng = rand::thread_rng();
         let limit = cmp::min(batch_size, self.0.len());
         let sample = match rand::seq::sample_iter(&mut rng, self.0.iter().take(limit), amount) {


### PR DESCRIPTION
* Add the `Contribution`, `NodeUidT`, and `Message` supertraits.
* Rename type parameters:
  * `Tx` -> `T` or `C`
  * `NodeUid` -> `N`

### Open Issues

* I'm not happy with the naming of `NodeUidT`. It technically *could* just be called `NodeUid`, and i'm learning towards just renaming it back to that, but it does share a name with `DistAlgorithm::NodeUid`. This is allowed but seems like it could be slightly confusing. Maybe not.
* Also the `traits` module name isn't wonderful.

As usual, It takes as more effort to name things as it does to code them...

@mbr, @afck, @drPeterVanNostrand, @vkomenda: Please let me know what you guys think.

