### PR TITLE
Spam protection part 1: remote epoch tracking in HoneyBadger

### DIFF
--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -435,20 +435,14 @@ fn main() {
         .map(|_| Transaction::new(args.flag_tx_size))
         .collect();
     let new_honey_badger = |netinfo: NetworkInfo<NodeId>| {
-        let (dyn_hb, dyn_hb_step) = DynamicHoneyBadger::builder()
+        let (dhb, dhb_step) = DynamicHoneyBadger::builder()
             .build(netinfo)
             .expect("`DynamicHoneyBadger` builder failed");
-        // Convert the initial step of the `DynamicHoneyBadger` instance into the initial step of
-        // the `QueueingHoneyBadger` instance.
-        let mut step = Step {
-            output: dyn_hb_step.output,
-            fault_log: dyn_hb_step.fault_log,
-            messages: dyn_hb_step.messages,
-        };
-        let (qhb, qhb_step) = QueueingHoneyBadger::builder(dyn_hb)
+        let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
             .batch_size(args.flag_b)
             .build_with_transactions(txs.clone())
             .expect("instantiate QueueingHoneyBadger");
+        let mut step = dhb_step.convert();
         step.extend(qhb_step);
         (qhb, step)
     };

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -48,12 +48,12 @@ where
     }
 
     /// Creates a new Dynamic Honey Badger instance with an empty buffer.
