### PR TITLE
Support a global RNG in transaction queue

### DIFF
--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -19,7 +19,7 @@ use std::{cmp, u64};
 use colored::*;
 use docopt::Docopt;
 use itertools::Itertools;
-use rand::Rng;
+use rand::{Isaac64Rng, Rng};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use signifix::{metric, TryFrom};
@@ -27,7 +27,6 @@ use signifix::{metric, TryFrom};
 use hbbft::dynamic_honey_badger::DynamicHoneyBadger;
 use hbbft::queueing_honey_badger::{Batch, QueueingHoneyBadger};
 use hbbft::{DistAlgorithm, NetworkInfo, Step, Target};
-use hbbft::transaction_queue::VecDequeTransactionQueue;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const USAGE: &str = "
@@ -355,9 +354,7 @@ impl EpochInfo {
         id: NodeId,
         time: Duration,
         batch: &Batch<Transaction, NodeId>,
-        network: &TestNetwork<
-            QueueingHoneyBadger<Transaction, NodeId, VecDequeTransactionQueue<Transaction>>,
-        >,
+        network: &TestNetwork<QueueingHoneyBadger<Transaction, NodeId, Vec<Transaction>>>,
     ) {
         if self.nodes.contains_key(&id) {
             return;
@@ -389,9 +386,7 @@ impl EpochInfo {
 
 /// Proposes `num_txs` values and expects nodes to output and order them.
 fn simulate_honey_badger(
-    mut network: TestNetwork<
-        QueueingHoneyBadger<Transaction, NodeId, VecDequeTransactionQueue<Transaction>>,
-    >,
+    mut network: TestNetwork<QueueingHoneyBadger<Transaction, NodeId, Vec<Transaction>>>,
 ) {
     // Handle messages until all nodes have output all transactions.
     println!(
@@ -444,7 +439,7 @@ fn main() {
         let dyn_hb = DynamicHoneyBadger::builder().build(netinfo);
         QueueingHoneyBadger::builder(dyn_hb)
             .batch_size(args.flag_b)
-            .build_with_transactions(txs.clone())
+            .build_with_transactions(txs.clone(), rand::thread_rng().gen::<Isaac64Rng>())
             .expect("instantiate QueueingHoneyBadger")
     };
     let hw_quality = HwQuality {

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -27,6 +27,7 @@ use signifix::{metric, TryFrom};
 use hbbft::dynamic_honey_badger::DynamicHoneyBadger;
 use hbbft::queueing_honey_badger::{Batch, QueueingHoneyBadger};
 use hbbft::{DistAlgorithm, NetworkInfo, Step, Target};
+use hbbft::transaction_queue::VecDequeTransactionQueue;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const USAGE: &str = "
@@ -354,7 +355,9 @@ impl EpochInfo {
         id: NodeId,
         time: Duration,
         batch: &Batch<Transaction, NodeId>,
-        network: &TestNetwork<QueueingHoneyBadger<Transaction, NodeId>>,
+        network: &TestNetwork<
+            QueueingHoneyBadger<Transaction, NodeId, VecDequeTransactionQueue<Transaction>>,
+        >,
     ) {
         if self.nodes.contains_key(&id) {
             return;
@@ -385,7 +388,11 @@ impl EpochInfo {
 }
 
 /// Proposes `num_txs` values and expects nodes to output and order them.
-fn simulate_honey_badger(mut network: TestNetwork<QueueingHoneyBadger<Transaction, NodeId>>) {
+fn simulate_honey_badger(
+    mut network: TestNetwork<
+        QueueingHoneyBadger<Transaction, NodeId, VecDequeTransactionQueue<Transaction>>,
+    >,
+) {
     // Handle messages until all nodes have output all transactions.
     println!(
         "{}",

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -38,7 +38,7 @@ pub struct DynamicHoneyBadger<C, N: Rand> {
     pub(super) incoming_queue: Vec<(N, Message<N>)>,
     /// A random number generator used for secret key generation.
     // Boxed to avoid overloading the algorithm's type with more generics.
-    pub(super) rng: Box<dyn rand::Rng + Send + Sync>,
+    pub(crate) rng: Box<dyn rand::Rng + Send + Sync>,
 }
 
 impl<C, N> fmt::Debug for DynamicHoneyBadger<C, N>

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -38,7 +38,7 @@ pub struct DynamicHoneyBadger<C, N: Rand> {
     pub(super) incoming_queue: Vec<(N, Message<N>)>,
     /// A random number generator used for secret key generation.
     // Boxed to avoid overloading the algorithm's type with more generics.
-    pub(crate) rng: Box<dyn rand::Rng + Send + Sync>,
+    pub(super) rng: Box<dyn rand::Rng + Send + Sync>,
 }
 
 impl<C, N> fmt::Debug for DynamicHoneyBadger<C, N>

--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -23,7 +23,7 @@
 //! the same transaction multiple times.
 
 use std::cmp;
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Display};
 use std::marker::PhantomData;
 
 use failure::{Backtrace, Context, Fail};
@@ -109,7 +109,7 @@ impl<T, N, Q> QueueingHoneyBadgerBuilder<T, N, Q>
 where
     T: Contribution + Serialize + for<'r> Deserialize<'r> + Clone,
     N: NodeIdT + Serialize + for<'r> Deserialize<'r> + Rand,
-    Q: TransactionQueue<T> + Debug + Default + Extend<T> + Sync + Send,
+    Q: TransactionQueue<T>,
 {
     /// Returns a new `QueueingHoneyBadgerBuilder` configured to use the node IDs and cryptographic
     /// keys specified by `netinfo`.
@@ -174,7 +174,7 @@ pub struct QueueingHoneyBadger<T, N, Q>
 where
     T: Contribution + Serialize + for<'r> Deserialize<'r>,
     N: NodeIdT + Serialize + for<'r> Deserialize<'r> + Rand,
-    Q: TransactionQueue<T> + Debug,
+    Q: TransactionQueue<T>,
 {
     /// The target number of transactions to be included in each batch.
     batch_size: usize,
@@ -190,7 +190,7 @@ impl<T, N, Q> DistAlgorithm for QueueingHoneyBadger<T, N, Q>
 where
     T: Contribution + Serialize + for<'r> Deserialize<'r> + Clone,
     N: NodeIdT + Serialize + for<'r> Deserialize<'r> + Rand,
-    Q: TransactionQueue<T> + Debug + Default + Extend<T> + Sync + Send,
+    Q: TransactionQueue<T>,
 {
     type NodeId = N;
     type Input = Input<T, N>;
@@ -242,7 +242,7 @@ impl<T, N, Q> QueueingHoneyBadger<T, N, Q>
 where
     T: Contribution + Serialize + for<'r> Deserialize<'r> + Clone,
     N: NodeIdT + Serialize + for<'r> Deserialize<'r> + Rand,
-    Q: TransactionQueue<T> + Debug + Default + Extend<T> + Sync + Send,
+    Q: TransactionQueue<T>,
 {
     /// Returns a new `QueueingHoneyBadgerBuilder` configured to use the node IDs and cryptographic
     /// keys specified by `netinfo`.

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -1,15 +1,39 @@
-use std::cmp;
 use std::collections::{HashSet, VecDeque};
+use std::{cmp, fmt};
 
-use rand;
+use rand::{self, Rng};
 
 use Contribution;
+use util::SubRng;
 
 /// A wrapper providing a few convenience methods for a queue of pending transactions.
-#[derive(Debug)]
-pub struct TransactionQueue<T>(pub VecDeque<T>);
+pub struct TransactionQueue<T> {
+    /// Random number generator passed on from the algorithm instance.
+    rng: Box<dyn Rng + Send + Sync>,
+    pub transactions: VecDeque<T>,
+}
+
+impl<T> fmt::Debug for TransactionQueue<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TransactionQueue")
+            .field("transactions", &self.transactions)
+            .field("rng", &"<RNG>")
+            .finish()
+    }
+}
 
 impl<T: Clone> TransactionQueue<T> {
+    /// Returns a new `TransactionQueue` object.
+    pub fn new<R: Rng + Send + Sync>(rng: &mut R, transactions: VecDeque<T>) -> Self {
+        TransactionQueue {
+            rng: rng.sub_rng(),
+            transactions,
+        }
+    }
+
     /// Removes the given transactions from the queue.
     pub fn remove_all<'a, I>(&mut self, txs: I)
     where
@@ -17,16 +41,19 @@ impl<T: Clone> TransactionQueue<T> {
         T: 'a + Contribution,
     {
         let tx_set: HashSet<_> = txs.into_iter().collect();
-        self.0.retain(|tx| !tx_set.contains(tx));
+        self.transactions.retain(|tx| !tx_set.contains(tx));
     }
 
     /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
     /// No transactions are removed from the queue.
     // TODO: Return references, once the `HoneyBadger` API accepts them. Remove `Clone` bound.
-    pub fn choose(&self, amount: usize, batch_size: usize) -> Vec<T> {
-        let mut rng = rand::thread_rng();
-        let limit = cmp::min(batch_size, self.0.len());
-        let sample = match rand::seq::sample_iter(&mut rng, self.0.iter().take(limit), amount) {
+    pub fn choose(&mut self, amount: usize, batch_size: usize) -> Vec<T> {
+        let limit = cmp::min(batch_size, self.transactions.len());
+        let sample = match rand::seq::sample_iter(
+            &mut self.rng,
+            self.transactions.iter().take(limit),
+            amount,
+        ) {
             Ok(choice) => choice,
             Err(choice) => choice, // Fewer than `amount` were available, which is fine.
         };

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -1,10 +1,9 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::HashSet;
 use std::{cmp, fmt};
 
-use rand::{self, Isaac64Rng, Rng};
+use rand::{self, Rng};
 
 use Contribution;
-use util::SubRng;
 
 /// An interface to the transaction queue. A transaction queue is a structural part of
 /// `QueueingHoneyBadger` that manages enqueueing of transactions for a future batch and dequeueing
@@ -13,101 +12,48 @@ pub trait TransactionQueue<T>: fmt::Debug + Default + Extend<T> + Sync + Send {
     /// Checks whether the queue is empty.
     fn is_empty(&self) -> bool;
     /// Appends an element at the end of the queue.
-    fn push_back(&mut self, t: T);
-    /// Returns a new set of `amount` transactions, chosen from the first `batch_size`.  No
-    /// transactions are removed from the queue.
+    fn push(&mut self, t: T);
+    /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
+    /// No transactions are removed from the queue.
     // TODO: Return references, once the `HoneyBadger` API accepts them.
-    fn choose(&mut self, amount: usize, batch_size: usize) -> Vec<T>;
+    fn choose<R: Rng>(&mut self, rng: &mut R, amount: usize, batch_size: usize) -> Vec<T>;
     /// Removes the given transactions from the queue.
-    fn remove_all<'a, I>(&mut self, txs: I)
+    fn remove_multiple<'a, I>(&mut self, txs: I)
     where
         I: IntoIterator<Item = &'a T>,
         T: 'a + Contribution;
 }
 
-/// A wrapper providing a few convenience methods for a queue of pending transactions.
-pub struct VecDequeTransactionQueue<T> {
-    /// Random number generator used for choosing transactions from the queue.
-    rng: Box<dyn Rng + Send + Sync>,
-    transactions: VecDeque<T>,
-}
-
-impl<T> TransactionQueue<T> for VecDequeTransactionQueue<T>
+impl<T> TransactionQueue<T> for Vec<T>
 where
     T: Clone + fmt::Debug + Sync + Send,
 {
-    /// Checks whether the queue is empty.
+    #[inline]
     fn is_empty(&self) -> bool {
-        self.transactions.is_empty()
+        self.is_empty()
     }
 
-    /// Appends an element at the end of the queue.
-    fn push_back(&mut self, t: T) {
-        self.transactions.push_back(t);
+    #[inline]
+    fn push(&mut self, t: T) {
+        self.push(t);
     }
 
-    /// Removes the given transactions from the queue.
-    fn remove_all<'a, I>(&mut self, txs: I)
+    fn remove_multiple<'a, I>(&mut self, txs: I)
     where
         I: IntoIterator<Item = &'a T>,
         T: 'a + Contribution,
     {
         let tx_set: HashSet<_> = txs.into_iter().collect();
-        self.transactions.retain(|tx| !tx_set.contains(tx));
+        self.retain(|tx| !tx_set.contains(tx));
     }
 
-    /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
-    /// No transactions are removed from the queue.
     // TODO: Return references, once the `HoneyBadger` API accepts them. Remove `Clone` bound.
-    fn choose(&mut self, amount: usize, batch_size: usize) -> Vec<T> {
-        let limit = cmp::min(batch_size, self.transactions.len());
-        let sample = match rand::seq::sample_iter(
-            &mut self.rng,
-            self.transactions.iter().take(limit),
-            amount,
-        ) {
+    fn choose<R: Rng>(&mut self, rng: &mut R, amount: usize, batch_size: usize) -> Vec<T> {
+        let limit = cmp::min(batch_size, self.len());
+        let sample = match rand::seq::sample_iter(rng, self.iter().take(limit), amount) {
             Ok(choice) => choice,
             Err(choice) => choice, // Fewer than `amount` were available, which is fine.
         };
         sample.into_iter().cloned().collect()
-    }
-}
-
-impl<T> Default for VecDequeTransactionQueue<T>
-where
-    T: Clone,
-{
-    /// Creates an empty transaction queue with a default random number generator.
-    fn default() -> Self {
-        let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
-        VecDequeTransactionQueue::new(&mut rng, VecDeque::new())
-    }
-}
-
-impl<T> fmt::Debug for VecDequeTransactionQueue<T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("VecDequeTransactionQueue")
-            .field("transactions", &self.transactions)
-            .field("rng", &"<RNG>")
-            .finish()
-    }
-}
-
-impl<T> Extend<T> for VecDequeTransactionQueue<T> {
-    /// Extends the transaction queue with the contents of a given iterator.
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        self.transactions.extend(iter);
-    }
-}
-impl<T: Clone> VecDequeTransactionQueue<T> {
-    /// Returns a new `VecDequeTransactionQueue` object.
-    pub fn new<R: Rng + Send + Sync>(rng: &mut R, transactions: VecDeque<T>) -> Self {
-        VecDequeTransactionQueue {
-            rng: rng.sub_rng(),
-            transactions,
-        }
     }
 }

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -1,41 +1,45 @@
 use std::collections::{HashSet, VecDeque};
 use std::{cmp, fmt};
 
-use rand::{self, Rng};
+use rand::{self, Isaac64Rng, Rng};
 
 use Contribution;
 use util::SubRng;
 
+/// An interface to the transaction queue. A transaction queue is a structural part of
+/// `QueueingHoneyBadger` that manages enqueueing of transactions for a future batch and dequeueing
+/// of transactions to become part of a current batch.
+pub trait TransactionQueue<T> {
+    fn is_empty(&self) -> bool;
+    fn push_back(&mut self, t: T);
+    fn choose(&mut self, amount: usize, batch_size: usize) -> Vec<T>;
+    fn remove_all<'a, I>(&mut self, txs: I)
+    where
+        I: IntoIterator<Item = &'a T>,
+        T: 'a + Contribution;
+}
+
 /// A wrapper providing a few convenience methods for a queue of pending transactions.
-pub struct TransactionQueue<T> {
+pub struct VecDequeTransactionQueue<T> {
     /// Random number generator passed on from the algorithm instance.
     rng: Box<dyn Rng + Send + Sync>,
     pub transactions: VecDeque<T>,
 }
 
-impl<T> fmt::Debug for TransactionQueue<T>
+impl<T> TransactionQueue<T> for VecDequeTransactionQueue<T>
 where
-    T: fmt::Debug,
+    T: Clone,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TransactionQueue")
-            .field("transactions", &self.transactions)
-            .field("rng", &"<RNG>")
-            .finish()
+    fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
     }
-}
 
-impl<T: Clone> TransactionQueue<T> {
-    /// Returns a new `TransactionQueue` object.
-    pub fn new<R: Rng + Send + Sync>(rng: &mut R, transactions: VecDeque<T>) -> Self {
-        TransactionQueue {
-            rng: rng.sub_rng(),
-            transactions,
-        }
+    fn push_back(&mut self, t: T) {
+        self.transactions.push_back(t);
     }
 
     /// Removes the given transactions from the queue.
-    pub fn remove_all<'a, I>(&mut self, txs: I)
+    fn remove_all<'a, I>(&mut self, txs: I)
     where
         I: IntoIterator<Item = &'a T>,
         T: 'a + Contribution,
@@ -47,7 +51,7 @@ impl<T: Clone> TransactionQueue<T> {
     /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
     /// No transactions are removed from the queue.
     // TODO: Return references, once the `HoneyBadger` API accepts them. Remove `Clone` bound.
-    pub fn choose(&mut self, amount: usize, batch_size: usize) -> Vec<T> {
+    fn choose(&mut self, amount: usize, batch_size: usize) -> Vec<T> {
         let limit = cmp::min(batch_size, self.transactions.len());
         let sample = match rand::seq::sample_iter(
             &mut self.rng,
@@ -58,5 +62,46 @@ impl<T: Clone> TransactionQueue<T> {
             Err(choice) => choice, // Fewer than `amount` were available, which is fine.
         };
         sample.into_iter().cloned().collect()
+    }
+}
+
+impl<T> Default for VecDequeTransactionQueue<T>
+where
+    T: Clone,
+{
+    /// Creates an empty transaction queue with a default random number generator.
+    fn default() -> Self {
+        let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
+        VecDequeTransactionQueue::new(&mut rng, VecDeque::new())
+    }
+}
+
+impl<T> fmt::Debug for VecDequeTransactionQueue<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("VecDequeTransactionQueue")
+            .field("transactions", &self.transactions)
+            .field("rng", &"<RNG>")
+            .finish()
+    }
+}
+
+impl<T> Extend<T> for VecDequeTransactionQueue<T> {
+    /// Extends the transaction queue with the contents of a given iterator.
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for tx in iter {
+            self.transactions.push_back(tx);
+        }
+    }
+}
+impl<T: Clone> VecDequeTransactionQueue<T> {
+    /// Returns a new `VecDequeTransactionQueue` object.
+    pub fn new<R: Rng + Send + Sync>(rng: &mut R, transactions: VecDeque<T>) -> Self {
+        VecDequeTransactionQueue {
+            rng: rng.sub_rng(),
+            transactions,
+        }
     }
 }

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use rand::{Isaac64Rng, Rng};
 
 use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input};
-use hbbft::transaction_queue::TransactionQueue;
+use hbbft::transaction_queue::{TransactionQueue, VecDequeTransactionQueue};
 use hbbft::NetworkInfo;
 
 use network::{Adversary, MessageScheduler, NodeId, SilentAdversary, TestNetwork, TestNode};
@@ -35,7 +35,12 @@ where
     A: Adversary<UsizeDhb>,
 {
     let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
-    let new_queue = |id: &NodeId| (*id, TransactionQueue::new(&mut rng, (0..num_txs).collect()));
+    let new_queue = |id: &NodeId| {
+        (
+            *id,
+            VecDequeTransactionQueue::new(&mut rng, (0..num_txs).collect()),
+        )
+    };
     let mut queues: BTreeMap<_, _> = network.nodes.keys().map(new_queue).collect();
     for (id, queue) in &mut queues {
         network.input(*id, Input::User(queue.choose(3, 10)));

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use rand::Rng;
+use rand::{Isaac64Rng, Rng};
 
 use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input};
 use hbbft::transaction_queue::TransactionQueue;
@@ -34,9 +34,10 @@ fn test_dynamic_honey_badger<A>(mut network: TestNetwork<A, UsizeDhb>, num_txs: 
 where
     A: Adversary<UsizeDhb>,
 {
-    let new_queue = |id: &NodeId| (*id, TransactionQueue((0..num_txs).collect()));
+    let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
+    let new_queue = |id: &NodeId| (*id, TransactionQueue::new(&mut rng, (0..num_txs).collect()));
     let mut queues: BTreeMap<_, _> = network.nodes.keys().map(new_queue).collect();
-    for (id, queue) in &queues {
+    for (id, queue) in &mut queues {
         network.input(*id, Input::User(queue.choose(3, 10)));
     }
 

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use rand::{Isaac64Rng, Rng};
 
 use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent};
-use hbbft::transaction_queue::TransactionQueue;
+use hbbft::transaction_queue::{TransactionQueue, VecDequeTransactionQueue};
 use hbbft::{threshold_decryption, NetworkInfo, Target, TargetedMessage};
 
 use network::{
@@ -128,7 +128,12 @@ where
     A: Adversary<UsizeHoneyBadger>,
 {
     let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
-    let new_queue = |id: &NodeId| (*id, TransactionQueue::new(&mut rng, (0..num_txs).collect()));
+    let new_queue = |id: &NodeId| {
+        (
+            *id,
+            VecDequeTransactionQueue::new(&mut rng, (0..num_txs).collect()),
+        )
+    };
     let mut queues: BTreeMap<_, _> = network.nodes.keys().map(new_queue).collect();
 
     // Returns `true` if the node has not output all transactions yet.

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -20,10 +20,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use rand::{Isaac64Rng, Rng};
+use rand::Rng;
 
 use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent};
-use hbbft::transaction_queue::{TransactionQueue, VecDequeTransactionQueue};
+use hbbft::transaction_queue::TransactionQueue;
 use hbbft::{threshold_decryption, NetworkInfo, Target, TargetedMessage};
 
 use network::{
@@ -127,13 +127,7 @@ fn test_honey_badger<A>(mut network: TestNetwork<A, UsizeHoneyBadger>, num_txs: 
 where
     A: Adversary<UsizeHoneyBadger>,
 {
-    let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
-    let new_queue = |id: &NodeId| {
-        (
-            *id,
-            VecDequeTransactionQueue::new(&mut rng, (0..num_txs).collect()),
-        )
-    };
+    let new_queue = |id: &NodeId| (*id, (0..num_txs).collect::<Vec<usize>>());
     let mut queues: BTreeMap<_, _> = network.nodes.keys().map(new_queue).collect();
 
     // Returns `true` if the node has not output all transactions yet.
@@ -155,8 +149,8 @@ where
             .collect();
         if let Some(id) = rng.choose(&input_ids) {
             let queue = queues.get_mut(id).unwrap();
-            queue.remove_all(network.nodes[id].outputs().iter().flat_map(Batch::iter));
-            network.input(*id, queue.choose(3, 10));
+            queue.remove_multiple(network.nodes[id].outputs().iter().flat_map(Batch::iter));
+            network.input(*id, queue.choose(&mut rng, 3, 10));
         } else {
             network.step();
         }

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use rand::Rng;
+use rand::{Isaac64Rng, Rng};
 
 use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent};
 use hbbft::transaction_queue::TransactionQueue;
@@ -127,7 +127,8 @@ fn test_honey_badger<A>(mut network: TestNetwork<A, UsizeHoneyBadger>, num_txs: 
 where
     A: Adversary<UsizeHoneyBadger>,
 {
-    let new_queue = |id: &NodeId| (*id, TransactionQueue((0..num_txs).collect()));
+    let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
+    let new_queue = |id: &NodeId| (*id, TransactionQueue::new(&mut rng, (0..num_txs).collect()));
     let mut queues: BTreeMap<_, _> = network.nodes.keys().map(new_queue).collect();
 
     // Returns `true` if the node has not output all transactions yet.

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -88,12 +88,12 @@ where
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-fn new_queueing_hb(
-    netinfo: Arc<NetworkInfo<NodeId>>,
-) -> (QHB, Step<usize, NodeId, Vec<usize>>) {
+fn new_queueing_hb(netinfo: Arc<NetworkInfo<NodeId>>) -> (QHB, Step<usize, NodeId, Vec<usize>>) {
     let dyn_hb = DynamicHoneyBadger::builder().build((*netinfo).clone());
     let rng = rand::thread_rng().gen::<Isaac64Rng>();
-    QueueingHoneyBadger::builder(dyn_hb).batch_size(3).build(rng)
+    QueueingHoneyBadger::builder(dyn_hb)
+        .batch_size(3)
+        .build(rng)
 }
 
 fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -18,16 +18,16 @@ mod network;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use itertools::Itertools;
+use rand::{Isaac64Rng, Rng};
+
 use hbbft::dynamic_honey_badger::DynamicHoneyBadger;
 use hbbft::queueing_honey_badger::{Batch, Change, ChangeState, Input, QueueingHoneyBadger, Step};
-use hbbft::transaction_queue::VecDequeTransactionQueue;
 use hbbft::NetworkInfo;
-use itertools::Itertools;
-use rand::Rng;
 
 use network::{Adversary, MessageScheduler, NodeId, SilentAdversary, TestNetwork, TestNode};
 
-type QHB = QueueingHoneyBadger<usize, NodeId, VecDequeTransactionQueue<usize>>;
+type QHB = QueueingHoneyBadger<usize, NodeId, Vec<usize>>;
 
 /// Proposes `num_txs` values and expects nodes to output and order them.
 fn test_queueing_honey_badger<A>(mut network: TestNetwork<A, QHB>, num_txs: usize)
@@ -90,9 +90,10 @@ where
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn new_queueing_hb(
     netinfo: Arc<NetworkInfo<NodeId>>,
-) -> (QHB, Step<usize, NodeId, VecDequeTransactionQueue<usize>>) {
+) -> (QHB, Step<usize, NodeId, Vec<usize>>) {
     let dyn_hb = DynamicHoneyBadger::builder().build((*netinfo).clone());
-    QueueingHoneyBadger::builder(dyn_hb).batch_size(3).build()
+    let rng = rand::thread_rng().gen::<Isaac64Rng>();
+    QueueingHoneyBadger::builder(dyn_hb).batch_size(3).build(rng)
 }
 
 fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -20,18 +20,19 @@ use std::sync::Arc;
 
 use hbbft::dynamic_honey_badger::DynamicHoneyBadger;
 use hbbft::queueing_honey_badger::{Batch, Change, ChangeState, Input, QueueingHoneyBadger, Step};
+use hbbft::transaction_queue::VecDequeTransactionQueue;
 use hbbft::NetworkInfo;
 use itertools::Itertools;
 use rand::Rng;
 
 use network::{Adversary, MessageScheduler, NodeId, SilentAdversary, TestNetwork, TestNode};
 
+type QHB = QueueingHoneyBadger<usize, NodeId, VecDequeTransactionQueue<usize>>;
+
 /// Proposes `num_txs` values and expects nodes to output and order them.
-fn test_queueing_honey_badger<A>(
-    mut network: TestNetwork<A, QueueingHoneyBadger<usize, NodeId>>,
-    num_txs: usize,
-) where
-    A: Adversary<QueueingHoneyBadger<usize, NodeId>>,
+fn test_queueing_honey_badger<A>(mut network: TestNetwork<A, QHB>, num_txs: usize)
+where
+    A: Adversary<QHB>,
 {
     // The second half of the transactions will be input only after a node has been removed.
     network.input_all(Input::Change(Change::Remove(NodeId(0))));
@@ -39,13 +40,13 @@ fn test_queueing_honey_badger<A>(
         network.input_all(Input::User(tx));
     }
 
-    fn has_remove(node: &TestNode<QueueingHoneyBadger<usize, NodeId>>) -> bool {
+    fn has_remove(node: &TestNode<QHB>) -> bool {
         node.outputs()
             .iter()
             .any(|batch| *batch.change() == ChangeState::Complete(Change::Remove(NodeId(0))))
     }
 
-    fn has_add(node: &TestNode<QueueingHoneyBadger<usize, NodeId>>) -> bool {
+    fn has_add(node: &TestNode<QHB>) -> bool {
         node.outputs().iter().any(|batch| match *batch.change() {
             ChangeState::Complete(Change::Add(ref id, _)) => *id == NodeId(0),
             _ => false,
@@ -54,7 +55,7 @@ fn test_queueing_honey_badger<A>(
 
     // Returns `true` if the node has not output all transactions yet.
     // If it has, and has advanced another epoch, it clears all messages for later epochs.
-    let node_busy = |node: &mut TestNode<QueueingHoneyBadger<usize, NodeId>>| {
+    let node_busy = |node: &mut TestNode<QHB>| {
         if !has_remove(node) || !has_add(node) {
             return true;
         }
@@ -89,14 +90,14 @@ fn test_queueing_honey_badger<A>(
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn new_queueing_hb(
     netinfo: Arc<NetworkInfo<NodeId>>,
-) -> (QueueingHoneyBadger<usize, NodeId>, Step<usize, NodeId>) {
+) -> (QHB, Step<usize, NodeId, VecDequeTransactionQueue<usize>>) {
     let dyn_hb = DynamicHoneyBadger::builder().build((*netinfo).clone());
     QueueingHoneyBadger::builder(dyn_hb).batch_size(3).build()
 }
 
 fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
 where
-    A: Adversary<QueueingHoneyBadger<usize, NodeId>>,
+    A: Adversary<QHB>,
     F: Fn(usize, usize, BTreeMap<NodeId, Arc<NetworkInfo<NodeId>>>) -> A,
 {
     // This returns an error in all but the first test.


### PR DESCRIPTION
Transaction queue is the component in old tests which is not currently tested by `proptest`-based tests. This PR adds functionality which enables such tests with a given random seed.

Only the minimal support is provided in the old non-`proptest` based tests, the intention being to extend the new framework wherever possible.