### PR TITLE
Temporarily disable clippy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,10 @@ env:
     - RUST_NEXT=beta
     - MLOCK_SECRETS=false
 script:
-  - cargo +${RUST_NEXT} clippy -- --deny clippy
-  - cargo +${RUST_NEXT} clippy --tests --examples -- --deny clippy
-  - cargo +${RUST_NEXT} clippy --all-features -- --deny clippy
-  - cargo +${RUST_NEXT} clippy --all-features --tests -- --deny clippy
+  # Clippy is disabled until the switch to stable.
+  # - cargo +${RUST_NEXT} clippy -- --deny clippy
+  # - cargo +${RUST_NEXT} clippy --tests --examples -- --deny clippy
+  # - cargo +${RUST_NEXT} clippy --all-features -- --deny clippy
+  # - cargo +${RUST_NEXT} clippy --all-features --tests -- --deny clippy
   - cargo +${RUST_NEXT} fmt -- --check
   - cargo test --all-features --release -- --test-threads 1


### PR DESCRIPTION
Currently, Clippy is a mess on travis and elsewhere, with the switch from beta to stable adding in numerous other problems. This PR disables it until we decide whether to reenable it fully, partially or not at all after pinning stable.