-    pub fn build(&self, netinfo: NetworkInfo<N>) -> DynamicHoneyBadger<C, N> {
+    pub fn build(&self, netinfo: NetworkInfo<N>) -> Result<(DynamicHoneyBadger<C, N>, Step<C, N>)> {
         let arc_netinfo = Arc::new(netinfo.clone());
-        let honey_badger = HoneyBadger::builder(arc_netinfo.clone())
+        let (honey_badger, hb_step) = HoneyBadger::builder(arc_netinfo.clone())
             .max_future_epochs(self.max_future_epochs)
             .build();
-        DynamicHoneyBadger {
+        let mut dhb = DynamicHoneyBadger {
             netinfo,
             max_future_epochs: self.max_future_epochs,
             start_epoch: 0,
@@ -62,11 +62,13 @@ where
             honey_badger,
             key_gen_state: None,
             incoming_queue: Vec::new(),
-        }
+        };
+        let step = dhb.process_output(hb_step)?;
+        Ok((dhb, step))
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
-    pub fn build_first_node(&self, our_id: N) -> Result<DynamicHoneyBadger<C, N>> {
+    pub fn build_first_node(&self, our_id: N) -> Result<(DynamicHoneyBadger<C, N>, Step<C, N>)> {
         let mut rng = rand::thread_rng();
         let sk_set = SecretKeySet::random(0, &mut rng)?;
         let pk_set = sk_set.public_keys();
@@ -74,7 +76,7 @@ where
         let sk: SecretKey = rng.gen();
         let pub_keys = once((our_id.clone(), sk.public_key())).collect();
         let netinfo = NetworkInfo::new(our_id, sks, pk_set, sk, pub_keys);
-        Ok(self.build(netinfo))
+        self.build(netinfo)
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to join the network at the epoch specified in
@@ -93,22 +95,26 @@ where
             join_plan.pub_keys,
         );
         let arc_netinfo = Arc::new(netinfo.clone());
-        let honey_badger = HoneyBadger::builder(arc_netinfo.clone())
+        let (honey_badger, hb_step) = HoneyBadger::builder(arc_netinfo.clone())
             .max_future_epochs(self.max_future_epochs)
             .build();
+        let start_epoch = join_plan.epoch;
         let mut dhb = DynamicHoneyBadger {
             netinfo,
             max_future_epochs: self.max_future_epochs,
-            start_epoch: join_plan.epoch,
+            start_epoch,
             vote_counter: VoteCounter::new(arc_netinfo, join_plan.epoch),
             key_gen_msg_buffer: Vec::new(),
             honey_badger,
             key_gen_state: None,
             incoming_queue: Vec::new(),
         };
-        let step = match join_plan.change {
-            ChangeState::InProgress(ref change) => dhb.update_key_gen(join_plan.epoch, change)?,
-            ChangeState::None | ChangeState::Complete(..) => Step::default(),
+        let mut step = dhb.process_output(hb_step)?;
+        match join_plan.change {
+            ChangeState::InProgress(ref change) => {
+                step.extend(dhb.update_key_gen(join_plan.epoch, change)?)
+            }
+            ChangeState::None | ChangeState::Complete(..) => (),
         };
         Ok((dhb, step))
     }

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -306,9 +306,7 @@ where
         } {
             info!("{:?} No-op change: {:?}", self.our_id(), change);
         }
-        let mut step: Step<C, N> = Step::default();
-        let step_on_restart = self.restart_honey_badger(epoch)?;
-        step.extend(step_on_restart);
+        let mut step = self.restart_honey_badger(epoch)?;
         // TODO: This needs to be the same as `num_faulty` will be in the _new_
         // `NetworkInfo` if the change goes through. It would be safer to deduplicate.
         let threshold = (pub_keys.len() - 1) / 3;

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -169,10 +169,6 @@ where
         sender_id: &N,
         message: HbMessage<N>,
     ) -> Result<Step<C, N>> {
-        if !self.netinfo.is_node_validator(sender_id) {
-            info!("Unknown sender {:?} of message {:?}", sender_id, message);
-            return Err(ErrorKind::UnknownSender.into());
-        }
         // Handle the message.
         let step = self
             .honey_badger

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -29,8 +29,6 @@ pub enum ErrorKind {
     HandleHoneyBadgerMessageHoneyBadger(honey_badger::Error),
     #[fail(display = "SyncKeyGen error: {}", _0)]
     SyncKeyGen(sync_key_gen::Error),
-    #[fail(display = "Unknown sender")]
-    UnknownSender,
 }
 
 /// A dynamic honey badger error.

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -1,16 +1,19 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 use rand::Rand;
 use serde::{Deserialize, Serialize};
 
-use super::HoneyBadger;
-use messaging::NetworkInfo;
+use super::{HoneyBadger, MessageContent, Step};
+use messaging::{NetworkInfo, Target};
 use traits::{Contribution, NodeIdT};
 
 /// A Honey Badger builder, to configure the parameters and create new instances of `HoneyBadger`.
-pub struct HoneyBadgerBuilder<C, N> {
+pub struct HoneyBadgerBuilder<C, N>
+where
+    N: Rand,
+{
     /// Shared network data.
     netinfo: Arc<NetworkInfo<N>>,
     /// The maximum number of future epochs for which we handle messages simultaneously.
@@ -39,15 +42,22 @@ where
         self
     }
 
-    /// Creates a new Honey Badger instance.
-    pub fn build(&self) -> HoneyBadger<C, N> {
-        HoneyBadger {
+    /// Creates a new Honey Badger instance in epoch 0 and makes the initial `Step` on that
+    /// instance.
+    pub fn build(&self) -> (HoneyBadger<C, N>, Step<C, N>) {
+        let hb = HoneyBadger {
             netinfo: self.netinfo.clone(),
             epoch: 0,
             has_input: false,
             epochs: BTreeMap::new(),
             max_future_epochs: self.max_future_epochs as u64,
             incoming_queue: BTreeMap::new(),
-        }
+            remote_epochs: BTreeMap::new(),
+        };
+        let mut msgs = VecDeque::new();
+        // The first message in an epoch announces the epoch transition.
+        msgs.push_back(Target::All.message(MessageContent::EpochStarted.with_epoch(0)));
+        let step = Step::new(Default::default(), Default::default(), msgs);
+        (hb, step)
     }
 }

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 use rand::Rand;
 use serde::{Deserialize, Serialize};
 
-use super::{HoneyBadger, MessageContent, Step};
+use super::{HoneyBadger, Message, Step};
 use messaging::{NetworkInfo, Target};
 use traits::{Contribution, NodeIdT};
 
@@ -54,10 +54,12 @@ where
             incoming_queue: BTreeMap::new(),
             remote_epochs: BTreeMap::new(),
         };
-        let mut msgs = VecDeque::new();
-        // The first message in an epoch announces the epoch transition.
-        msgs.push_back(Target::All.message(MessageContent::EpochStarted.with_epoch(0)));
-        let step = Step::new(Default::default(), Default::default(), msgs);
+        let step = if self.netinfo.is_validator() {
+            // The first message in an epoch announces the epoch transition.
+            Target::All.message(Message::EpochStarted(0)).into()
+        } else {
+            Step::default()
+        };
         (hb, step)
     }
 }

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -119,6 +119,19 @@ pub struct EpochState<C, N: Rand> {
     _phantom: PhantomData<C>,
 }
 
