### PR TITLE
Enable overflow-checks and fix a bug that slipped through during their absence.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,9 @@ name = "consensus-node"
 
 [[example]]
 name = "simulation"
+
+# This will turn on overflow checks in `cargo test --release` and
+# `cargo bench`. Dependencies will not be affected, as they use the
+# `[profile.release]` block in both cases.
+[profile.bench]
+overflow-checks = true

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -54,7 +54,7 @@ impl NetworkDimension {
         };
 
         // Reduce the number of faulty nodes, if we are outside our limits.
-        if !half.faulty * 3 <= half.size {
+        if !(half.faulty * 3 <= half.size) {
             half.faulty -= 1;
         }
 


### PR DESCRIPTION
When run with `--release`, `cargo test` will use `[profile.bench]` to compile the crate itself, but all dependencies use `[profile.release]`. This is both an excellent trap to fall into and a nifty default to exploit when one is aware of the fact.

The PR fixes a bug that made it through (`!` is both logical and bitwise negation in Rust) but would have been caught by overflow checks, and enables these checks even for `--release` tests (but not builds).

After careful benchmarking, the `[profile.release]` was not altered due to the performance being noticeably worse when `overflow-checks` are added there. There might be some merit in adding them in the `[profile.bench]` section in `threshold_crypto` as well, provided the tests are smaller.

CC'ing @afck for the heads-up!