### PR TITLE
Refinements to SyncKeyGen error and fault handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ reed-solomon-erasure = "3.1.0"
 ring = "^0.12"
 serde = "1.0.55"
 serde_derive = "1.0.55"
-threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto" }
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto", branch = "mlock-secrets" }
 
 [dev-dependencies]
 colored = "1.6"

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -106,8 +106,11 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
         // required by the interface to all algorithms in Honey Badger. Therefore we set placeholder
         // keys here. A fully-featured application would need to take appropriately initialized keys
         // from elsewhere.
-        let secret_key_set = SecretKeySet::from(Poly::zero());
-        let sk_share = secret_key_set.secret_key_share(our_id);
+        let secret_key_set =
+            SecretKeySet::from(Poly::zero().expect("Failed to create an empty `Poly`"));
+        let sk_share = secret_key_set
+            .secret_key_share(our_id)
+            .expect("Failed to create our node's `SecretKeyShare`");
         let pub_key_set = secret_key_set.public_keys();
         let sk = SecretKey::default();
         let pub_keys = all_ids

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -268,7 +268,9 @@ where
     where
         F: Fn(NetworkInfo<NodeUid>) -> (D, Step<D>),
     {
-        let netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid));
+        let node_ids = (0..(good_num + adv_num)).map(NodeUid);
+        let netinfos =
+            NetworkInfo::generate_map(node_ids).expect("Failed to create `NetworkInfo` map");
         let new_node = |(uid, netinfo): (NodeUid, NetworkInfo<_>)| {
             (uid, TestNode::new(new_algo(netinfo), hw_quality))
         };

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -70,7 +70,8 @@
 //!     let mut rng = thread_rng();
 //!
 //!     // Create a random set of keys for testing.
