### PR TITLE
Added a NetworkInfo getter trait

### DIFF
--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -6,7 +6,7 @@ use super::bool_set::BoolSet;
 use super::sbv_broadcast::{self, SbvBroadcast};
 use super::{Error, Message, MessageContent, Nonce, Result, Step};
 use coin::{self, Coin, CoinMessage};
-use {DistAlgorithm, NetworkInfo, NodeIdT, Target};
+use {DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT, Target};
 
 /// The state of the current epoch's coin. In some epochs this is fixed, in others it starts
 /// with in `InProgress`.
@@ -103,6 +103,13 @@ impl<N: NodeIdT> DistAlgorithm for BinaryAgreement<N> {
 
     fn our_id(&self) -> &Self::NodeId {
         self.netinfo.our_id()
+    }
+}
+
+impl<N: NodeIdT> HasNetworkInfo for BinaryAgreement<N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 

--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -16,7 +16,7 @@ use super::bool_multimap::BoolMultimap;
 use super::bool_set::{self, BoolSet};
 use super::{Error, Result};
 use fault_log::{Fault, FaultKind};
-use {DistAlgorithm, NetworkInfo, NodeIdT, Target};
+use {DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT, Target};
 
 pub type Step<N> = ::Step<SbvBroadcast<N>>;
 
@@ -81,6 +81,13 @@ impl<N: NodeIdT> DistAlgorithm for SbvBroadcast<N> {
 
     fn our_id(&self) -> &Self::NodeId {
         self.netinfo.our_id()
+    }
+}
+
+impl<N: NodeIdT> HasNetworkInfo for SbvBroadcast<N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -10,7 +10,7 @@ use super::merkle::{Digest, MerkleTree, Proof};
 use super::message::HexProof;
 use super::{Error, Message, Result};
 use fault_log::{Fault, FaultKind};
-use {DistAlgorithm, NetworkInfo, NodeIdT, Target};
+use {DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT, Target};
 
 /// Broadcast algorithm instance.
 #[derive(Debug)]
@@ -74,6 +74,13 @@ impl<N: NodeIdT> DistAlgorithm for Broadcast<N> {
 
     fn our_id(&self) -> &N {
         self.netinfo.our_id()
+    }
+}
+
+impl<N: NodeIdT> HasNetworkInfo for Broadcast<N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 

--- a/src/coin.rs
+++ b/src/coin.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use crypto::{self, Signature, SignatureShare};
 use fault_log::{Fault, FaultKind};
-use {DistAlgorithm, NetworkInfo, NodeIdT, Target};
+use {DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT, Target};
 
 /// A coin error.
 #[derive(Clone, Eq, PartialEq, Debug, Fail)]
@@ -115,6 +115,13 @@ where
 
     fn our_id(&self) -> &Self::NodeId {
         self.netinfo.our_id()
+    }
+}
+
+impl<N, T> HasNetworkInfo for Coin<N, T> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 

--- a/src/dynamic_honey_badger/batch.rs
+++ b/src/dynamic_honey_badger/batch.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use super::{ChangeState, JoinPlan};
-use {NetworkInfo, NodeIdT};
+use {HasNetworkInfo, NetworkInfo, NodeIdT};
 
 /// A batch of transactions the algorithm has output.
 #[derive(Clone, Debug)]
@@ -18,6 +18,13 @@ pub struct Batch<C, N> {
     pub(super) change: ChangeState<N>,
     /// The network info that applies to the _next_ epoch.
     pub(super) netinfo: Arc<NetworkInfo<N>>,
+}
+
+impl<C, N> HasNetworkInfo for Batch<C, N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
+    }
 }
 
 impl<C, N: NodeIdT> Batch<C, N> {

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -16,7 +16,7 @@ use fault_log::{Fault, FaultKind, FaultLog};
 use honey_badger::{self, HoneyBadger, Message as HbMessage};
 use sync_key_gen::{Ack, Part, PartOutcome, SyncKeyGen};
 use util::SubRng;
-use {Contribution, DistAlgorithm, NetworkInfo, NodeIdT, Target};
+use {Contribution, DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT, Target};
 
 /// A Honey Badger instance that can handle adding and removing nodes.
 pub struct DynamicHoneyBadger<C, N: Rand> {
@@ -113,6 +113,13 @@ where
 
     fn our_id(&self) -> &N {
         self.netinfo.our_id()
+    }
+}
+
+impl<C, N: Rand> HasNetworkInfo for DynamicHoneyBadger<C, N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Change, ErrorKind, Result};
 use fault_log::{FaultKind, FaultLog};
