### PR TITLE
Added error handling for mlock errors in threshold_crypto crate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     #       `beta` after the stable release of Rust 1.28; and finally migrating
     #       everything to `stable` at Rust 1.29.
     - RUST_NEXT=nightly-2018-07-13
+    - MLOCK_SECRETS=false
 script:
   - cargo +${RUST_NEXT} clippy -- --deny clippy
   - cargo +${RUST_NEXT} clippy --tests --examples -- --deny clippy

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -106,8 +106,11 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
         // required by the interface to all algorithms in Honey Badger. Therefore we set placeholder
         // keys here. A fully-featured application would need to take appropriately initialized keys
         // from elsewhere.
-        let secret_key_set = SecretKeySet::from(Poly::zero());
-        let sk_share = secret_key_set.secret_key_share(our_id);
+        let secret_key_set =
+            SecretKeySet::from(Poly::zero().expect("Failed to create an empty `Poly`"));
+        let sk_share = secret_key_set
+            .secret_key_share(our_id)
+            .expect("Failed to create our node's `SecretKeyShare`");
         let pub_key_set = secret_key_set.public_keys();
         let sk = SecretKey::default();
         let pub_keys = all_ids

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -268,7 +268,9 @@ where
     where
         F: Fn(NetworkInfo<NodeUid>) -> (D, Step<D>),
     {
-        let netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid));
+        let node_ids = (0..(good_num + adv_num)).map(NodeUid);
+        let netinfos =
+            NetworkInfo::generate_map(node_ids).expect("Failed to create `NetworkInfo` map");
         let new_node = |(uid, netinfo): (NodeUid, NetworkInfo<_>)| {
             (uid, TestNode::new(new_algo(netinfo), hw_quality))
         };

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -70,7 +70,8 @@
 //!     let mut rng = thread_rng();
 //!
 //!     // Create a random set of keys for testing.
