### PR TITLE
Add a test time limit.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -123,6 +123,23 @@ assert!(net.nodes().all(|node| node.outputs() == first));
 println!("End result: {:?}", first);
 ```
 
+### Time-limits
+
+Every `VirtualNet` instance limits execution time to 20 minutes by default, this can be adjusted using the `time_limit` function:
+
+```rust
+use std::time;
+
+let num_nodes = 10;
+let mut net = NetBuilder::new(0..num_nodes)
+    // Change the time limit to five minutes per node total.
+    .time_limit(time::Duration::from_secs(num_nodes * 5 * 60))
+```
+
+If the time limit has been reached, `crank` will return a `TimeLimitHit` error. The time-limit can be disabled completely through `no_time_limit()`.
+
+It's also possible to run tests without a time-limit on a per-run basis by setting the `HBBFT_NO_TIME_LIMIT` environment variable to "true".
+
 ### Property based testing
 
 Many higher-level tests allow for a variety of different input parameters like the number of nodes in a network or the amount of faulty ones among them. Other possible parameters include transaction, batch or contribution sizes. To test a variety of randomized combinations of these, the [proptest](https://docs.rs/proptest) crate should be used.

--- a/tests/net/err.rs
+++ b/tests/net/err.rs
@@ -1,6 +1,6 @@
 //! Test network errors
 
-use std::fmt;
+use std::{fmt, time};
 
 use failure;
 use hbbft::messaging::DistAlgorithm;
@@ -27,6 +27,8 @@ where
     CrankLimitExceeded(usize),
     /// The configured maximum number of messages has been reached or exceeded.
     MessageLimitExceeded(usize),
+    /// The execution time limit has been reached or exceeded.
+    TimeLimitHit(time::Duration),
 }
 
 // Note: Deriving [Debug](std::fmt::Debug), [Fail](failure::Fail) and through that,
@@ -60,6 +62,9 @@ where
             CrankError::MessageLimitExceeded(max) => {
                 write!(f, "Maximum number of messages exceeded: {}", max)
             }
+            CrankError::TimeLimitHit(lim) => {
+                write!(f, "Time limit of {} seconds exceeded.", lim.as_secs())
+            }
         }
     }
 }
@@ -82,6 +87,7 @@ where
             CrankError::MessageLimitExceeded(max) => {
                 f.debug_tuple("MessageLimitExceeded").field(max).finish()
             }
+            CrankError::TimeLimitHit(lim) => f.debug_tuple("TimeLimitHit").field(lim).finish(),
         }
     }
 }

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -272,7 +272,7 @@ where
     crank_limit: Option<usize>,
     /// Optional message limit.
     message_limit: Option<usize>,
-    /// Optoinal time limit.
+    /// Optional time limit.
     time_limit: Option<time::Duration>,
 }
 
@@ -336,7 +336,7 @@ where
 
     /// Set a crank limit.
     ///
-    /// Crank limits are useful to limit execution time and reign in adversary. Otherwise, message
+    /// Crank limits are useful to limit execution time and rein in adversary. Otherwise, message
     /// limits are typically more useful. After the limit is hit, any call to `crank` will return a
     /// `CrankError::CrankLimitExceeded`.
     #[inline]
@@ -377,7 +377,7 @@ where
     /// Time limit.
     ///
     /// Sets the time limit; `crank` will fail if called after this much time as elapsed since
-    /// the first time it was ever called.
+    /// the network was instantiated.
     #[inline]
     pub fn time_limit(mut self, limit: time::Duration) -> Self {
         self.time_limit = Some(limit);

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -427,6 +427,20 @@ where
     /// If the total number of nodes is not `> 3 * num_faulty`, construction will panic.
     #[inline]
     pub fn build(self) -> Result<VirtualNet<D>, crypto::error::Error> {
+        // The time limit can be overriden on the command-line:
+        let override_time_limit = env::var("HBBFT_NO_TIME_LIMIT")
+            // We fail early, to avoid tricking the user into thinking that they have set the time
+            // limit when they haven't.
+            .map(|s| s.parse().expect("could not parse `HBBFT_NO_TIME_LIMIT`"))
+            .unwrap_or(false);
+
+        let time_limit = if override_time_limit {
+            eprintln!("WARNING: The time limit for individual tests has been manually disabled through `HBBFT_NO_TIME_LIMIT`.");
+            None
+        } else {
+            self.time_limit
+        };
+
         let cons = self
             .cons
             .as_ref()

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -19,7 +19,7 @@ pub mod proptest;
 pub mod util;
 
 use std::io::Write;
-use std::{cmp, collections, env, fmt, fs, io, ops, process};
+use std::{cmp, collections, env, fmt, fs, io, ops, process, time};
 
 use rand;
 use rand::Rand;
@@ -29,6 +29,9 @@ use hbbft::messaging::{self, DistAlgorithm, NetworkInfo, Step};
 
 pub use self::adversary::Adversary;
 pub use self::err::CrankError;
+
+/// The time limit for any network if none was specified.
+const DEFAULT_TIME_LIMIT: Option<time::Duration> = Some(time::Duration::from_secs(60 * 20));
 
 /// Helper macro for tracing.
 ///
@@ -269,6 +272,8 @@ where
     crank_limit: Option<usize>,
     /// Optional message limit.
     message_limit: Option<usize>,
+    /// Optoinal time limit.
+    time_limit: Option<time::Duration>,
 }
 
 impl<D, I> fmt::Debug for NetBuilder<D, I>
@@ -313,6 +318,7 @@ where
             trace: None,
             crank_limit: None,
             message_limit: None,
+            time_limit: DEFAULT_TIME_LIMIT,
         }
     }
 
@@ -350,12 +356,31 @@ where
         self
     }
 
+    /// Remove the time limit.
+    ///
+    /// Removes any time limit from the builder.
+    #[inline]
+    pub fn no_time_limit(mut self) -> Self {
+        self.time_limit = None;
+        self
+    }
+
     /// Number of faulty nodes.
     ///
     /// Indicates the number of nodes that should be marked faulty.
     #[inline]
     pub fn num_faulty(mut self, num_faulty: usize) -> Self {
         self.num_faulty = num_faulty;
+        self
+    }
+
+    /// Time limit.
+    ///
+    /// Sets the time limit; `crank` will fail if called after this much time as elapsed since
+    /// the first time it was ever called.
+    #[inline]
+    pub fn time_limit(mut self, limit: time::Duration) -> Self {
+        self.time_limit = Some(limit);
         self
     }
 


### PR DESCRIPTION
Adds a wall-clock time limit to virtual networks, the default is 20 minutes. It can be changed or disabled in a variety of ways.

Briefly tested, but not unit tests at the moment (a generic testing-`DistAlgorithm` is still missing). The merge should be squashed.