### PR TITLE
Add `NetworkInfo` to `Batch`.

### DIFF
--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -15,7 +15,6 @@ extern crate threshold_crypto as crypto;
 
 mod network;
 
-use std::cmp;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -101,22 +100,7 @@ where
             input_add = true;
         }
     }
-    verify_output_sequence(&network);
-}
-
-/// Verifies that all instances output the same sequence of batches. We already know that all of
-/// them have output all transactions and events, but some may have advanced a few empty batches
-/// more than others, so we ignore those.
-fn verify_output_sequence<A>(network: &TestNetwork<A, UsizeDhb>)
-where
-    A: Adversary<UsizeDhb>,
-{
-    let expected = network.nodes[&NodeId(0)].outputs().to_vec();
-    assert!(!expected.is_empty());
-    for node in network.nodes.values() {
-        let len = cmp::min(expected.len(), node.outputs().len());
-        assert_eq!(&expected[..len], &node.outputs()[..len]);
-    }
+    network.verify_batches();
 }
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -245,8 +245,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
     }
 
     // As a final step, we verify that all nodes have arrived at the same conclusion.
-    let first = net.correct_nodes().nth(0).unwrap().outputs();
-    assert!(net.nodes().all(|node| node.outputs() == first));
+    let out = net.verify_batches();
 
-    println!("End result: {:?}", first);
+    println!("End result: {:?}", out);
 }

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -15,7 +15,6 @@ extern crate threshold_crypto as crypto;
 
 mod network;
 
-use std::cmp;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -83,22 +82,7 @@ fn test_queueing_honey_badger<A>(
             input_add = true;
         }
     }
-    verify_output_sequence(&network);
-}
-
-/// Verifies that all instances output the same sequence of batches. We already know that all of
-/// them have output all transactions and events, but some may have advanced a few empty batches
-/// more than others, so we ignore those.
-fn verify_output_sequence<A>(network: &TestNetwork<A, QueueingHoneyBadger<usize, NodeId>>)
-where
-    A: Adversary<QueueingHoneyBadger<usize, NodeId>>,
-{
-    let expected = network.nodes[&NodeId(0)].outputs().to_vec();
-    assert!(!expected.is_empty());
-    for node in network.nodes.values() {
-        let len = cmp::min(expected.len(), node.outputs().len());
-        assert_eq!(&expected[..len], &node.outputs()[..len]);
-    }
+    network.verify_batches();
 }
 
 // Allow passing `netinfo` by value. `TestNetwork` expects this function signature.


### PR DESCRIPTION
Instead of just the public key, the batches returned from `DynamicHoneyBadger` and `QueueingHoneyBadger` now contain the full `NetworkInfo`, so the user can use the validators' keys for signing and encryption.