### PR TITLE
Update docs: missing algorithms, private merkle, whitespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Honey Badger Byzantine Fault Tolerant (BFT) consensus algorithm
 
-[![Build Status](https://travis-ci.org/poanetwork/hbbft.svg?branch=master)](https://travis-ci.org/poanetwork/hbbft) 
+[![Build Status](https://travis-ci.org/poanetwork/hbbft.svg?branch=master)](https://travis-ci.org/poanetwork/hbbft)
 [![Gitter](https://badges.gitter.im/poanetwork/hbbft.svg)](https://gitter.im/poanetwork/hbbft?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Welcome to a [Rust](https://www.rust-lang.org/en-US/) library of the Honey Badger Byzantine Fault Tolerant (BFT) consensus algorithm. The research and protocols for this algorithm are explained in detail in "[The Honey Badger of BFT Protocols](https://eprint.iacr.org/2016/199.pdf)" by Miller et al., 2016.
 
-Following is an overview of HoneyBadger BFT and [basic instructions for getting started](#getting-started). 
+Following is an overview of HoneyBadger BFT and [basic instructions for getting started](#getting-started).
 
 _**Note:** This library is a work in progress and parts of the algorithm are still in development._
 
@@ -17,38 +17,41 @@ Honey Badger is **Byzantine Fault Tolerant**. The protocol can reach consensus w
 Honey Badger is **asynchronous**.  It does not make timing assumptions about message delivery. An adversary can control network scheduling and delay messages without impacting consensus.
 
 ## How does it work?
-Honey Badger is a modular library composed of several independent algorithms.  To reach consensus, Honey Badger proceeds in epochs. In each epoch, participating nodes broadcast a set of encrypted data transactions to one another and agree on the contents of those transactions. 
+Honey Badger is a modular library composed of several independent algorithms.  To reach consensus, Honey Badger proceeds in epochs. In each epoch, participating nodes broadcast a set of encrypted data transactions to one another and agree on the contents of those transactions.
 
-In an optimal networking environment, output includes data sent from each node. In an adverse environment, the output is an agreed upon subset of data. Either way, the resulting output contains a batch of transactions which is guaranteed to be consistent across all nodes.  
+In an optimal networking environment, output includes data sent from each node. In an adverse environment, the output is an agreed upon subset of data. Either way, the resulting output contains a batch of transactions which is guaranteed to be consistent across all nodes.
 
 In addition to **validators**, the algorithms support **observers**: These don't actively participate, and don't need to be trusted, but they receive the output as well, and are able to verify it under the assumption that more than two thirds of the validators are correct.
 
 ## Algorithms
 
-- [x] **[Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/honey_badger/mod.rs):** Each node inputs transactions. The protocol outputs a sequence of batches of transactions.
+- **[Honey Badger](src/honey_badger/honey_badger.rs):** Each node inputs transactions. The protocol outputs a sequence of batches of transactions.
 
-- [x] **[Dynamic Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/dynamic_honey_badger/mod.rs):** A modified Honey Badger where nodes can dynamically add and remove other nodes to/from the network.
+- **[Dynamic Honey Badger](src/dynamic_honey_badger/dynamic_honey_badger.rs):** A modified Honey Badger where nodes can dynamically add and remove other nodes to/from the network.
 
-- [x] **[Queueing Honey Badger](https://github.com/poanetwork/hbbft/blob/master/src/queueing_honey_badger.rs):** Works exactly like Dynamic Honey Badger, but includes a built in transaction queue.
+- **[Queueing Honey Badger](src/queueing_honey_badger.rs):** Works exactly like Dynamic Honey Badger, but includes a built in transaction queue.
 
-- [x] **[Subset](https://github.com/poanetwork/hbbft/blob/master/src/subset.rs):** Each node inputs data. The nodes agree on a subset of suggested data. 
+- **[Subset](src/subset.rs):** Each node inputs data. The nodes agree on a subset of suggested data.
 
-- [x] **[Broadcast](https://github.com/poanetwork/hbbft/blob/master/src/broadcast.rs):** A proposer node inputs data and every node receives this output.
+- **[Broadcast](src/broadcast/broadcast.rs):** A proposer node inputs data and every node receives this output.
 
-- [x] **[Binary Agreement](https://github.com/poanetwork/hbbft/blob/master/src/agreement/mod.rs):** Each node inputs a binary value. The nodes agree on a value that was input by at least one correct node. 
+- **[Binary Agreement](src/agreement/agreement.rs):** Each node inputs a binary value. The nodes agree on a value that was input by at least one correct node.
 
-- [x] **[Coin](https://github.com/poanetwork/hbbft/blob/master/src/coin.rs):** A pseudorandom binary value used by the Binary Agreement protocol.
+- **[Coin](src/coin.rs):** A pseudorandom binary value used by the Binary Agreement protocol.
 
-- [x] **[Synchronous Key Generation](https://github.com/poanetwork/hbbft/blob/master/src/sync_key_gen.rs)** A dealerless algorithm that generates keys for threshold encryption and signing. Unlike the other algorithms, this one is _completely synchronous_ and should run on top of Honey Badger (or another consensus algorithm)
+- **[Threshold Decryption](src/threshold_decryption.rs):**
+  Each node inputs the same ciphertext, encrypted to the public master key, and outputs the decrypted data.
 
-### External crates developed for this library 
+- **[Synchronous Key Generation](src/sync_key_gen.rs)** A dealerless algorithm that generates keys for threshold encryption and signing. Unlike the other algorithms, this one is _completely synchronous_ and should run on top of Honey Badger (or another consensus algorithm)
 
-- [x] **[Threshold Crypto](https://github.com/poanetwork/threshold_crypto):** A threshold cryptosystem for collaborative message decryption and signature creation. 
+### External crates developed for this library
+
+- **[Threshold Crypto](https://github.com/poanetwork/threshold_crypto):** A threshold cryptosystem for collaborative message decryption and signature creation.
 
 
 ## Getting Started
 
-This library requires a distributed network environment to function. Details on network requirements TBD. 
+This library requires a distributed network environment to function. Details on network requirements TBD.
 
 _**Note:** Additional examples are currently in progress._
 
@@ -68,7 +71,7 @@ $ cargo test --release
 
 ### Example Network Simulation
 
-A basic [example](https://github.com/poanetwork/hbbft/blob/master/examples/README.md) is included to run a network simulation.
+A basic [example](examples/README.md) is included to run a network simulation.
 
 ```
 $ cargo run --example simulation --release
@@ -76,32 +79,32 @@ $ cargo run --example simulation --release
 
 ![Screenshot](screenshot.png)
 
-|  Heading    | Definition                       
-| ----------- | -------------------------------------------------------------------------- | 
-| Epoch       |  Epoch number. In each epoch, transactions are processed in a batch by simulated nodes (default is 10 nodes) on a network. The batch is always output in one piece, with all transactions at once.                                                           | 
-| Min Time   | Time in simulated milliseconds until the first correct (i.e. not faulty) node outputs the batch.                                          |  
-| Max Time   | Time in simulated milliseconds until the last correct node outputs the batch.                                                  |  
-| Txs         | Number of transactions processed in the epoch.                                           |  
-| Msgs/Node   | Average number of messages handled by a node. The counter is cumulative and includes the number of messages handled in the current epoch and all previous epochs.                                                               |  
-| Size/Node   | Average message size (in converted bytes) handled by a node. This is cumulative and includes message size for the current epoch and all previous epochs.                                                             |  
- 
+|  Heading    | Definition
+| ----------- | -------------------------------------------------------------------------- |
+| Epoch       |  Epoch number. In each epoch, transactions are processed in a batch by simulated nodes (default is 10 nodes) on a network. The batch is always output in one piece, with all transactions at once.                                                           |
+| Min Time   | Time in simulated milliseconds until the first correct (i.e. not faulty) node outputs the batch.                                          |
+| Max Time   | Time in simulated milliseconds until the last correct node outputs the batch.                                                  |
+| Txs         | Number of transactions processed in the epoch.                                           |
+| Msgs/Node   | Average number of messages handled by a node. The counter is cumulative and includes the number of messages handled in the current epoch and all previous epochs.                                                               |
+| Size/Node   | Average message size (in converted bytes) handled by a node. This is cumulative and includes message size for the current epoch and all previous epochs.                                                             |
+
 
 #### Options
 
 Set different parameters to simulate different transaction and network conditions.
 
-|  Flag                  | Description                         | 
-| ---------------------- | -------------------------------- | 
-| `-h, --help`            | Show help options                   | 
-| `--version`             | Show the version of hbbft |  
-| `-n <n>, --nodes <n>`   | The total number of nodes [default: 10]        |  
-| `-f <f>, --faulty <f>`  | The number of faulty nodes [default: 0]|  
-| `-t <txs>, --txs <txs>` | The number of transactions to process [default: 1000]                     |  
-| `-b <b>, --batch <b>`   | The batch size, i.e. txs per epoch [default: 100]                    |  
-|  `-l <lag>, --lag <lag>` | The network lag between sending and receiving [default: 100]                     |  
-|  `--bw <bw>`             | The bandwidth, in kbit/s [default: 2000]                    |  
-|  `--cpu <cpu>`           | The CPU speed, in percent of this machine's [default: 100]                     |  
-|  `--tx-size <size>`      | The size of a transaction, in bytes [default: 10]                     |  
+|  Flag                  | Description                         |
+| ---------------------- | -------------------------------- |
+| `-h, --help`            | Show help options                   |
+| `--version`             | Show the version of hbbft |
+| `-n <n>, --nodes <n>`   | The total number of nodes [default: 10]        |
+| `-f <f>, --faulty <f>`  | The number of faulty nodes [default: 0]|
+| `-t <txs>, --txs <txs>` | The number of transactions to process [default: 1000]                     |
+| `-b <b>, --batch <b>`   | The batch size, i.e. txs per epoch [default: 100]                    |
+|  `-l <lag>, --lag <lag>` | The network lag between sending and receiving [default: 100]                     |
+|  `--bw <bw>`             | The bandwidth, in kbit/s [default: 2000]                    |
+|  `--cpu <cpu>`           | The CPU speed, in percent of this machine's [default: 100]                     |
+|  `--tx-size <size>`      | The size of a transaction, in bytes [default: 10]                     |
 
 
 **Examples:**
@@ -129,23 +132,23 @@ See [Issues](https://github.com/poanetwork/hbbft/issues) for all tasks.
 ## Protocol Modifications
 
 Our implementation modifies the protocols described in "[The Honey Badger of BFT Protocols](https://eprint.iacr.org/2016/199.pdf)" in several ways:
-*  We use a [pairing elliptic curve library](https://github.com/ebfull/pairing) to implement pairing-based cryptography using a Barrento-Lynn-Scott (BLS12-381) curve. 
+*  We use a [pairing elliptic curve library](https://github.com/ebfull/pairing) to implement pairing-based cryptography using a Barrento-Lynn-Scott (BLS12-381) curve.
 * We add a `Terminate` message to the Binary Agreement algorithm. Termination occurs following output, preventing the algorithm from running (or staying in memory) indefinitely. ([#53](https://github.com/poanetwork/hbbft/issues/55))
 *  We add a `Conf` message to the Binary Agreement algorithm. An additional message phase prevents an attack if an adversary controls a network scheduler and a node. ([#37](https://github.com/poanetwork/hbbft/issues/37))
 *  We return additional information from the Subset and Honey Badger algorithms that specifies which node input which data. This allows for identification of potentially malicious nodes.
 * We include a Distributed Key Generation (DKG) protocol which does not require a trusted dealer; nodes collectively generate a secret key. This addresses the problem of single point of failure. See [Distributed Key Generation in the Wild](https://eprint.iacr.org/2012/377.pdf).
 
-### Algorithm naming conventions  
+### Algorithm naming conventions
 
 We have simplified algorithm naming conventions from the original paper.
 
-|  Algorithm Name  | Original Name                    | 
-| ---------------- | -------------------------------- | 
-| Honey Badger     | HoneyBadgerBFT                   | 
-| Subset           | Asynchronous Common Subset (ACS) |  
-| Broadcast        | Reliable Broadcast (RBC)         |  
-| Binary Agreement | Binary Byzantine Agreement (BBA) |  
-| Coin             | Common Coin                      |  
+|  Algorithm Name  | Original Name                    |
+| ---------------- | -------------------------------- |
+| Honey Badger     | HoneyBadgerBFT                   |
+| Subset           | Asynchronous Common Subset (ACS) |
+| Broadcast        | Reliable Broadcast (RBC)         |
+| Binary Agreement | Binary Byzantine Agreement (BBA) |
+| Coin             | Common Coin                      |
 
 ## Contributing
 

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -57,7 +57,7 @@ impl Debug for Message {
     }
 }
 
-/// Reliable Broadcast algorithm instance.
+/// Broadcast algorithm instance.
 #[derive(Debug)]
 pub struct Broadcast<N> {
     /// Shared network data.

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -1,6 +1,6 @@
 //! # Broadcast
 //!
-//! The Reliable Broadcast Protocol assumes a network of _N_ nodes that send signed messages to
+//! The Broadcast Protocol assumes a network of _N_ nodes that send signed messages to
 //! each other, with at most _f_ of them faulty, where _3 f < N_. Handling the networking and
 //! signing is the responsibility of this crate's user; a message is only handed to the Broadcast
 //! instance after it has been verified to be "from node i". One of the nodes is the "proposer"
@@ -151,7 +151,7 @@
 
 mod broadcast;
 mod error;
-pub mod merkle;
+pub(crate) mod merkle;
 
 pub use self::broadcast::{Broadcast, Message, Step};
 pub use self::error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! transactions. Using the Subset protocol, they agree on at least _N - f_ of those
 //! proposals. The batch contains the union of these sets of transactions.
 //!
-//! [**Reliable Broadcast**](broadcast/index.html)
+//! [**Broadcast**](broadcast/index.html)
 //!
 //! One node, the _proposer_, inputs an item, and every node receives that item as an output. Even
 //! if the proposer is faulty it is guaranteed that either none of the correct nodes output
@@ -91,6 +91,21 @@
 //! receive `true` or all nodes receive `false`. The outcome cannot be known by the adversary
 //! before at least one correct node has provided input, and is uniformly distributed and
 //! pseudorandom.
+//!
+//! [**Threshold Decryption**](threshold_decryption/index.html)
+//!
+//! Each node inputs the same ciphertext, encrypted to the public master key. Once _f + 1_
+//! validators have received input, all nodes output the decrypted data.
+//!
+//! [**Synchronous Key Generation**](sync_key_gen/index.html)
+//!
+//! The participating nodes collaboratively generate a key set for threshold cryptography, such
+//! that each node learns its own secret key share, as well as everyone's public key share and the
+//! public master key. No single trusted dealer is involved and no node ever learns the secret
+//! master key or another node's secret key share.
+//!
+//! Unlike the other algorithms, this one is _not_ asynchronous: All nodes must handle the same
+//! messages, in the same order.
 //!
 //! ## Serialization
 //!

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -1,6 +1,6 @@
-//! # Asynchronous Subset algorithm.
+//! # Subset algorithm.
 //!
-//! The Asynchronous Subset protocol assumes a network of _N_ nodes that send signed
+//! The Subset protocol assumes a network of _N_ nodes that send signed
 //! messages to each other, with at most _f_ of them malicious, where _3 f < N_. Handling the
 //! networking and signing is the responsibility of the user: only when a message has been
 //! verified to be "from node i" (e.g. using cryptographic signatures), it can be handed to the
@@ -71,7 +71,7 @@ pub enum Message<N: Rand> {
     Agreement(N, agreement::Message),
 }
 
-/// Asynchronous Subset algorithm instance
+/// Subset algorithm instance
 #[derive(Debug)]
 pub struct Subset<N: Rand> {
     /// Shared network information.

--- a/tests/subset.rs
+++ b/tests/subset.rs
@@ -1,5 +1,5 @@
 #![deny(unused_must_use)]
-//! Integration tests of the Asynchronous Subset protocol.
+//! Integration tests of the Subset protocol.
 
 extern crate env_logger;
 extern crate hbbft;


### PR DESCRIPTION
* Make the `merkle` module private.
* Make sure the algorithm names are consistent.
* Add the Threshold Decryption and Synchronous Key Generation algorithms
  to the list in the main crate documentation.
* Remove some trailing whitespace from the README.
* Remove checkboxes: all algorithms are implemented.
* Link to the algorithm implementations, not the modules.
* Use relative links in the README.

Closes #100.