### PR TITLE
Change the time limit to five minutes for now.

### DIFF
--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -31,7 +31,7 @@ pub use self::adversary::Adversary;
 pub use self::err::CrankError;
 
 /// The time limit for any network if none was specified.
-const DEFAULT_TIME_LIMIT: Option<time::Duration> = Some(time::Duration::from_secs(60 * 20));
+const DEFAULT_TIME_LIMIT: Option<time::Duration> = Some(time::Duration::from_secs(60 * 5));
 
 /// Helper macro for tracing.
 ///


### PR DESCRIPTION
Until we arrive at a better solution, this should at least give us some output when a test hangs.