### PR TITLE
Fix test-case shrinking issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ itertools = "0.7"
 serde_derive = "1.0.55"
 signifix = "0.9"
 proptest = "0.8.7"
+# Note: `rand_core` is solely used for the randomness adapter in `net_utils.rs`
+#       tests and should be removed as soon as a migration path to rand 0.5
+#       appears.
+rand_core = "0.2.1"
 
 [[example]]
 name = "consensus-node"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ proptest = "0.8.7"
 #       tests and should be removed as soon as a migration path to rand 0.5
 #       appears.
 rand_core = "0.2.1"
+integer-sqrt = "0.1.1"
 
 [[example]]
 name = "consensus-node"

--- a/tests/README.md
+++ b/tests/README.md
@@ -150,8 +150,8 @@ fn do_example_test(seed: TestRngSeed, dimension: NetworkDimension) {
     // Instantiates a new random number generator for the test.
     let mut rng: TestRng = TestRng::from_seed(cfg.seed);
 
-    let mut net = NetBuilder::new(0..dimension.size)
-        .num_faulty(cfg.dimension.faulty)
+    let mut net = NetBuilder::new(0..dimension.size())
+        .num_faulty(cfg.dimension.faulty())
         // Setting `rng` ensures that randomness will only be retrieved by
         // `VirtualNet` from the `TestRng` instantiated above.
         .rng(rng)
@@ -199,8 +199,8 @@ proptest! {
 }
 
 fn do_basic_operations(dimension: NetworkDimension, num_txs: u32) {
-    let mut net = NetBuilder::new(0..cfg.dimension.size)
-        .num_faulty(cfg.dimension.faulty)
+    let mut net = NetBuilder::new(0..cfg.dimension.size())
+        .num_faulty(cfg.dimension.faulty())
         // ...
 }
 ```

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -491,7 +491,9 @@ where
 
         // Note: Closure is not redundant, won't compile without it.
         #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
-        let mut net = VirtualNet::new(self.node_ids, self.num_faulty, rng, move |node| cons(node))?;
+        let mut net = VirtualNet::new(self.node_ids, self.num_faulty as usize, rng, move |node| {
+            cons(node)
+        })?;
 
         if self.adversary.is_some() {
             net.adversary = self.adversary;

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -76,7 +76,7 @@ impl NetworkDimension {
         };
 
         // Reduce the number of faulty nodes, if we are outside our limits.
-        if half.faulty * 3 > half.size {
+        if !half.is_bft() {
             half.faulty -= 1;
         }
 

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -60,18 +60,18 @@ impl NetworkDimension {
     }
 
     #[inline]
-    pub fn faulty(&self) -> usize {
+    pub fn faulty(self) -> usize {
         self.faulty.into()
     }
 
     #[inline]
-    pub fn size(&self) -> usize {
+    pub fn size(self) -> usize {
         self.size.into()
     }
 
     /// Checks whether the network dimension satisfies the `3 * faulty + 1 <= size` condition.
     #[inline]
-    fn is_bft(&self) -> bool {
+    fn is_bft(self) -> bool {
         self.faulty * 3 < self.size
     }
 
@@ -87,7 +87,7 @@ impl NetworkDimension {
     /// function returns the next-higher valid instance by first trying to increase `faulty`, then
     /// `size`.
     #[inline]
-    pub fn succ(&self) -> NetworkDimension {
+    pub fn succ(self) -> NetworkDimension {
         let mut n = self.size;
         let mut f = self.faulty + 1;
 
@@ -189,9 +189,9 @@ impl From<NetworkDimension> for u32 {
         // We observe that each block starts at index `3 * (b(b+1)/2)`. Along with the offset,
         // we can calculate a mapping onto the natural numbers using this:
 
-        let b = (dim.size as u32 - 1) / 3;
+        let b = (u32::from(dim.size) - 1) / 3;
         let start = 3 * b * (b + 1) / 2;
-        let offset = (dim.size as u32 - 3 * b - 1) * (b + 1) + dim.faulty as u32;
+        let offset = (u32::from(dim.size) - 3 * b - 1) * (b + 1) + u32::from(dim.faulty);
 
         start + offset
     }

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -47,11 +47,13 @@ impl NetworkDimension {
     ///
     /// Dimensions that do not satisfy BFT conditions (see `is_bft`) can be created using this
     /// function.
+    #[inline]
     pub fn new(size: usize, faulty: usize) -> Self {
         NetworkDimension { size, faulty }
     }
 
     /// Checks whether the network dimension satisfies the `3 * faulty + 1 <= size` condition.
+    #[inline]
     pub fn is_bft(&self) -> bool {
         self.faulty * 3 < self.size
     }
@@ -87,6 +89,7 @@ impl NetworkDimension {
     }
 
     /// Creates a proptest strategy to create network dimensions within a certain range.
+    #[inline]
     pub fn range(min_size: usize, max_size: usize) -> NetworkDimensionStrategy {
         NetworkDimensionStrategy { min_size, max_size }
     }

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -151,7 +151,7 @@ impl ValueTree for NetworkDimensionTree {
         let prev = *self;
 
         self.high = self.current;
-        self.current = self.low + (self.high - self.low) / 2;
+        self.current = (self.low + self.high) / 2;
 
         (prev.high != self.high || prev.current != self.current)
     }
@@ -164,7 +164,7 @@ impl ValueTree for NetworkDimensionTree {
         }
 
         self.low = self.current + 1;
-        self.current = self.low + (self.high - self.low) / 2;
+        self.current = (self.low + self.high) / 2;
 
         (prev.current != self.current || prev.low != self.low)
     }

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -38,9 +38,9 @@ pub fn gen_seed() -> impl Strategy<Value = TestRngSeed> {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct NetworkDimension {
     /// Total number of nodes in network.
-    pub size: u16,
+    size: u16,
     /// Number of faulty nodes in a network.
-    pub faulty: u16,
+    faulty: u16,
     /// Hidden value to prevent instantion outside of `new`:
     _hidden: (),
 }
@@ -63,6 +63,16 @@ impl NetworkDimension {
             "Tried to create network dimension that violates BFT-property."
         );
         dim
+    }
+
+    #[inline]
+    pub fn faulty(&self) -> usize {
+        self.faulty.into()
+    }
+
+    #[inline]
+    pub fn size(&self) -> usize {
+        self.size.into()
     }
 
     /// Checks whether the network dimension satisfies the `3 * faulty + 1 <= size` condition.

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -41,8 +41,6 @@ pub struct NetworkDimension {
     size: u16,
     /// Number of faulty nodes in a network.
     faulty: u16,
-    /// Hidden value to prevent instantion outside of `new`:
-    _hidden: (),
 }
 
 impl NetworkDimension {
@@ -53,11 +51,7 @@ impl NetworkDimension {
 
     #[inline]
     pub fn new(size: u16, faulty: u16) -> Self {
-        let dim = NetworkDimension {
-            size,
-            faulty,
-            _hidden: (),
-        };
+        let dim = NetworkDimension { size, faulty };
         assert!(
             dim.is_bft(),
             "Tried to create network dimension that violates BFT-property."

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -82,8 +82,12 @@ impl NetworkDimension {
             half.faulty -= 1;
         }
 
-        // This assert just checks for bugs.
+        // Perform invariant checking.
         assert!(half.is_bft());
+        assert!(half.size >= self.size);
+        assert!(half.faulty >= self.faulty);
+        assert!(half.size <= high.size);
+        assert!(half.faulty <= high.faulty);
 
         half
     }

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -2,6 +2,7 @@ extern crate failure;
 extern crate hbbft;
 #[macro_use]
 extern crate proptest;
+extern crate integer_sqrt;
 extern crate rand;
 extern crate threshold_crypto;
 
@@ -92,8 +93,8 @@ fn do_drop_and_readd(cfg: TestConfig) {
     let mut rng: TestRng = TestRng::from_seed(cfg.seed);
 
     // First, we create a new test network with Honey Badger instances.
-    let mut net = NetBuilder::new(0..cfg.dimension.size)
-        .num_faulty(cfg.dimension.faulty)
+    let mut net = NetBuilder::new(0..cfg.dimension.size as usize)
+        .num_faulty(cfg.dimension.faulty as usize)
         .message_limit(200_000) // Limited to 200k messages for now.
         .rng(rng.gen::<TestRng>()) // Ensure runs are reproducible.
         .using_step(move |node| {

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -8,7 +8,7 @@ extern crate threshold_crypto;
 
 pub mod net;
 
-use std::collections;
+use std::{collections, time};
 
 use hbbft::dynamic_honey_badger::{Change, ChangeState, DynamicHoneyBadger, Input};
 use hbbft::messaging::DistAlgorithm;
@@ -95,8 +95,12 @@ fn do_drop_and_readd(cfg: TestConfig) {
     // First, we create a new test network with Honey Badger instances.
     let mut net = NetBuilder::new(0..cfg.dimension.size())
         .num_faulty(cfg.dimension.faulty())
-        .message_limit(200_000) // Limited to 200k messages for now.
-        .rng(rng.gen::<TestRng>()) // Ensure runs are reproducible.
+        // Limited to 200k messages for now.
+        .message_limit(15_000 * cfg.dimension.size() as usize)
+        // 30 secs per node.
+        .time_limit(time::Duration::from_secs(30 * cfg.dimension.size() as u64))
+        // Ensure runs are reproducible.
+        .rng(rng.gen::<TestRng>())
         .using_step(move |node| {
             println!("Constructing new dynamic honey badger node #{}", node.id);
             DynamicHoneyBadger::builder()

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -95,7 +95,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
     // First, we create a new test network with Honey Badger instances.
     let mut net = NetBuilder::new(0..cfg.dimension.size())
         .num_faulty(cfg.dimension.faulty())
-        // Limited to 200k messages for now.
+        // Limited to 15k messages per node.
         .message_limit(15_000 * cfg.dimension.size() as usize)
         // 30 secs per node.
         .time_limit(time::Duration::from_secs(30 * cfg.dimension.size() as u64))

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -93,8 +93,8 @@ fn do_drop_and_readd(cfg: TestConfig) {
     let mut rng: TestRng = TestRng::from_seed(cfg.seed);
 
     // First, we create a new test network with Honey Badger instances.
-    let mut net = NetBuilder::new(0..cfg.dimension.size as usize)
-        .num_faulty(cfg.dimension.faulty as usize)
+    let mut net = NetBuilder::new(0..cfg.dimension.size())
+        .num_faulty(cfg.dimension.faulty())
         .message_limit(200_000) // Limited to 200k messages for now.
         .rng(rng.gen::<TestRng>()) // Ensure runs are reproducible.
         .using_step(move |node| {

--- a/tests/net_util.proptest-regressions
+++ b/tests/net_util.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 2984819682 1621205622 3953858650 3756562836 # shrinks to seed = [724246048, 1190443809, 4113437293, 1855000933], ops = [Simplify, Complicate]

--- a/tests/net_util.rs
+++ b/tests/net_util.rs
@@ -2,6 +2,7 @@ extern crate failure;
 extern crate hbbft;
 #[macro_use]
 extern crate proptest;
+extern crate integer_sqrt;
 extern crate rand;
 extern crate rand_core;
 extern crate threshold_crypto;
@@ -13,7 +14,7 @@ use proptest::prelude::RngCore;
 use proptest::strategy::{Strategy, ValueTree};
 use rand::{Rng as Rng4, SeedableRng as SeedableRng4};
 
-use net::proptest::{NetworkDimension, NetworkDimensionTree};
+use net::proptest::{max_sum, NetworkDimension, NetworkDimensionTree};
 
 struct RngAdapter4To5<T>(pub T);
 
@@ -88,8 +89,8 @@ fn check_sanity_works() {
 proptest!{
     /// Ensure that `.average_higher()` produces valid new dimensions.
     #[test]
-    fn average_higher_is_bft(size in 4..40usize) {
-        let mut faulty: usize = size/3;
+    fn average_higher_is_bft(size in 4..40u16) {
+        let mut faulty: u16 = size/3;
         if faulty > 0 {
             faulty -= 1;
         }
@@ -162,15 +163,139 @@ proptest!{
 
         let mut tree = NetworkDimensionTree::gen(&mut rng5, 1, 40);
         assert!(tree.current().is_bft());
-        println!("Current: {:?}", tree);
+        println!("Start: {:?}", tree);
 
         for op in ops.iter() {
+            println!("Op: {:?}", op);
             match op {
                 Op::Simplify => tree.simplify(),
                 Op::Complicate => tree.complicate(),
             };
+            println!("Result: {:?}", tree);
 
             assert!(tree.current().is_bft());
         }
     }
+}
+
+#[test]
+fn network_succ_works() {
+    let expected = (&[
+        (1, 0),
+        (2, 0),
+        (3, 0),
+        (4, 0),
+        (4, 1),
+        (5, 0),
+        (5, 1),
+        (6, 0),
+        (6, 1),
+        (7, 0),
+        (7, 1),
+        (7, 2),
+        (8, 0),
+        (8, 1),
+        (8, 2),
+        (9, 0),
+        (9, 1),
+        (9, 2),
+        (10, 0),
+        (10, 1),
+        (10, 2),
+        (10, 3),
+    ])
+        .iter()
+        .map(|&(n, f)| NetworkDimension::new(n, f));
+
+    let mut dim = NetworkDimension::new(1, 0);
+
+    for exp in expected {
+        assert_eq!(dim, exp);
+        dim = dim.succ();
+    }
+}
+
+#[test]
+fn test_max_sum() {
+    assert_eq!(max_sum(0), 0);
+    assert_eq!(max_sum(1), 1);
+    assert_eq!(max_sum(2), 1);
+    assert_eq!(max_sum(3), 2);
+    assert_eq!(max_sum(4), 2);
+    assert_eq!(max_sum(5), 2);
+    assert_eq!(max_sum(6), 3);
+    assert_eq!(max_sum(7), 3);
+    assert_eq!(max_sum(8), 3);
+    assert_eq!(max_sum(9), 3);
+    assert_eq!(max_sum(10), 4);
+    assert_eq!(max_sum(5049), 99);
+    assert_eq!(max_sum(5050), 100);
+    assert_eq!(max_sum(5051), 100);
+    assert_eq!(max_sum(5150), 100);
+    assert_eq!(max_sum(5151), 101);
+}
+
+#[test]
+fn network_to_u32_is_correct() {
+    assert_eq!(u32::from(NetworkDimension::new(1, 0)), 0u32);
+    assert_eq!(u32::from(NetworkDimension::new(2, 0)), 1u32);
+    assert_eq!(u32::from(NetworkDimension::new(3, 0)), 2u32);
+    assert_eq!(u32::from(NetworkDimension::new(4, 0)), 3u32);
+    assert_eq!(u32::from(NetworkDimension::new(4, 1)), 4u32);
+    assert_eq!(u32::from(NetworkDimension::new(5, 0)), 5u32);
+    assert_eq!(u32::from(NetworkDimension::new(5, 1)), 6u32);
+    assert_eq!(u32::from(NetworkDimension::new(6, 0)), 7u32);
+    assert_eq!(u32::from(NetworkDimension::new(6, 1)), 8u32);
+    assert_eq!(u32::from(NetworkDimension::new(7, 0)), 9u32);
+    assert_eq!(u32::from(NetworkDimension::new(7, 1)), 10u32);
+    assert_eq!(u32::from(NetworkDimension::new(7, 2)), 11u32);
+    assert_eq!(u32::from(NetworkDimension::new(8, 0)), 12u32);
+    assert_eq!(u32::from(NetworkDimension::new(8, 1)), 13u32);
+    assert_eq!(u32::from(NetworkDimension::new(8, 2)), 14u32);
+    assert_eq!(u32::from(NetworkDimension::new(9, 0)), 15u32);
+    assert_eq!(u32::from(NetworkDimension::new(9, 1)), 16u32);
+    assert_eq!(u32::from(NetworkDimension::new(9, 2)), 17u32);
+    assert_eq!(u32::from(NetworkDimension::new(10, 0)), 18u32);
+    assert_eq!(u32::from(NetworkDimension::new(10, 1)), 19u32);
+    assert_eq!(u32::from(NetworkDimension::new(10, 2)), 20u32);
+    assert_eq!(u32::from(NetworkDimension::new(10, 3)), 21u32);
+}
+
+#[test]
+fn network_from_u32_is_correct() {
+    assert_eq!(NetworkDimension::new(1, 0), NetworkDimension::from(0u32));
+    assert_eq!(NetworkDimension::new(2, 0), NetworkDimension::from(1u32));
+    assert_eq!(NetworkDimension::new(3, 0), NetworkDimension::from(2u32));
+    assert_eq!(NetworkDimension::new(4, 0), NetworkDimension::from(3u32));
+    assert_eq!(NetworkDimension::new(4, 1), NetworkDimension::from(4u32));
+    assert_eq!(NetworkDimension::new(5, 0), NetworkDimension::from(5u32));
+    assert_eq!(NetworkDimension::new(5, 1), NetworkDimension::from(6u32));
+    assert_eq!(NetworkDimension::new(6, 0), NetworkDimension::from(7u32));
+    assert_eq!(NetworkDimension::new(6, 1), NetworkDimension::from(8u32));
+    assert_eq!(NetworkDimension::new(7, 0), NetworkDimension::from(9u32));
+    assert_eq!(NetworkDimension::new(7, 1), NetworkDimension::from(10u32));
+    assert_eq!(NetworkDimension::new(7, 2), NetworkDimension::from(11u32));
+    assert_eq!(NetworkDimension::new(8, 0), NetworkDimension::from(12u32));
+    assert_eq!(NetworkDimension::new(8, 1), NetworkDimension::from(13u32));
+    assert_eq!(NetworkDimension::new(8, 2), NetworkDimension::from(14u32));
+    assert_eq!(NetworkDimension::new(9, 0), NetworkDimension::from(15u32));
+    assert_eq!(NetworkDimension::new(9, 1), NetworkDimension::from(16u32));
+    assert_eq!(NetworkDimension::new(9, 2), NetworkDimension::from(17u32));
+    assert_eq!(NetworkDimension::new(10, 0), NetworkDimension::from(18u32));
+    assert_eq!(NetworkDimension::new(10, 1), NetworkDimension::from(19u32));
+    assert_eq!(NetworkDimension::new(10, 2), NetworkDimension::from(20u32));
+    assert_eq!(NetworkDimension::new(10, 3), NetworkDimension::from(21u32));
+    assert_eq!(NetworkDimension::new(11, 0), NetworkDimension::from(22u32));
+    assert_eq!(NetworkDimension::new(11, 1), NetworkDimension::from(23u32));
+    assert_eq!(NetworkDimension::new(11, 2), NetworkDimension::from(24u32));
+    assert_eq!(NetworkDimension::new(11, 3), NetworkDimension::from(25u32));
+    assert_eq!(NetworkDimension::new(12, 0), NetworkDimension::from(26u32));
+    assert_eq!(NetworkDimension::new(12, 1), NetworkDimension::from(27u32));
+    assert_eq!(NetworkDimension::new(12, 2), NetworkDimension::from(28u32));
+    assert_eq!(NetworkDimension::new(12, 3), NetworkDimension::from(29u32));
+    assert_eq!(NetworkDimension::new(13, 0), NetworkDimension::from(30u32));
+    assert_eq!(NetworkDimension::new(13, 1), NetworkDimension::from(31u32));
+    assert_eq!(NetworkDimension::new(13, 2), NetworkDimension::from(32u32));
+    assert_eq!(NetworkDimension::new(13, 3), NetworkDimension::from(33u32));
+    assert_eq!(NetworkDimension::new(13, 4), NetworkDimension::from(34u32));
 }

--- a/tests/net_util.rs
+++ b/tests/net_util.rs
@@ -86,7 +86,7 @@ proptest!{
         let mut tree = NetworkDimensionTree::gen(&mut rng5, 1, 40);
         println!("Start: {:?}", tree);
 
-        for op in ops.iter() {
+        for op in ops {
             println!("Op: {:?}", op);
             match op {
                 Op::Simplify => tree.simplify(),

--- a/tests/net_util.rs
+++ b/tests/net_util.rs
@@ -54,89 +54,11 @@ where
     }
 }
 
-/// Checks the `check_sanity` function with various inputs.
-#[test]
-fn check_sanity_works() {
-    assert!(NetworkDimension::new(3, 0).is_bft());
-    assert!(NetworkDimension::new(4, 0).is_bft());
-    assert!(NetworkDimension::new(5, 0).is_bft());
-    assert!(NetworkDimension::new(6, 0).is_bft());
-    assert!(!NetworkDimension::new(3, 1).is_bft());
-    assert!(NetworkDimension::new(4, 1).is_bft());
-    assert!(NetworkDimension::new(5, 1).is_bft());
-    assert!(NetworkDimension::new(6, 1).is_bft());
-    assert!(NetworkDimension::new(16, 3).is_bft());
-    assert!(NetworkDimension::new(17, 3).is_bft());
-    assert!(NetworkDimension::new(18, 3).is_bft());
-    assert!(NetworkDimension::new(19, 3).is_bft());
-    assert!(NetworkDimension::new(16, 5).is_bft());
-    assert!(NetworkDimension::new(17, 5).is_bft());
-    assert!(NetworkDimension::new(18, 5).is_bft());
-    assert!(NetworkDimension::new(19, 5).is_bft());
-    assert!(!NetworkDimension::new(16, 6).is_bft());
-    assert!(!NetworkDimension::new(17, 6).is_bft());
-    assert!(!NetworkDimension::new(18, 6).is_bft());
-    assert!(NetworkDimension::new(19, 6).is_bft());
-    assert!(!NetworkDimension::new(19, 19).is_bft());
-    assert!(!NetworkDimension::new(19, 21).is_bft());
-
-    // Edge cases:
-    assert!(NetworkDimension::new(1, 0).is_bft());
-    assert!(!NetworkDimension::new(0, 0).is_bft());
-    assert!(!NetworkDimension::new(1, 1).is_bft());
-}
-
-proptest!{
-    /// Ensure that `.average_higher()` produces valid new dimensions.
-    #[test]
-    fn average_higher_is_bft(size in 4..40u16) {
-        let mut faulty: u16 = size/3;
-        if faulty > 0 {
-            faulty -= 1;
-        }
-
-        let high = NetworkDimension::new(size, faulty);
-        let low = NetworkDimension::new(size/4, faulty/12);
-
-        println!("high: {:?}, low: {:?}", high, low);
-        assert!(high.is_bft());
-        assert!(low.is_bft());
-
-        let average_higher = low.average_higher(high);
-        println!("average_higher: {:?}", average_higher);
-        assert!(average_higher.is_bft());
-    }
-}
-
-/// Ensure `.average_higher()` works for edge cases.
-#[test]
-fn average_higher_handles_edge_cases() {
-    let high = NetworkDimension::new(1, 0);
-    let low = NetworkDimension::new(1, 0);
-    let average_higher = low.average_higher(high);
-    assert!(average_higher.is_bft());
-
-    let high = NetworkDimension::new(10, 0);
-    let low = NetworkDimension::new(10, 0);
-    let average_higher = low.average_higher(high);
-    assert!(average_higher.is_bft());
-
-    let high = NetworkDimension::new(10, 3);
-    let low = NetworkDimension::new(10, 3);
-    let average_higher = low.average_higher(high);
-    assert!(average_higher.is_bft());
-
-    let high = NetworkDimension::new(11, 3);
-    let low = NetworkDimension::new(10, 3);
-    let average_higher = low.average_higher(high);
-    assert!(average_higher.is_bft());
-}
-
 proptest!{
     /// Ensures all generated network dimensions are actually sane.
     #[test]
-    fn generated_network_dimensions_are_sane(nt in NetworkDimension::range(1, 400)) {
-        assert!(nt.is_bft());
+    fn generated_network_dimensions_are_sane(_nt in NetworkDimension::range(1, 400)) {
+        // Nothing to do here, assert already in `NetworkDimension::new`.
     }
 }
 
@@ -162,7 +84,6 @@ proptest!{
         let mut rng5 = RngAdapter4To5(rand::XorShiftRng::from_seed(seed));
 
         let mut tree = NetworkDimensionTree::gen(&mut rng5, 1, 40);
-        assert!(tree.current().is_bft());
         println!("Start: {:?}", tree);
 
         for op in ops.iter() {
@@ -172,8 +93,6 @@ proptest!{
                 Op::Complicate => tree.complicate(),
             };
             println!("Result: {:?}", tree);
-
-            assert!(tree.current().is_bft());
         }
     }
 }


### PR DESCRIPTION
Replaces the `NetworkDimensionStrategy`'s implementation with one based on a mapping of network dimensions to the natural numbers. This fixed panics during shrinking, making tests not exit without information when failing.