### PR TITLE
Fix DHB test: wait for lagging nodes.

### DIFF
--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -78,6 +78,8 @@ where
                 node_busy(*node)
                     && !node.instance().has_input()
                     && node.instance().netinfo().is_validator()
+                    // Wait until all nodes have completed removing 0, before inputting `Add`.
+                    && (input_add || !has_remove(node))
                     // If there's only one node, it will immediately output on input. Make sure we
                     // first process all incoming messages before providing input again.
                     && (network.nodes.len() > 2 || node.queue.is_empty())


### PR DESCRIPTION
The Dynamic Honey Badger tests would currently fail _without_ faulty
nodes, because with "first" delivery, all but the first _N - f_ nodes
are lagging indefinitely.

This change makes sure we give lagging nodes a chance to finish the first
phase of the test and arrive at the batch containing the completed
`Remove` event.