+#[derive(Debug)]
+pub struct HandledMessageContent<C, N>
+where
+    C: Contribution + Serialize + for<'r> Deserialize<'r>,
+    N: NodeIdT + Rand,
+{
+    /// The step output from processing message content.
+    pub(super) step: Step<C, N>,
+    /// The flag indicating whether the minimum epoch accepted by the remote Honey Badger instance
+    /// should be updated to the epoch of this message.
+    pub(super) update_epoch: bool,
+}
+
 impl<C, N> EpochState<C, N>
 where
     C: Contribution + Serialize + for<'r> Deserialize<'r>,
@@ -155,17 +168,24 @@ where
         &mut self,
         sender_id: &N,
         content: MessageContent<N>,
-    ) -> Result<Step<C, N>> {
+    ) -> Result<HandledMessageContent<C, N>> {
         match content {
             MessageContent::Subset(cs_msg) => {
                 let cs_step = self.subset.handle_message(sender_id, cs_msg)?;
                 self.process_subset(cs_step)
+                    .map(|step| HandledMessageContent {
+                        step,
+                        update_epoch: false,
+                    })
             }
             MessageContent::DecryptionShare { proposer_id, share } => {
                 if let Some(ref ids) = self.subset.accepted_ids() {
                     if !ids.contains(&proposer_id) {
                         let fault_kind = FaultKind::UnexpectedDecryptionShare;
-                        return Ok(Fault::new(sender_id.clone(), fault_kind).into());
+                        return Ok(HandledMessageContent {
+                            step: Fault::new(sender_id.clone(), fault_kind).into(),
+                            update_epoch: false,
+                        });
                     }
                 }
                 let td_step = match self.decryption.entry(proposer_id.clone()) {
@@ -176,7 +196,15 @@ where
                 }.handle_message(sender_id, share)
                 .map_err(ErrorKind::ThresholdDecryption)?;
                 self.process_decryption(proposer_id, td_step)
+                    .map(|step| HandledMessageContent {
+                        step,
+                        update_epoch: false,
+                    })
             }
+            MessageContent::EpochStarted => Ok(HandledMessageContent {
+                step: Step::default(),
+                update_epoch: true,
+            }),
         }
     }
 