-use {NetworkInfo, NodeIdT};
+use {HasNetworkInfo, NetworkInfo, NodeIdT};
 
 /// A buffer and counter collecting pending and committed votes for validator set changes.
 ///
@@ -24,6 +24,13 @@ pub struct VoteCounter<N> {
     /// Collected votes for adding or removing nodes. Each node has one vote, and casting another
     /// vote revokes the previous one.
     committed: BTreeMap<N, Vote<N>>,
+}
+
+impl<N> HasNetworkInfo for VoteCounter<N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
+    }
 }
 
 impl<N> VoteCounter<N>

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -13,7 +13,7 @@ use super::{Batch, ErrorKind, MessageContent, Result, Step};
 use fault_log::{Fault, FaultKind, FaultLog};
 use subset::{self as cs, Subset, SubsetOutput};
 use threshold_decryption::{self as td, ThresholdDecryption};
-use {Contribution, DistAlgorithm, NetworkInfo, NodeIdT};
+use {Contribution, DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT};
 
 /// The status of an encrypted contribution.
 #[derive(Debug)]
@@ -192,6 +192,13 @@ pub struct EpochState<C, N: Rand> {
     /// Determines the behavior upon receiving proposals from `subset`.
     subset_handler: SubsetHandler<N>,
     _phantom: PhantomData<C>,
+}
+
+impl<C, N: Rand> HasNetworkInfo for EpochState<C, N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
+    }
 }
 
 impl<C, N> EpochState<C, N>

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::epoch_state::EpochState;
 use super::{Batch, Error, ErrorKind, HoneyBadgerBuilder, Message, MessageContent, Result};
-use {Contribution, DistAlgorithm, NetworkInfo, NodeIdT};
+use {Contribution, DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT};
 
 pub use super::epoch_state::SubsetHandlingStrategy;
 
@@ -79,6 +79,13 @@ where
 
     fn our_id(&self) -> &N {
         self.netinfo.our_id()
+    }
+}
+
+impl<C, N: Rand> HasNetworkInfo for HoneyBadger<C, N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,5 +156,5 @@ pub mod util;
 
 pub use crypto::pairing;
 pub use messaging::{SourcedMessage, Target, TargetedMessage};
-pub use network_info::NetworkInfo;
+pub use network_info::{HasNetworkInfo, NetworkInfo};
 pub use traits::{Contribution, DistAlgorithm, Message, NodeIdT, Step};

--- a/src/network_info.rs
+++ b/src/network_info.rs
@@ -187,3 +187,9 @@ impl<N: NodeIdT> NetworkInfo<N> {
             .collect()
     }
 }
+
+/// An interface to algorithms that carry a `NetworkInfo`.
+pub trait HasNetworkInfo {
+    type N;
+    fn netinfo(&self) -> &NetworkInfo<Self::N>;
+}

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -32,7 +32,7 @@ use hex_fmt::HexFmt;
 use binary_agreement::{self, BinaryAgreement};
 use broadcast::{self, Broadcast};
 use rand::Rand;
-use {DistAlgorithm, NetworkInfo, NodeIdT};
+use {DistAlgorithm, HasNetworkInfo, NetworkInfo, NodeIdT};
 
 /// A subset error.
 #[derive(Clone, PartialEq, Debug, Fail)]
@@ -118,6 +118,13 @@ impl<N: NodeIdT + Rand> DistAlgorithm for Subset<N> {
 
     fn our_id(&self) -> &Self::NodeId {
         self.netinfo.our_id()
+    }
+}
+
+impl<N: Rand> HasNetworkInfo for Subset<N> {
+    type N = N;
+    fn netinfo(&self) -> &NetworkInfo<N> {
+        &self.netinfo
     }
 }
 


### PR DESCRIPTION
I added `HasNetworkInfo` to access the `netinfo` field of a `DistAlgorithm` if it has one. This can be used in the generic sender queue.