-//!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES);
+//!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES)
+//!         .expect("Failed to generate `NetworkInfo` map");
 //!
 //!     // Create initial nodes by instantiating a `Broadcast` for each.
 //!     let mut nodes = BTreeMap::new();

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -66,15 +66,15 @@ where
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
-    pub fn build_first_node(&self, our_uid: N) -> DynamicHoneyBadger<C, N> {
+    pub fn build_first_node(&self, our_uid: N) -> Result<DynamicHoneyBadger<C, N>> {
         let mut rng = rand::thread_rng();
-        let sk_set = SecretKeySet::random(0, &mut rng);
+        let sk_set = SecretKeySet::random(0, &mut rng)?;
         let pk_set = sk_set.public_keys();
-        let sks = sk_set.secret_key_share(0);
+        let sks = sk_set.secret_key_share(0)?;
         let sk: SecretKey = rng.gen();
         let pub_keys = once((our_uid.clone(), sk.public_key())).collect();
         let netinfo = NetworkInfo::new(our_uid, sks, pk_set, sk, pub_keys);
-        self.build(netinfo)
+        Ok(self.build(netinfo))
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to join the network at the epoch specified in

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -275,7 +275,7 @@ where
             if let Some(kgs) = self.take_ready_key_gen() {
                 // If DKG completed, apply the change, restart Honey Badger, and inform the user.
                 debug!("{:?} DKG for {:?} complete!", self.our_id(), kgs.change);
-                self.netinfo = kgs.key_gen.into_network_info();
+                self.netinfo = kgs.key_gen.into_network_info()?;
                 self.restart_honey_badger(batch.epoch + 1);
                 batch.set_change(ChangeState::Complete(kgs.change), &self.netinfo);
             } else if let Some(change) = self.vote_counter.compute_winner().cloned() {
@@ -316,7 +316,7 @@ where
         let threshold = (pub_keys.len() - 1) / 3;
         let sk = self.netinfo.secret_key().clone();
         let our_uid = self.our_id().clone();
-        let (key_gen, part) = SyncKeyGen::new(our_uid, sk, pub_keys, threshold);
+        let (key_gen, part) = SyncKeyGen::new(our_uid, sk, pub_keys, threshold)?;
         self.key_gen_state = Some(KeyGenState::new(key_gen, change.clone()));
         if let Some(part) = part {
             self.send_transaction(KeyGenMessage::Part(part))

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -1,7 +1,11 @@
-use bincode;
-use failure::{Backtrace, Context, Fail};
-use honey_badger;
 use std::fmt::{self, Display};
+
+use bincode;
+use crypto;
+use failure::{Backtrace, Context, Fail};
+
+use honey_badger;
+use sync_key_gen;
 
 /// Dynamic honey badger error variants.
 #[derive(Debug, Fail)]
@@ -14,6 +18,8 @@ pub enum ErrorKind {
     SignVoteForBincode(bincode::ErrorKind),
     #[fail(display = "ValidateBincode error: {}", _0)]
     ValidateBincode(bincode::ErrorKind),
+    #[fail(display = "Crypto error: {}", _0)]
+    Crypto(crypto::error::Error),
     #[fail(display = "ProposeHoneyBadger error: {}", _0)]
     ProposeHoneyBadger(honey_badger::Error),
     #[fail(
@@ -21,6 +27,8 @@ pub enum ErrorKind {
         _0
     )]
     HandleHoneyBadgerMessageHoneyBadger(honey_badger::Error),
+    #[fail(display = "SyncKeyGen error: {}", _0)]
+    SyncKeyGen(sync_key_gen::Error),
     #[fail(display = "Unknown sender")]
     UnknownSender,
 }
@@ -58,6 +66,22 @@ impl From<ErrorKind> for Error {
 impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Error {
         Error { inner }
+    }
+}
+
+impl From<crypto::error::Error> for Error {
+    fn from(e: crypto::error::Error) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::Crypto(e)),
+        }
+    }
+}
+
+impl From<sync_key_gen::Error> for Error {
+    fn from(e: sync_key_gen::Error) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::SyncKeyGen(e)),
+        }
     }
 }
 

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -200,7 +200,8 @@ mod tests {
     /// order.
     fn setup(node_num: usize, era: u64) -> (Vec<VoteCounter<usize>>, Vec<Vec<SignedVote<usize>>>) {
         // Create keys for threshold cryptography.
-        let netinfos = NetworkInfo::generate_map(0..node_num);
+        let netinfos =
+            NetworkInfo::generate_map(0..node_num).expect("Failed to generate `NetworkInfo` map");
 
         // Create a `VoteCounter` instance for each node.
         let create_counter =

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -5,6 +5,23 @@
 //! calling algorithm via `DistAlgorihm`'s `.input()` and
 //! `.handle_message()` trait methods.
 
+/// A fault log entry.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Fail)]
+pub enum AckMessageFault {
+    #[fail(display = "Wrong node count")]
+    NodeCount,
+    #[fail(display = "Sender does not exist")]
+    SenderExist,
+    #[fail(display = "Duplicate ack")]
+    DuplicateAck,
+    #[fail(display = "Value decryption failed")]
+    ValueDecryption,
+    #[fail(display = "Value deserialization failed")]
+    ValueDeserialization,
+    #[fail(display = "Invalid value")]
+    ValueInvalid,
+}
+
 /// Represents each reason why a node could be considered faulty.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FaultKind {
@@ -35,7 +52,7 @@ pub enum FaultKind {
     /// with an invalid signature.
     IncorrectPayloadSignature,
     /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Ack message.
-    InvalidAckMessage,
+    AckMessage(AckMessageFault),
     /// `DynamicHoneyBadger`/`SyncKeyGen` received an invalid Part message.
     InvalidPartMessage,
     /// `DynamicHoneyBadger` received a change vote with an invalid signature.

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -161,14 +161,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
 
 use bincode;
-use crypto::poly::{BivarCommitment, BivarPoly, Poly};
-use crypto::serde_impl::field_vec::FieldWrap;
-use crypto::{self, Ciphertext, PublicKey, PublicKeySet, SecretKey, SecretKeyShare};
+use crypto::{
+    error::Error as CryptoError,
+    poly::{BivarCommitment, BivarPoly, Poly},
+    serde_impl::field_vec::FieldWrap,
+    Ciphertext, PublicKey, PublicKeySet, SecretKey, SecretKeyShare,
+};
 use pairing::bls12_381::{Fr, G1Affine};
 use pairing::{CurveAffine, Field};
 use rand::OsRng;
 
-use fault_log::{FaultKind, FaultLog};
+use fault_log::{AckMessageFault as Fault, FaultKind, FaultLog};
 use messaging::NetworkInfo;
 use traits::NodeUidT;
 
@@ -177,14 +180,12 @@ use traits::NodeUidT;
 // A sync-key-gen error.
 #[derive(Clone, Eq, PartialEq, Debug, Fail)]
 pub enum Error {
-    #[fail(display = "Crypto error: {}", _0)]
-    Crypto(crypto::error::Error),
-}
-
-impl From<crypto::error::Error> for Error {
-    fn from(e: crypto::error::Error) -> Self {
-        Error::Crypto(e)
-    }
+    #[fail(display = "Error creating SyncKeyGen: {}", _0)]
+    Creation(CryptoError),
+    #[fail(display = "Error generating keys: {}", _0)]
+    Generation(CryptoError),
+    #[fail(display = "Error acknowledging part: {}", _0)]
+    Ack(CryptoError),
 }
 
 /// A submission by a validator for the key generation. It must to be sent to all participating
@@ -304,10 +305,10 @@ impl<N: NodeUidT> SyncKeyGen<N> {
             return Ok((key_gen, None)); // No part: we are an observer.
         }
         let mut rng = OsRng::new().expect("OS random number generator");
-        let our_part = BivarPoly::random(threshold, &mut rng)?;
+        let our_part = BivarPoly::random(threshold, &mut rng).map_err(Error::Creation)?;
         let commit = our_part.commitment();
         let encrypt = |(i, pk): (usize, &PublicKey)| {
-            let row = our_part.row(i + 1)?;
+            let row = our_part.row(i + 1).map_err(Error::Creation)?;
             let bytes = bincode::serialize(&row).expect("failed to serialize row");
             Ok(pk.encrypt(&bytes))
         };
@@ -335,7 +336,7 @@ impl<N: NodeUidT> SyncKeyGen<N> {
         let opt_commit_row = self.our_idx.map(|idx| commit.row(idx + 1));
         match self.parts.entry(sender_idx) {
             Entry::Occupied(_) => {
-                debug!("Received multiple parts from node {:?}.", sender_id);
+                error!("Received multiple parts from node {:?}.", sender_id);
                 return None;
             }
             Entry::Vacant(entry) => {
@@ -354,7 +355,7 @@ impl<N: NodeUidT> SyncKeyGen<N> {
             return Some(PartOutcome::Invalid(fault_log));
         };
         if row.commitment() != commit_row {
-            debug!("Invalid part from node {:?}.", sender_id);
+            error!("Invalid part from node {:?}.", sender_id);
             let fault_log = FaultLog::init(sender_id.clone(), FaultKind::InvalidPartMessage);
             return Some(PartOutcome::Invalid(fault_log));
         }
@@ -377,9 +378,9 @@ impl<N: NodeUidT> SyncKeyGen<N> {
     pub fn handle_ack(&mut self, sender_id: &N, ack: Ack) -> FaultLog<N> {
         let mut fault_log = FaultLog::new();
         if let Some(sender_idx) = self.node_index(sender_id) {
-            if let Err(err) = self.handle_ack_or_err(sender_idx, ack) {
-                debug!("Invalid ack from node {:?}: {}", sender_id, err);
-                fault_log.append(sender_id.clone(), FaultKind::InvalidAckMessage);
+            if let Err(fault) = self.handle_ack_or_err(sender_idx, ack) {
+                error!("Invalid ack from node {:?}: {}", sender_id, fault);
+                fault_log.append(sender_id.clone(), FaultKind::AckMessage(fault));
             }
         }
         fault_log
@@ -416,18 +417,19 @@ impl<N: NodeUidT> SyncKeyGen<N> {
     /// All participating nodes must have handled the exact same sequence of `Part` and `Ack`
     /// messages before calling this method. Otherwise their key shares will not match.
     pub fn generate(&self) -> Result<(PublicKeySet, Option<SecretKeyShare>), Error> {
-        let mut pk_commit = Poly::zero()?.commitment();
+        let mut pk_commit = Poly::zero().map_err(Error::Generation)?.commitment();
         let mut opt_sk_val = self.our_idx.map(|_| Fr::zero());
         let is_complete = |part: &&ProposalState| part.is_complete(self.threshold);
         for part in self.parts.values().filter(is_complete) {
             pk_commit += part.commit.row(0);
             if let Some(sk_val) = opt_sk_val.as_mut() {
-                let row = Poly::interpolate(part.values.iter().take(self.threshold + 1))?;
+                let row = Poly::interpolate(part.values.iter().take(self.threshold + 1))
+                    .map_err(Error::Generation)?;
                 sk_val.add_assign(&row.evaluate(0));
             }
         }
         let opt_sk = if let Some(mut fr) = opt_sk_val {
-            let sk = SecretKeyShare::from_mut_ptr(&mut fr as *mut Fr)?;
+            let sk = SecretKeyShare::from_mut_ptr(&mut fr as *mut Fr).map_err(Error::Generation)?;
             Some(sk)
         } else {
             None
@@ -452,16 +454,16 @@ impl<N: NodeUidT> SyncKeyGen<N> {
         &mut self,
         sender_idx: u64,
         Ack(proposer_idx, values): Ack,
-    ) -> Result<(), String> {
+    ) -> Result<(), Fault> {
         if values.len() != self.pub_keys.len() {
-            return Err("wrong node count".to_string());
+            return Err(Fault::NodeCount);
         }
         let part = self
             .parts
             .get_mut(&proposer_idx)
-            .ok_or_else(|| "sender does not exist".to_string())?;
+            .ok_or_else(|| Fault::SenderExist)?;
         if !part.acks.insert(sender_idx) {
-            return Err("duplicate ack".to_string());
+            return Err(Fault::DuplicateAck);
         }
         let our_idx = match self.our_idx {
             Some(our_idx) => our_idx,
@@ -470,12 +472,18 @@ impl<N: NodeUidT> SyncKeyGen<N> {
         let ser_val: Vec<u8> = self
             .sec_key
             .decrypt(&values[our_idx as usize])
-            .ok_or_else(|| "value decryption failed".to_string())?;
+            .ok_or_else(|| Fault::ValueDecryption)?;
         let val = bincode::deserialize::<FieldWrap<Fr, Fr>>(&ser_val)
-            .map_err(|err| format!("deserialization failed: {:?}", err))?
+            .map_err(|err| {
+                error!(
+                    "Secure value deserialization failed while handling ack: {:?}",
+                    err
+                );
+                Fault::ValueDeserialization
+            })?
             .into_inner();
         if part.commit.evaluate(our_idx + 1, sender_idx + 1) != G1Affine::one().mul(val) {
-            return Err("wrong value".to_string());
+            return Err(Fault::ValueInvalid);
         }
         part.values.insert(sender_idx + 1, val);
         Ok(())
@@ -486,7 +494,7 @@ impl<N: NodeUidT> SyncKeyGen<N> {
         if let Some(node_idx) = self.pub_keys.keys().position(|uid| uid == node_id) {
             Some(node_idx as u64)
         } else {
-            debug!("Unknown node {:?}", node_id);
+            error!("Unknown node {:?}", node_id);
             None
         }
     }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -78,7 +78,12 @@ impl Adversary<Broadcast<NodeUid>> for ProposeAdversary {
         };
 
         // FIXME: Take the correct, known keys from the network.
-        let netinfo = Arc::new(NetworkInfo::generate_map(node_ids).remove(&id).unwrap());
+        let netinfo = Arc::new(
+            NetworkInfo::generate_map(node_ids)
+                .expect("Failed to create `NetworkInfo` map")
+                .remove(&id)
+                .unwrap(),
+        );
         let mut bc = Broadcast::new(netinfo, id).expect("broadcast instance");
         // FIXME: Use the output.
         let step = bc.input(b"Fake news".to_vec()).expect("propose");

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -398,7 +398,9 @@ where
         G: Fn(BTreeMap<D::NodeUid, Arc<NetworkInfo<D::NodeUid>>>) -> A,
     {
         let mut rng = rand::thread_rng();
-        let mut netinfos = NetworkInfo::generate_map((0..(good_num + adv_num)).map(NodeUid));
+        let node_ids = (0..(good_num + adv_num)).map(NodeUid);
+        let mut netinfos =
+            NetworkInfo::generate_map(node_ids).expect("Failed to generate `NetworkInfo` map");
         let obs_netinfo = {
             let node_ni = netinfos.values().next().unwrap();
             NetworkInfo::new(


### PR DESCRIPTION
* Add a new `AckMessageFault` type.
* Add new `sync_key_gen::Error` variants and remove `From` impl.