### PR TITLE
Make Subset optimization optional

### DIFF
--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -21,6 +21,7 @@ pub struct DynamicHoneyBadgerBuilder<C, N> {
     /// Random number generator passed on to algorithm instance for key generation. Also used to
     /// instantiate `HoneyBadger`.
     rng: Box<dyn rand::Rng>,
+    /// Strategy used to handle the output of the `Subset` algorithm.
     subset_handling_strategy: SubsetHandlingStrategy,
     _phantom: PhantomData<(C, N)>,
 }
@@ -60,6 +61,7 @@ where
         self
     }
 
+    /// Sets the strategy to use when handling `Subset` output.
     pub fn subset_handling_strategy(
         &mut self,
         subset_handling_strategy: SubsetHandlingStrategy,

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -22,6 +22,7 @@ where
     max_future_epochs: usize,
     /// Random number generator passed on to algorithm instance for signing and encrypting.
     rng: Box<dyn Rng>,
+    /// Strategy used to handle the output of the `Subset` algorithm.
     subset_handling_strategy: SubsetHandlingStrategy,
     _phantom: PhantomData<C>,
 }
@@ -55,6 +56,7 @@ where
         self
     }
 
+    /// Sets the strategy to use when handling `Subset` output.
     pub fn subset_handling_strategy(
         &mut self,
         subset_handling_strategy: SubsetHandlingStrategy,

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -110,20 +110,26 @@ where
 /// proposals from a `Subset` instance.
 #[derive(Debug, Clone)]
 pub enum SubsetHandlingStrategy {
+    /// Sets the `EpochState` to return proposals as they are contributed.
     Incremental,
+    /// Sets the `EpochState` to return all received proposals once consensus has been finalized.
     AllAtEnd,
 }
 
 /// Used in an `EpochState` to encapsulate the state necessary to maintain each
 /// `SubsetHandlingStrategy`.
 #[derive(Debug, Clone)]
-pub enum SubsetHandler<N> {
+enum SubsetHandler<N> {
     Incremental,
     AllAtEnd(Vec<(N, Vec<u8>)>),
 }
 
-pub struct SubsetHandleData<N> {
+/// The result of a call to `SubsetHandler::handle(...)`.
+struct SubsetHandleData<N> {
+    /// The number of contributions propagated from the handler.
     contributions: Vec<(N, Vec<u8>)>,
+    /// Indicates whether the underlying `Subset` algorithm has achieved consensus and whether
+    /// there may be more contributions or not.
     is_done: bool,
 }
 

--- a/src/honey_badger/mod.rs
+++ b/src/honey_badger/mod.rs
@@ -32,5 +32,5 @@ mod message;
 pub use self::batch::Batch;
 pub use self::builder::HoneyBadgerBuilder;
 pub use self::error::{Error, ErrorKind, Result};
-pub use self::honey_badger::{HoneyBadger, Step};
+pub use self::honey_badger::{HoneyBadger, Step, SubsetHandlingStrategy};
 pub use self::message::{Message, MessageContent};


### PR DESCRIPTION
Fixes #243. Allow client code to control the behavior of `EpochState` and when it decides to send decryption shares. There are two options for the behavior for handling the output of a `Subset` algorithm, which are represented by the new `SubsetHandlingStrategy` (bikeshedding welcome!) enum:

1) `Incremental`, which is the current (optimized) behavior.
2) `AllAtEnd`, which is supposed to be the old behavior. *Reviewers crunched for time might want to place priority on making sure I've done this right.*

`SubsetHandlingStrategy` is exposed at the builder level. Internally, an `EpochState` instance now stores a `SubsetHandler` enum member that models the necessary state for each different strategy. To resolve ownership issues, I've changed `EpochState::{process_decryption,send_decryption_share}` to take members of the `EpochState` struct instead of the entire struct (`self`). I've also created the `finalize_subset_with_step` method which also uses members and not `self`.

~~Tests compile, but I'm currently blocked on https://github.com/poanetwork/hbbft/issues/249 for testing locally until I get home and have access to my *nix machines.~~

## Current concerns

- [ ] Bikeshedding on new symbol names?