### PR TITLE
Remove unused pairing imports.

### DIFF
--- a/examples/consensus-node.rs
+++ b/examples/consensus-node.rs
@@ -9,7 +9,6 @@ extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
-extern crate pairing;
 extern crate serde;
 extern crate threshold_crypto as crypto;
 

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -4,7 +4,6 @@ extern crate docopt;
 extern crate env_logger;
 extern crate hbbft;
 extern crate itertools;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate rand_derive;

--- a/src/dynamic_honey_badger/batch.rs
+++ b/src/dynamic_honey_badger/batch.rs
@@ -48,7 +48,7 @@ impl<C, N: NodeIdT + Rand> Batch<C, N> {
     where
         &'a C: IntoIterator,
     {
-        self.contributions.values().flat_map(|item| item)
+        self.contributions.values().flatten()
     }
 
     /// Returns an iterator over all transactions included in the batch. Consumes the batch.

--- a/tests/binary_agreement.rs
+++ b/tests/binary_agreement.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -5,7 +5,6 @@ extern crate hbbft;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/coin.rs
+++ b/tests/coin.rs
@@ -5,7 +5,6 @@ extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -6,7 +6,6 @@ extern crate itertools;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -7,7 +7,6 @@ extern crate itertools;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate rand_derive;

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -6,7 +6,6 @@ extern crate hbbft;
 extern crate itertools;
 #[macro_use]
 extern crate log;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/subset.rs
+++ b/tests/subset.rs
@@ -5,7 +5,6 @@ extern crate env_logger;
 extern crate hbbft;
 #[macro_use]
 extern crate log;
-extern crate pairing;
 extern crate rand;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -3,7 +3,6 @@
 
 extern crate env_logger;
 extern crate hbbft;
-extern crate pairing;
 extern crate rand;
 extern crate threshold_crypto as crypto;
 


### PR DESCRIPTION
Pairing isn't used directly in tests and examples anymore.

Also, use the new `Iterator::flatten`.