### PR TITLE
Advance to Rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,9 @@ env:
   global:
     - RUST_BACKTRACE=1
     - RUSTFLAGS="-D warnings"
-    # Note: Currently (as of 2018-07-13), `clippy-preview` is only in the nightly
-    #       release. A version of `rustfmt` that supports the `--check` option
-    #       is also not in stable yet.
-    #
-    #       A Clear migration path is swapping out `nightly-2018-07-13` with
-    #       `beta` after the stable release of Rust 1.28; and finally migrating
-    #       everything to `stable` at Rust 1.29.
-    - RUST_NEXT=nightly-2018-07-13
+    # Note: `beta` should be removed along with `RUST_NEXT` after the 1.28
+    #       stable release on 2018-09-13.
+    - RUST_NEXT=beta
     - MLOCK_SECRETS=false
 script:
   - cargo +${RUST_NEXT} clippy -- --deny clippy

--- a/examples/network/connection.rs
+++ b/examples/network/connection.rs
@@ -41,7 +41,6 @@ pub fn make(
                 TcpStream::connect(address).expect("failed to connect")
             };
             Connection::new(tcp_conn, there_str.to_string())
-        })
-        .collect();
+        }).collect();
     (here_str, connections)
 }

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -213,8 +213,7 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                 .send(())
                 .map_err(|e| {
                     error!("{}", e);
-                })
-                .unwrap();
+                }).unwrap();
 
             process::exit(0);
         }) // end of thread scope

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -156,8 +156,7 @@ where
                     target: msg.target,
                     message: ser_msg,
                 }
-            })
-            .collect();
+            }).collect();
         let outputs = step
             .output
             .into_iter()
@@ -204,8 +203,7 @@ where
             .map(|msg| {
                 let ser_msg = bincode::serialize(&msg.message).expect("serialize");
                 (msg.target, ser_msg)
-            })
-            .collect();
+            }).collect();
         self.time += start.elapsed() * self.hw_quality.cpu_factor / 100;
         let time = self.time;
         self.outputs

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -343,8 +343,7 @@ impl<N: NodeIdT> Broadcast<N> {
                         None
                     }
                 })
-            })
-            .collect();
+            }).collect();
         if let Some(value) =
             decode_from_shards(&mut leaf_values, &self.coding, self.data_shard_num, hash)
         {

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -116,8 +116,7 @@ where
                 contrib,
                 key_gen_messages: self.key_gen_msg_buffer.clone(),
                 votes: self.vote_counter.pending_votes().cloned().collect(),
-            })
-            .map_err(ErrorKind::ProposeHoneyBadger)?;
+            }).map_err(ErrorKind::ProposeHoneyBadger)?;
         self.process_output(step)
     }
 

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -66,11 +66,10 @@ where
         sender_id: &N,
         signed_vote: SignedVote<N>,
     ) -> Result<FaultLog<N>> {
-        if signed_vote.vote.era != self.era
-            || self
-                .pending
-                .get(&signed_vote.voter)
-                .map_or(false, |sv| sv.vote.num >= signed_vote.vote.num)
+        if signed_vote.vote.era != self.era || self
+            .pending
+            .get(&signed_vote.voter)
+            .map_or(false, |sv| sv.vote.num >= signed_vote.vote.num)
         {
             return Ok(FaultLog::new()); // The vote is obsolete or already exists.
         }
@@ -149,8 +148,8 @@ where
 
     /// Returns `true` if the signature is valid.
     fn validate(&self, signed_vote: &SignedVote<N>) -> Result<bool> {
-        let ser_vote =
-            bincode::serialize(&signed_vote.vote).map_err(|err| ErrorKind::ValidateBincode(*err))?;
+        let ser_vote = bincode::serialize(&signed_vote.vote)
+            .map_err(|err| ErrorKind::ValidateBincode(*err))?;
         let pk_opt = self.netinfo.public_key(&signed_vote.voter);
         Ok(pk_opt.map_or(false, |pk| pk.verify(&signed_vote.sig, ser_vote)))
     }

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -138,7 +138,8 @@ where
 
     /// If the instance hasn't terminated yet, inputs our encrypted contribution.
     pub fn propose(&mut self, ciphertext: &Ciphertext) -> Result<Step<C, N>> {
-        let ser_ct = bincode::serialize(ciphertext).map_err(|err| ErrorKind::ProposeBincode(*err))?;
+        let ser_ct =
+            bincode::serialize(ciphertext).map_err(|err| ErrorKind::ProposeBincode(*err))?;
         let cs_step = self.subset.handle_input(ser_ct)?;
         self.process_subset(cs_step)
     }
@@ -173,7 +174,7 @@ where
                         entry.insert(DecryptionState::new(self.netinfo.clone()))
                     }
                 }.handle_message(sender_id, share)
