### PR TITLE
Travis: Enable cpu-specific optimizations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ before_install:
 env:
   global:
     - RUST_BACKTRACE=1
-    - RUSTFLAGS="-D warnings"
+    # Enables additional cpu-specific optimizations.
+    - RUSTFLAGS="-D warnings -C target-cpu=native"
     # Note: `beta` should be removed along with `RUST_NEXT` after the 1.28
     #       stable release on 2018-09-13.
     - RUST_NEXT=beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ script:
   - cargo +${RUST_NEXT} clippy --all-features -- --deny clippy
   - cargo +${RUST_NEXT} clippy --all-features --tests -- --deny clippy
   - cargo +${RUST_NEXT} fmt -- --check
-  - cargo test --all-features --release
+  - cargo test --all-features --release -- --test-threads 1


### PR DESCRIPTION
This is off by default so that binaries can be shared. Enabling this
flag could improve test speed on Travis (will check).