### PR TITLE
Make `DistAlgorithm` require `Send`.

### DIFF
--- a/src/coin.rs
+++ b/src/coin.rs
@@ -78,7 +78,7 @@ pub type Step<N, T> = messaging::Step<Coin<N, T>>;
 impl<N, T> DistAlgorithm for Coin<N, T>
 where
     N: NodeIdT,
-    T: Clone + AsRef<[u8]>,
+    T: Clone + AsRef<[u8]> + Send,
 {
     type NodeId = N;
     type Input = ();
@@ -123,7 +123,7 @@ where
 impl<N, T> Coin<N, T>
 where
     N: NodeIdT,
-    T: Clone + AsRef<[u8]>,
+    T: Clone + AsRef<[u8]> + Send,
 {
     pub fn new(netinfo: Arc<NetworkInfo<N>>, nonce: T) -> Self {
         Coin {

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -39,7 +39,7 @@ pub struct DynamicHoneyBadger<C, N: Rand> {
     pub(super) incoming_queue: Vec<(N, Message<N>)>,
     /// A random number generator used for secret key generation.
     // Boxed to avoid overloading the algorithm's type with more generics.
-    pub(super) rng: Box<dyn rand::Rng>,
+    pub(super) rng: Box<dyn rand::Rng + Send>,
 }
 
 impl<C, N> fmt::Debug for DynamicHoneyBadger<C, N>

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -32,7 +32,7 @@ pub struct HoneyBadger<C, N: Rand> {
     pub(super) remote_epochs: BTreeMap<N, u64>,
     /// A random number generator used for secret key generation.
     // Boxed to avoid overloading the algorithm's type with more generics.
-    pub(super) rng: Box<dyn Rng>,
+    pub(super) rng: Box<dyn Rng + Send>,
     /// Represents the optimization strategy to use for output of the `Subset` algorithm.
     pub(super) subset_handling_strategy: SubsetHandlingStrategy,
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -185,7 +185,7 @@ impl<D: DistAlgorithm> From<TargetedMessage<D::Message, D::NodeId>> for Step<D> 
 }
 
 /// A distributed algorithm that defines a message flow.
-pub trait DistAlgorithm {
+pub trait DistAlgorithm: Send {
     /// Unique node identifier.
     type NodeId: NodeIdT;
     /// The input provided by the user.

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,14 +7,14 @@ use rand;
 
 /// Workaround trait for creating new random number generators
 pub trait SubRng {
-    fn sub_rng(&mut self) -> Box<dyn rand::Rng>;
+    fn sub_rng(&mut self) -> Box<dyn rand::Rng + Send>;
 }
 
 impl<R> SubRng for R
 where
     R: rand::Rng,
 {
-    fn sub_rng(&mut self) -> Box<dyn rand::Rng> {
+    fn sub_rng(&mut self) -> Box<dyn rand::Rng + Send> {
         // Currently hard-coded to be an `Isaac64Rng`, until better options emerge. This is either
         // dependant on `rand` 0.5 support or an API re-design of parts of `threshold_crypto` and
         // `hbbft`.


### PR DESCRIPTION
Using `hbbft` in other software that is based on frameworks like [tokio](https://tokio.rs), being `Send` is often a requirement on shared data structures.

This goes slightly beyond just making sure HoneyBadger is suitable for tokio by adding a `Send` requirement on `DistAlgorithm`. It was tempting to do so and ensures we won't accidentally break things in the future at the cost of complicating `coin.rs` slightly; we can restrict to just adding the `Box<Rng + Send>` type bounds instead if this is an issue.