-                    .map_err(ErrorKind::ThresholdDecryption)?;
+                .map_err(ErrorKind::ThresholdDecryption)?;
                 self.process_decryption(proposer_id, td_step)
             }
         }

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -131,7 +131,8 @@ impl<N: NodeIdT + Rand> Subset<N> {
         for proposer_id in netinfo.all_ids() {
             broadcast_instances.insert(
                 proposer_id.clone(),
-                Broadcast::new(netinfo.clone(), proposer_id.clone()).map_err(Error::NewBroadcast)?,
+                Broadcast::new(netinfo.clone(), proposer_id.clone())
+                    .map_err(Error::NewBroadcast)?,
             );
         }
 

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -480,8 +480,7 @@ impl<N: NodeIdT> SyncKeyGen<N> {
                     err
                 );
                 Fault::ValueDeserialization
-            })?
-            .into_inner();
+            })?.into_inner();
         if part.commit.evaluate(our_idx + 1, sender_idx + 1) != G1Affine::one().mul(val) {
             return Err(Fault::ValueInvalid);
         }

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -83,8 +83,7 @@ where
                     // If there's only one node, it will immediately output on input. Make sure we
                     // first process all incoming messages before providing input again.
                     && (network.nodes.len() > 2 || node.queue.is_empty())
-            })
-            .map(|(id, _)| *id)
+            }).map(|(id, _)| *id)
             .collect();
         if let Some(id) = rng.choose(&input_ids) {
             let queue = queues.get_mut(id).unwrap();

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -176,8 +176,7 @@ where
                      epoch,
                      contributions,
                  }| (epoch, contributions),
-            )
-            .collect();
+            ).collect();
         if expected.is_none() {
             expected = Some(outputs);
         } else if let Some(expected) = &expected {

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -525,8 +525,7 @@ where
                 });
                 steps.insert(id.clone(), step);
                 (id, Node::new(algorithm, is_faulty))
-            })
-            .collect();
+            }).collect();
 
         let mut message_count: usize = 0;
         // For every recorded step, apply it.
@@ -732,8 +731,7 @@ where
                     node.id().clone(),
                     node.algorithm.handle_input(input.clone())?,
                 ))
-            })
-            .collect::<Result<_, _>>()?;
+            }).collect::<Result<_, _>>()?;
 
         // Process all messages from all steps in the queue.
         steps.iter().for_each(|(id, step)| {

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -32,8 +32,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
                 .unwrap_or_else(|_err| panic!("Failed to create `SyncKeyGen` instance #{}", id));
             nodes.push(sync_key_gen);
             proposal
-        })
-        .collect();
+        }).collect();
 
     // Handle the first `threshold + 1` proposals. Those should suffice for key generation.
     let mut acks = Vec::new();
@@ -81,8 +80,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
             let sig = sk.sign(msg);
             assert!(pks.public_key_share(idx).verify(&sig, msg));
             (idx, sig)
-        })
-        .collect();
+        }).collect();
     let sig = pub_key_set
         .combine_signatures(sig_shares.iter().take(threshold + 1))
         .expect("signature shares match");


### PR DESCRIPTION
For the planned migration to Rust 1.29, switch the CI over to the now working beta (tested with `rustc 1.29.0-beta.7 (49720ea9c 2018-08-26)`). The following advance to 1.29 should ideally be seamless afterwards.