--- a/src/honey_badger/error.rs
+++ b/src/honey_badger/error.rs
@@ -19,8 +19,8 @@ pub enum ErrorKind {
     HandleSubsetMessage(subset::Error),
     #[fail(display = "Threshold decryption error: {}", _0)]
     ThresholdDecryption(threshold_decryption::Error),
-    #[fail(display = "Unknown sender")]
-    UnknownSender,
+    #[fail(display = "HoneyBadger message sender is not a validator")]
+    SenderNotValidator,
 }
 
 /// A honey badger error.

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -127,10 +127,6 @@ where
 
     /// Handles an epoch start announcement.
     fn handle_epoch_started(&mut self, sender_id: &N, epoch: u64) {
-        self.update_remote_epoch(sender_id, epoch);
-    }
-
-    fn update_remote_epoch(&mut self, sender_id: &N, epoch: u64) {
         self.remote_epochs
             .entry(sender_id.clone())
             .and_modify(|e| {

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -88,11 +88,11 @@ where
 
     /// Handles a message received from `sender_id`.
     fn handle_message(&mut self, sender_id: &N, message: Message<N>) -> Result<Step<C, N>> {
-        if !self.netinfo.is_node_validator(sender_id) {
-            return Err(ErrorKind::UnknownSender.into());
-        }
         match message {
-            Message::HoneyBadgerMessage { epoch, content } => {
+            Message::HoneyBadger { epoch, content } => {
+                if !self.netinfo.is_node_validator(sender_id) {
+                    return Err(ErrorKind::SenderNotValidator.into());
+                }
                 self.handle_honey_badger_message(sender_id, epoch, content)
             }
             Message::EpochStarted(epoch) => {

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -133,8 +133,7 @@ where
                 if *e < epoch {
                     *e = epoch;
                 }
-            })
-            .or_insert(epoch);
+            }).or_insert(epoch);
     }
 
     /// Returns `true` if input for the current epoch has already been provided.

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -13,6 +13,10 @@ pub enum MessageContent<N: Rand> {
         proposer_id: N,
         share: threshold_decryption::Message,
     },
+    /// A Honey Badger participant uses this message to announce its transition to the given
+    /// epoch. This message informs the recipients that this participant now accepts messages for
+    /// `max_future_epochs + 1` epochs counting from the given one.
+    EpochStarted,
 }
 
 impl<N: Rand> MessageContent<N> {

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -4,7 +4,7 @@ use subset;
 use threshold_decryption;
 
 /// The content of a `HoneyBadger` message. It should be further annotated with an epoch.
-#[derive(Clone, Debug, Deserialize, Rand, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Rand, Serialize)]
 pub enum MessageContent<N: Rand> {
     /// A message belonging to the subset algorithm in the given epoch.
     Subset(subset::Message<N>),
@@ -13,15 +13,11 @@ pub enum MessageContent<N: Rand> {
         proposer_id: N,
         share: threshold_decryption::Message,
     },
-    /// A Honey Badger participant uses this message to announce its transition to the given
-    /// epoch. This message informs the recipients that this participant now accepts messages for
-    /// `max_future_epochs + 1` epochs counting from the given one.
-    EpochStarted,
 }
 
 impl<N: Rand> MessageContent<N> {
     pub fn with_epoch(self, epoch: u64) -> Message<N> {
-        Message {
+        Message::HoneyBadgerMessage {
             epoch,
             content: self,
         }
@@ -30,13 +26,23 @@ impl<N: Rand> MessageContent<N> {
 
 /// A message sent to or received from another node's Honey Badger instance.
 #[derive(Clone, Debug, Deserialize, Rand, Serialize)]
-pub struct Message<N: Rand> {
-    pub(super) epoch: u64,
-    pub(super) content: MessageContent<N>,
+pub enum Message<N: Rand> {
+    /// Honey Badger algorithm message annotated with the epoch number.
+    HoneyBadgerMessage {
+        epoch: u64,
+        content: MessageContent<N>,
+    },
+    /// A Honey Badger participant uses this message to announce its transition to the given
+    /// epoch. This message informs the recipients that this participant now accepts messages for
+    /// `max_future_epochs + 1` epochs counting from the given one.
+    EpochStarted(u64),
 }
 
 impl<N: Rand> Message<N> {
     pub fn epoch(&self) -> u64 {
-        self.epoch
+        match *self {
+            Message::HoneyBadgerMessage { epoch, .. } => epoch,
+            Message::EpochStarted(epoch) => epoch,
+        }
     }
 }

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -17,7 +17,7 @@ pub enum MessageContent<N: Rand> {
 
 impl<N: Rand> MessageContent<N> {
     pub fn with_epoch(self, epoch: u64) -> Message<N> {
-        Message::HoneyBadgerMessage {
+        Message::HoneyBadger {
             epoch,
             content: self,
         }
@@ -27,21 +27,23 @@ impl<N: Rand> MessageContent<N> {
 /// A message sent to or received from another node's Honey Badger instance.
 #[derive(Clone, Debug, Deserialize, Rand, Serialize)]
 pub enum Message<N: Rand> {
-    /// Honey Badger algorithm message annotated with the epoch number.
-    HoneyBadgerMessage {
+    /// A Honey Badger algorithm message annotated with the epoch number.
+    HoneyBadger {
         epoch: u64,
         content: MessageContent<N>,
     },
     /// A Honey Badger participant uses this message to announce its transition to the given
     /// epoch. This message informs the recipients that this participant now accepts messages for
-    /// `max_future_epochs + 1` epochs counting from the given one.
+    /// `max_future_epochs + 1` epochs counting from the given one, and drops any incoming messages
+    /// from earlier epochs.
     EpochStarted(u64),
 }
 
 impl<N: Rand> Message<N> {
+    /// Returns the epoch from which the message originated.
     pub fn epoch(&self) -> u64 {
         match *self {
-            Message::HoneyBadgerMessage { epoch, .. } => epoch,
+            Message::HoneyBadger { epoch, .. } => epoch,
             Message::EpochStarted(epoch) => epoch,
         }
     }

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -62,7 +62,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 type ProposedValue = Vec<u8>;
 
 /// Message from Subset to remote nodes.
-#[derive(Serialize, Deserialize, Clone, Debug, Rand)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
 pub enum Message<N: Rand> {
     /// A message for the broadcast algorithm concerning the set element proposed by the given node.
     Broadcast(N, broadcast::Message),

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use rand::Rng;
 
-use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input};
+use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input, Step};
 use hbbft::messaging::NetworkInfo;
 use hbbft::transaction_queue::TransactionQueue;
 
@@ -122,8 +122,10 @@ where
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-fn new_dynamic_hb(netinfo: Arc<NetworkInfo<NodeId>>) -> UsizeDhb {
-    DynamicHoneyBadger::builder().build((*netinfo).clone())
+fn new_dynamic_hb(netinfo: Arc<NetworkInfo<NodeId>>) -> (UsizeDhb, Step<Vec<usize>, NodeId>) {
+    DynamicHoneyBadger::builder()
+        .build((*netinfo).clone())
+        .expect("`new_dynamic_hb` failed")
 }
 
 fn test_dynamic_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
@@ -145,7 +147,8 @@ where
             num_good_nodes, num_adv_nodes
         );
         let adversary = |adv_nodes| new_adversary(num_good_nodes, num_adv_nodes, adv_nodes);
-        let network = TestNetwork::new(num_good_nodes, num_adv_nodes, adversary, new_dynamic_hb);
+        let network =
+            TestNetwork::new_with_step(num_good_nodes, num_adv_nodes, adversary, new_dynamic_hb);
         test_dynamic_honey_badger(network, num_txs);
     }
 }

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use rand::Rng;
 
-use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent};
+use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent, Step};
 use hbbft::messaging::{NetworkInfo, Target, TargetedMessage};
 use hbbft::threshold_decryption;
 use hbbft::transaction_queue::TransactionQueue;
@@ -185,7 +185,9 @@ where
     }
 }
 
-fn new_honey_badger(netinfo: Arc<NetworkInfo<NodeId>>) -> UsizeHoneyBadger {
+fn new_honey_badger(
+    netinfo: Arc<NetworkInfo<NodeId>>,
+) -> (UsizeHoneyBadger, Step<Vec<usize>, NodeId>) {
     HoneyBadger::builder(netinfo).build()
 }
 
@@ -207,7 +209,8 @@ where
             num_good_nodes, num_adv_nodes
         );
         let adversary = |adv_nodes| new_adversary(num_good_nodes, num_adv_nodes, adv_nodes);
-        let network = TestNetwork::new(num_good_nodes, num_adv_nodes, adversary, new_honey_badger);
+        let network =
+            TestNetwork::new_with_step(num_good_nodes, num_adv_nodes, adversary, new_honey_badger);
         test_honey_badger(network, num_txs);
     }
 }

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -68,9 +68,9 @@ fn do_drop_and_readd(
     let mut net = NetBuilder::new(0..total)
         .num_faulty(num_faulty)
         .message_limit(200_000)  // Limited to 200k messages for now.
-        .using(move |node| {
+        .using_step(move |node| {
             println!("Constructing new dynamic honey badger node #{}", node.id);
-            DynamicHoneyBadger::builder().build(node.netinfo)
+            DynamicHoneyBadger::builder().build(node.netinfo).expect("cannot build instance")
         }).build()
         .expect("could not construct test network");
 

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -110,14 +110,8 @@ fn new_queueing_hb(
     let (dhb, dhb_step) = DynamicHoneyBadger::builder()
         .build((*netinfo).clone())
         .expect("`new_queueing_hb` failed");
-    // Convert the initial step of the `DynamicHoneyBadger` instance into the initial step of
-    // the `QueueingHoneyBadger` instance.
-    let mut step = Step {
-        output: dhb_step.output,
-        fault_log: dhb_step.fault_log,
-        messages: dhb_step.messages,
-    };
     let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb).batch_size(3).build();
+    let mut step = dhb_step.convert();
     step.extend(qhb_step);
     (qhb, step)
 }

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -107,8 +107,19 @@ where
 fn new_queueing_hb(
     netinfo: Arc<NetworkInfo<NodeId>>,
 ) -> (QueueingHoneyBadger<usize, NodeId>, Step<usize, NodeId>) {
-    let dyn_hb = DynamicHoneyBadger::builder().build((*netinfo).clone());
-    QueueingHoneyBadger::builder(dyn_hb).batch_size(3).build()
+    let (dhb, dhb_step) = DynamicHoneyBadger::builder()
+        .build((*netinfo).clone())
+        .expect("`new_queueing_hb` failed");
+    // Convert the initial step of the `DynamicHoneyBadger` instance into the initial step of
+    // the `QueueingHoneyBadger` instance.
+    let mut step = Step {
+        output: dhb_step.output,
+        fault_log: dhb_step.fault_log,
+        messages: dhb_step.messages,
+    };
+    let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb).batch_size(3).build();
+    step.extend(qhb_step);
+    (qhb, step)
 }
 
 fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)


### PR DESCRIPTION
This PR adds a basic part of the spam protection functionality according to #43. The following are added:

1. a map of known `HoneyBadger` epochs of remote `HoneyBadger` nodes;
2. a message broadcast to all remote nodes signalling the start of an epoch;
3. a step output from the builders of `HoneyBadger`, `DynamicHoneyBadger` and `QueueingHoneyBadger`, with the necessary adjustments in tests and in the simulation.

The tests now pass and the PR is ready for review.