### PR TITLE
Remove push from queue

### DIFF
--- a/src/queueing_honey_badger.rs
+++ b/src/queueing_honey_badger.rs
@@ -22,9 +22,9 @@
 //! entries, any two nodes will likely make almost disjoint contributions instead of proposing
 //! the same transaction multiple times.
 
-use std::cmp;
 use std::fmt::{self, Display};
 use std::marker::PhantomData;
+use std::{cmp, iter};
 
 use failure::{Backtrace, Context, Fail};
 use rand::{Rand, Rng};
@@ -224,7 +224,7 @@ where
         // in addition signed and broadcast.
         let mut step = match input {
             Input::User(tx) => {
-                self.queue.push(tx);
+                self.queue.extend(iter::once(tx));
                 Step::default()
             }
             Input::Change(change) => self

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -11,8 +11,6 @@ use Contribution;
 pub trait TransactionQueue<T>: fmt::Debug + Default + Extend<T> + Sync + Send {
     /// Checks whether the queue is empty.
     fn is_empty(&self) -> bool;
-    /// Appends an element at the end of the queue.
-    fn push(&mut self, t: T);
     /// Returns a new set of `amount` transactions, randomly chosen from the first `batch_size`.
     /// No transactions are removed from the queue.
     // TODO: Return references, once the `HoneyBadger` API accepts them.
@@ -31,11 +29,6 @@ where
     #[inline]
     fn is_empty(&self) -> bool {
         self.is_empty()
-    }
-
-    #[inline]
-    fn push(&mut self, t: T) {
-        self.push(t);
     }
 
     fn remove_multiple<'a, I>(&mut self, txs: I)

--- a/src/transaction_queue.rs
+++ b/src/transaction_queue.rs
@@ -31,6 +31,7 @@ where
         self.is_empty()
     }
 
+    #[inline]
     fn remove_multiple<'a, I>(&mut self, txs: I)
     where
         I: IntoIterator<Item = &'a T>,
@@ -41,6 +42,7 @@ where
     }
 
     // TODO: Return references, once the `HoneyBadger` API accepts them. Remove `Clone` bound.
+    #[inline]
     fn choose<R: Rng>(&mut self, rng: &mut R, amount: usize, batch_size: usize) -> Vec<T> {
         let limit = cmp::min(batch_size, self.len());
         let sample = match rand::seq::sample_iter(rng, self.iter().take(limit), amount) {


### PR DESCRIPTION
Small change to shrink the interface of `TransactionQueue` by leveraging `iter::once`. We only use `push` once anyway. The resulting generated .asm should be for all intents and purposes identical.