### PR TITLE
Revert EpochStarted messages

### DIFF
--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -434,16 +434,11 @@ fn main() {
         .map(|_| Transaction::new(args.flag_tx_size))
         .collect();
     let new_honey_badger = |netinfo: NetworkInfo<NodeId>| {
-        let (dhb, dhb_step) = DynamicHoneyBadger::builder()
-            .build(netinfo)
-            .expect("`DynamicHoneyBadger` builder failed");
-        let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
+        let dyn_hb = DynamicHoneyBadger::builder().build(netinfo);
+        QueueingHoneyBadger::builder(dyn_hb)
             .batch_size(args.flag_b)
             .build_with_transactions(txs.clone())
-            .expect("instantiate QueueingHoneyBadger");
-        let mut step = dhb_step.convert();
-        step.extend(qhb_step);
-        (qhb, step)
+            .expect("instantiate QueueingHoneyBadger")
     };
     let hw_quality = HwQuality {
         latency: Duration::from_millis(args.flag_lag),

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -71,10 +71,7 @@ where
     }
 
     /// Creates a new Dynamic Honey Badger instance with an empty buffer.
-    pub fn build(
-        &mut self,
-        netinfo: NetworkInfo<N>,
-    ) -> Result<(DynamicHoneyBadger<C, N>, Step<C, N>)> {
+    pub fn build(&mut self, netinfo: NetworkInfo<N>) -> DynamicHoneyBadger<C, N> {
         let DynamicHoneyBadgerBuilder {
             max_future_epochs,
             rng,
@@ -83,12 +80,12 @@ where
         } = self;
         let max_future_epochs = *max_future_epochs;
         let arc_netinfo = Arc::new(netinfo.clone());
-        let (honey_badger, hb_step) = HoneyBadger::builder(arc_netinfo.clone())
+        let honey_badger = HoneyBadger::builder(arc_netinfo.clone())
             .max_future_epochs(max_future_epochs)
             .rng(rng.sub_rng())
             .subset_handling_strategy(subset_handling_strategy.clone())
             .build();
-        let mut dhb = DynamicHoneyBadger {
+        DynamicHoneyBadger {
             netinfo,
             max_future_epochs,
             start_epoch: 0,
@@ -98,23 +95,18 @@ where
             key_gen_state: None,
             incoming_queue: Vec::new(),
             rng: Box::new(rng.sub_rng()),
-        };
-        let step = dhb.process_output(hb_step)?;
-        Ok((dhb, step))
+        }
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
-    pub fn build_first_node(
-        &mut self,
-        our_id: N,
-    ) -> Result<(DynamicHoneyBadger<C, N>, Step<C, N>)> {
+    pub fn build_first_node(&mut self, our_id: N) -> Result<DynamicHoneyBadger<C, N>> {
         let sk_set = SecretKeySet::random(0, &mut self.rng)?;
         let pk_set = sk_set.public_keys();
         let sks = sk_set.secret_key_share(0)?;
         let sk: SecretKey = self.rng.gen();
         let pub_keys = once((our_id.clone(), sk.public_key())).collect();
         let netinfo = NetworkInfo::new(our_id, sks, pk_set, sk, pub_keys);
-        self.build(netinfo)
+        Ok(self.build(netinfo))
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to join the network at the epoch specified in
@@ -133,14 +125,13 @@ where
             join_plan.pub_keys,
         );
         let arc_netinfo = Arc::new(netinfo.clone());
-        let (honey_badger, hb_step) = HoneyBadger::builder(arc_netinfo.clone())
+        let honey_badger = HoneyBadger::builder(arc_netinfo.clone())
             .max_future_epochs(self.max_future_epochs)
             .build();
-        let start_epoch = join_plan.epoch;
         let mut dhb = DynamicHoneyBadger {
             netinfo,
             max_future_epochs: self.max_future_epochs,
-            start_epoch,
+            start_epoch: join_plan.epoch,
             vote_counter: VoteCounter::new(arc_netinfo, join_plan.epoch),
             key_gen_msg_buffer: Vec::new(),
             honey_badger,
@@ -148,12 +139,9 @@ where
             incoming_queue: Vec::new(),
             rng: Box::new(self.rng.sub_rng()),
         };
-        let mut step = dhb.process_output(hb_step)?;
-        match join_plan.change {
-            ChangeState::InProgress(ref change) => {
-                step.extend(dhb.update_key_gen(join_plan.epoch, change)?)
-            }
-            ChangeState::None | ChangeState::Complete(..) => (),
+        let step = match join_plan.change {
+            ChangeState::InProgress(ref change) => dhb.update_key_gen(join_plan.epoch, change)?,
+            ChangeState::None | ChangeState::Complete(..) => Step::default(),
         };
         Ok((dhb, step))
     }

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -29,6 +29,8 @@ pub enum ErrorKind {
     HandleHoneyBadgerMessageHoneyBadger(honey_badger::Error),
     #[fail(display = "SyncKeyGen error: {}", _0)]
     SyncKeyGen(sync_key_gen::Error),
+    #[fail(display = "Unknown sender")]
+    UnknownSender,
 }
 
 /// A dynamic honey badger error.

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -5,17 +5,14 @@ use std::sync::Arc;
 use rand::{self, Rand, Rng};
 use serde::{Deserialize, Serialize};
 
-use super::{HoneyBadger, Message, Step};
+use super::HoneyBadger;
 use honey_badger::SubsetHandlingStrategy;
-use messaging::{NetworkInfo, Target};
+use messaging::NetworkInfo;
 use traits::{Contribution, NodeIdT};
 use util::SubRng;
 
 /// A Honey Badger builder, to configure the parameters and create new instances of `HoneyBadger`.
-pub struct HoneyBadgerBuilder<C, N>
-where
-    N: Rand,
-{
+pub struct HoneyBadgerBuilder<C, N> {
     /// Shared network data.
     netinfo: Arc<NetworkInfo<N>>,
     /// The maximum number of future epochs for which we handle messages simultaneously.
@@ -65,26 +62,17 @@ where
         self
     }
 
-    /// Creates a new Honey Badger instance in epoch 0 and makes the initial `Step` on that
-    /// instance.
-    pub fn build(&mut self) -> (HoneyBadger<C, N>, Step<C, N>) {
-        let hb = HoneyBadger {
+    /// Creates a new Honey Badger instance.
+    pub fn build(&mut self) -> HoneyBadger<C, N> {
+        HoneyBadger {
             netinfo: self.netinfo.clone(),
             epoch: 0,
             has_input: false,
             epochs: BTreeMap::new(),
             max_future_epochs: self.max_future_epochs as u64,
             incoming_queue: BTreeMap::new(),
-            remote_epochs: BTreeMap::new(),
             rng: Box::new(self.rng.sub_rng()),
             subset_handling_strategy: self.subset_handling_strategy.clone(),
-        };
-        let step = if self.netinfo.is_validator() {
-            // The first message in an epoch announces the epoch transition.
-            Target::All.message(Message::EpochStarted(0)).into()
-        } else {
-            Step::default()
-        };
-        (hb, step)
+        }
     }
 }

--- a/src/honey_badger/error.rs
+++ b/src/honey_badger/error.rs
@@ -19,8 +19,8 @@ pub enum ErrorKind {
     HandleSubsetMessage(subset::Error),
     #[fail(display = "Threshold decryption error: {}", _0)]
     ThresholdDecryption(threshold_decryption::Error),
-    #[fail(display = "HoneyBadger message sender is not a validator")]
-    SenderNotValidator,
+    #[fail(display = "Unknown sender")]
+    UnknownSender,
 }
 
 /// A honey badger error.

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -4,7 +4,7 @@ use subset;
 use threshold_decryption;
 
 /// The content of a `HoneyBadger` message. It should be further annotated with an epoch.
-#[derive(Clone, Debug, Deserialize, PartialEq, Rand, Serialize)]
+#[derive(Clone, Debug, Deserialize, Rand, Serialize)]
 pub enum MessageContent<N: Rand> {
     /// A message belonging to the subset algorithm in the given epoch.
     Subset(subset::Message<N>),
@@ -17,7 +17,7 @@ pub enum MessageContent<N: Rand> {
 
 impl<N: Rand> MessageContent<N> {
     pub fn with_epoch(self, epoch: u64) -> Message<N> {
-        Message::HoneyBadger {
+        Message {
             epoch,
             content: self,
         }
@@ -26,25 +26,13 @@ impl<N: Rand> MessageContent<N> {
 
 /// A message sent to or received from another node's Honey Badger instance.
 #[derive(Clone, Debug, Deserialize, Rand, Serialize)]
-pub enum Message<N: Rand> {
-    /// A Honey Badger algorithm message annotated with the epoch number.
-    HoneyBadger {
-        epoch: u64,
-        content: MessageContent<N>,
-    },
-    /// A Honey Badger participant uses this message to announce its transition to the given
-    /// epoch. This message informs the recipients that this participant now accepts messages for
-    /// `max_future_epochs + 1` epochs counting from the given one, and drops any incoming messages
-    /// from earlier epochs.
-    EpochStarted(u64),
+pub struct Message<N: Rand> {
+    pub(super) epoch: u64,
+    pub(super) content: MessageContent<N>,
 }
 
 impl<N: Rand> Message<N> {
-    /// Returns the epoch from which the message originated.
     pub fn epoch(&self) -> u64 {
-        match *self {
-            Message::HoneyBadger { epoch, .. } => epoch,
-            Message::EpochStarted(epoch) => epoch,
-        }
+        self.epoch
     }
 }

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -62,7 +62,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 type ProposedValue = Vec<u8>;
 
 /// Message from Subset to remote nodes.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
+#[derive(Serialize, Deserialize, Clone, Debug, Rand)]
 pub enum Message<N: Rand> {
     /// A message for the broadcast algorithm concerning the set element proposed by the given node.
     Broadcast(N, broadcast::Message),

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use rand::Rng;
 
-use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input, Step};
+use hbbft::dynamic_honey_badger::{Batch, Change, ChangeState, DynamicHoneyBadger, Input};
 use hbbft::messaging::NetworkInfo;
 use hbbft::transaction_queue::TransactionQueue;
 
@@ -121,10 +121,8 @@ where
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-fn new_dynamic_hb(netinfo: Arc<NetworkInfo<NodeId>>) -> (UsizeDhb, Step<Vec<usize>, NodeId>) {
-    DynamicHoneyBadger::builder()
-        .build((*netinfo).clone())
-        .expect("`new_dynamic_hb` failed")
+fn new_dynamic_hb(netinfo: Arc<NetworkInfo<NodeId>>) -> UsizeDhb {
+    DynamicHoneyBadger::builder().build((*netinfo).clone())
 }
 
 fn test_dynamic_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)
@@ -146,8 +144,7 @@ where
             num_good_nodes, num_adv_nodes
         );
         let adversary = |adv_nodes| new_adversary(num_good_nodes, num_adv_nodes, adv_nodes);
-        let network =
-            TestNetwork::new_with_step(num_good_nodes, num_adv_nodes, adversary, new_dynamic_hb);
+        let network = TestNetwork::new(num_good_nodes, num_adv_nodes, adversary, new_dynamic_hb);
         test_dynamic_honey_badger(network, num_txs);
     }
 }

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use rand::Rng;
 
-use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent, Step};
+use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent};
 use hbbft::messaging::{NetworkInfo, Target, TargetedMessage};
 use hbbft::threshold_decryption;
 use hbbft::transaction_queue::TransactionQueue;
@@ -184,9 +184,7 @@ where
     }
 }
 
-fn new_honey_badger(
-    netinfo: Arc<NetworkInfo<NodeId>>,
-) -> (UsizeHoneyBadger, Step<Vec<usize>, NodeId>) {
+fn new_honey_badger(netinfo: Arc<NetworkInfo<NodeId>>) -> UsizeHoneyBadger {
     HoneyBadger::builder(netinfo).build()
 }
 
@@ -208,8 +206,7 @@ where
             num_good_nodes, num_adv_nodes
         );
         let adversary = |adv_nodes| new_adversary(num_good_nodes, num_adv_nodes, adv_nodes);
-        let network =
-            TestNetwork::new_with_step(num_good_nodes, num_adv_nodes, adversary, new_honey_badger);
+        let network = TestNetwork::new(num_good_nodes, num_adv_nodes, adversary, new_honey_badger);
         test_honey_badger(network, num_txs);
     }
 }

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -101,12 +101,11 @@ fn do_drop_and_readd(cfg: TestConfig) {
         .time_limit(time::Duration::from_secs(30 * cfg.dimension.size() as u64))
         // Ensure runs are reproducible.
         .rng(rng.gen::<TestRng>())
-        .using_step(move |node| {
+        .using(move |node| {
             println!("Constructing new dynamic honey badger node #{}", node.id);
             DynamicHoneyBadger::builder()
                 .rng(node.rng)
                 .build(node.netinfo)
-                .expect("cannot build instance")
         }).build()
         .expect("could not construct test network");
 

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -106,13 +106,8 @@ where
 fn new_queueing_hb(
     netinfo: Arc<NetworkInfo<NodeId>>,
 ) -> (QueueingHoneyBadger<usize, NodeId>, Step<usize, NodeId>) {
-    let (dhb, dhb_step) = DynamicHoneyBadger::builder()
-        .build((*netinfo).clone())
-        .expect("`new_queueing_hb` failed");
-    let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb).batch_size(3).build();
-    let mut step = dhb_step.convert();
-    step.extend(qhb_step);
-    (qhb, step)
+    let dyn_hb = DynamicHoneyBadger::builder().build((*netinfo).clone());
+    QueueingHoneyBadger::builder(dyn_hb).batch_size(3).build()
 }
 
 fn test_queueing_honey_badger_different_sizes<A, F>(new_adversary: F, num_txs: usize)


### PR DESCRIPTION
This reverts PR #219 and simplifies the code a bit. We need an external sender queue (#226) that would manage epoch announcements by itself. `EpochStarted` messages from algorithms will not be used. Hence I've removed those.