-//!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES);
+//!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES)
+//!         .expect("Failed to create `NetworkInfo` map");
 //!
 //!     // Create initial nodes by instantiating a `Broadcast` for each.
 //!     let mut nodes = BTreeMap::new();

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -66,15 +66,15 @@ where
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
-    pub fn build_first_node(&self, our_uid: N) -> DynamicHoneyBadger<C, N> {
+    pub fn build_first_node(&self, our_uid: N) -> Result<DynamicHoneyBadger<C, N>> {
         let mut rng = rand::thread_rng();
-        let sk_set = SecretKeySet::random(0, &mut rng);
+        let sk_set = SecretKeySet::random(0, &mut rng)?;
         let pk_set = sk_set.public_keys();
-        let sks = sk_set.secret_key_share(0);
+        let sks = sk_set.secret_key_share(0)?;
         let sk: SecretKey = rng.gen();
         let pub_keys = once((our_uid.clone(), sk.public_key())).collect();
         let netinfo = NetworkInfo::new(our_uid, sks, pk_set, sk, pub_keys);
-        self.build(netinfo)
+        Ok(self.build(netinfo))
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to join the network at the epoch specified in

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -275,7 +275,7 @@ where
             if let Some(kgs) = self.take_ready_key_gen() {
                 // If DKG completed, apply the change, restart Honey Badger, and inform the user.
                 debug!("{:?} DKG for {:?} complete!", self.our_id(), kgs.change);
-                self.netinfo = kgs.key_gen.into_network_info();
+                self.netinfo = kgs.key_gen.into_network_info()?;
                 self.restart_honey_badger(batch.epoch + 1);
                 batch.set_change(ChangeState::Complete(kgs.change), &self.netinfo);
             } else if let Some(change) = self.vote_counter.compute_winner().cloned() {
@@ -316,7 +316,7 @@ where
         let threshold = (pub_keys.len() - 1) / 3;
         let sk = self.netinfo.secret_key().clone();
         let our_uid = self.our_id().clone();
-        let (key_gen, part) = SyncKeyGen::new(our_uid, sk, pub_keys, threshold);
+        let (key_gen, part) = SyncKeyGen::new(our_uid, sk, pub_keys, threshold)?;
         self.key_gen_state = Some(KeyGenState::new(key_gen, change.clone()));
         if let Some(part) = part {
             self.send_transaction(KeyGenMessage::Part(part))

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -1,7 +1,11 @@
-use bincode;
-use failure::{Backtrace, Context, Fail};
-use honey_badger;
 use std::fmt::{self, Display};
+
+use bincode;
+use crypto;
+use failure::{Backtrace, Context, Fail};
+
+use honey_badger;
+use sync_key_gen;
 
 /// Dynamic honey badger error variants.
 #[derive(Debug, Fail)]
@@ -14,6 +18,8 @@ pub enum ErrorKind {
     SignVoteForBincode(bincode::ErrorKind),
     #[fail(display = "ValidateBincode error: {}", _0)]
     ValidateBincode(bincode::ErrorKind),
+    #[fail(display = "Crypto error: {}", _0)]
+    Crypto(crypto::error::Error),
     #[fail(display = "ProposeHoneyBadger error: {}", _0)]
     ProposeHoneyBadger(honey_badger::Error),
     #[fail(
@@ -21,6 +27,8 @@ pub enum ErrorKind {
         _0
     )]
     HandleHoneyBadgerMessageHoneyBadger(honey_badger::Error),
+    #[fail(display = "SyncKeyGen error: {}", _0)]
+    SyncKeyGen(sync_key_gen::Error),
     #[fail(display = "Unknown sender")]
     UnknownSender,
 }
@@ -58,6 +66,22 @@ impl From<ErrorKind> for Error {
 impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Error {
         Error { inner }
+    }
+}
+
+impl From<crypto::error::Error> for Error {
+    fn from(e: crypto::error::Error) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::Crypto(e)),
+        }
+    }
+}
+
+impl From<sync_key_gen::Error> for Error {
+    fn from(e: sync_key_gen::Error) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::SyncKeyGen(e)),
+        }
     }
 }
 

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -200,7 +200,8 @@ mod tests {
     /// order.
     fn setup(node_num: usize, era: u64) -> (Vec<VoteCounter<usize>>, Vec<Vec<SignedVote<usize>>>) {
         // Create keys for threshold cryptography.
-        let netinfos = NetworkInfo::generate_map(0..node_num);
+        let netinfos =
+            NetworkInfo::generate_map(0..node_num).expect("Failed to generate `NetworkInfo` map");
 
         // Create a `VoteCounter` instance for each node.
         let create_counter =

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -5,6 +5,23 @@
 //! calling algorithm via `DistAlgorihm`'s `.input()` and
 //! `.handle_message()` trait methods.
 
+/// A fault log entry.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Fail)]
+pub enum AckMessageFault {
+    #[fail(display = "Wrong node count")]
+    NodeCount,
+    #[fail(display = "Sender does not exist")]
+    SenderExist,
+    #[fail(display = "Duplicate ack")]
+    DuplicateAck,
+    #[fail(display = "Value decryption failed")]
+    ValueDecryption,
+    #[fail(display = "Value deserialization failed")]
+    ValueDeserialization,
+    #[fail(display = "Invalid value")]
+    ValueInvalid,
+}
+
 /// Represents each reason why a node could be considered faulty.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FaultKind {
@@ -39,7 +56,7 @@ pub enum FaultKind {
     /// with an invalid signature.
     IncorrectPayloadSignature,
     /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Ack message.
-    InvalidAckMessage,
+    AckMessage(AckMessageFault),
     /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Part message.
     InvalidPartMessage,
     /// `DynamicHoneyBadger` received a change vote with an invalid signature.

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -78,7 +78,12 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         };
 
         // FIXME: Take the correct, known keys from the network.
-        let netinfo = Arc::new(NetworkInfo::generate_map(node_ids).remove(&id).unwrap());
+        let netinfo = Arc::new(
+            NetworkInfo::generate_map(node_ids)
+                .expect("Failed to create `NetworkInfo` map")
+                .remove(&id)
+                .unwrap(),
+        );
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
         // FIXME: Use the output.
         let step = bc.input(b"Fake news".to_vec()).expect("propose");

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -398,7 +398,9 @@ where
         G: Fn(BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>) -> A,
     {
         let mut rng = rand::thread_rng();
-        let mut netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid));
+        let node_ids = (0..(good_num + adv_num)).map(NodeUid);
+        let mut netinfos =
+            NetworkInfo::generate_map(node_ids).expect("Failed to generate `NetworkInfo` map");
         let obs_netinfo = {
             let node_ni = netinfos.values().next().unwrap();
             NetworkInfo::new(


### PR DESCRIPTION
- Adds error handling around errors that could arise from failed `mlock`/`munlock` syscalls.

Closes Issue #165