### PR TITLE
Use latest `pairing` crate and accordingly updated `threshold_crypto`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,12 @@ travis-ci = { repository = "poanetwork/hbbft" }
 bincode = "1.0.0"
 byteorder = "1.2.3"
 env_logger = "0.5.10"
+ff = "0.4.0"
 failure = "0.1"
 init_with = "1.1.0"
 itertools = "0.7"
 log = "0.4.1"
-pairing = { version = "0.14.2", features = ["u128-support"] }
+pairing = { git = "https://github.com/zkcrypto/pairing", rev = "183a64b08e9dc7067f78624ec161371f1829623e" }
 rand = "0.4.2"
 rand_derive = "0.3.1"
 reed-solomon-erasure = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ extern crate bincode;
 extern crate byteorder;
 #[macro_use]
 extern crate failure;
+extern crate ff;
 extern crate init_with;
 #[macro_use]
 extern crate log;

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -167,8 +167,9 @@ use crypto::{
     serde_impl::field_vec::FieldWrap,
     Ciphertext, PublicKey, PublicKeySet, SecretKey, SecretKeyShare,
 };
+use ff::Field;
 use pairing::bls12_381::{Fr, G1Affine};
-use pairing::{CurveAffine, Field};
+use pairing::CurveAffine;
 use rand::OsRng;
 
 use fault_log::{AckMessageFault as Fault, FaultKind, FaultLog};


### PR DESCRIPTION
The tests will fail until https://github.com/poanetwork/threshold_crypto/pull/12 is merged.

As with `threshold_crypto`, the changes are fairly small. We should lobby for an updated `pairing` release regardless.