### PR TITLE
Extend API to work without DistAlgorithm.

### DIFF
--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -82,18 +82,7 @@ impl<N: NodeIdT> DistAlgorithm for BinaryAgreement<N> {
 
     /// Receive input from a remote node.
     fn handle_message(&mut self, sender_id: &Self::NodeId, msg: Message) -> Result<Step<N>> {
-        let Message { epoch, content } = msg;
-        if self.decision.is_some() || (epoch < self.epoch && content.can_expire()) {
-            // Message is obsolete: We are already in a later epoch or terminated.
-            Ok(Step::default())
-        } else if epoch > self.epoch {
-            // Message is for a later epoch. We can't handle that yet.
-            let queue = self.incoming_queue.entry(epoch).or_insert_with(Vec::new);
-            queue.push((sender_id.clone(), content));
-            Ok(Step::default())
-        } else {
-            self.handle_message_content(sender_id, content)
-        }
+        self.handle_message(sender_id, msg)
     }
 
     /// Whether the algorithm has terminated.
@@ -107,6 +96,10 @@ impl<N: NodeIdT> DistAlgorithm for BinaryAgreement<N> {
 }
 
 impl<N: NodeIdT> BinaryAgreement<N> {
+    /// Creates a new `BinaryAgreement` instance. The `session_id` and `proposer_id` are used to
+    /// uniquely identify this instance: its messages cannot be replayed in an instance with
+    /// different values.
+    // TODO: Use a generic type argument for that instead of something `Subset`-specific.
     pub fn new(netinfo: Arc<NetworkInfo<N>>, session_id: u64, proposer_id: N) -> Result<Self> {
         if !netinfo.is_node_validator(&proposer_id) {
             return Err(Error::UnknownProposer);
@@ -128,9 +121,9 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     }
 
     /// Sets the input value for Binary Agreement.
-    fn handle_input(&mut self, input: bool) -> Result<Step<N>> {
-        if self.epoch != 0 || self.estimated.is_some() {
-            return Err(Error::InputNotAccepted);
+    pub fn handle_input(&mut self, input: bool) -> Result<Step<N>> {
+        if !self.can_input() {
+            return Ok(Step::default());
         }
         // Set the initial estimated value to the input value.
         self.estimated = Some(input);
@@ -139,8 +132,25 @@ impl<N: NodeIdT> BinaryAgreement<N> {
         self.handle_sbvb_step(sbvb_step)
     }
 
-    /// Acceptance check to be performed before setting the input value.
-    pub fn accepts_input(&self) -> bool {
+    /// Handles an incoming message.
+    pub fn handle_message(&mut self, sender_id: &N, msg: Message) -> Result<Step<N>> {
+        let Message { epoch, content } = msg;
+        if self.decision.is_some() || (epoch < self.epoch && content.can_expire()) {
+            // Message is obsolete: We are already in a later epoch or terminated.
+            Ok(Step::default())
+        } else if epoch > self.epoch {
+            // Message is for a later epoch. We can't handle that yet.
+            let queue = self.incoming_queue.entry(epoch).or_insert_with(Vec::new);
+            queue.push((sender_id.clone(), content));
+            Ok(Step::default())
+        } else {
+            self.handle_message_content(sender_id, content)
+        }
+    }
+
+    /// Whether we can still input a value. It is not an error to input if this returns `false`,
+    /// but it will have no effect on the outcome.
+    pub fn can_input(&self) -> bool {
         self.epoch == 0 && self.estimated.is_none()
     }
 

--- a/src/binary_agreement/mod.rs
+++ b/src/binary_agreement/mod.rs
@@ -84,8 +84,6 @@ pub enum Error {
     InvokeCoin(threshold_sign::Error),
     #[fail(display = "Unknown proposer")]
     UnknownProposer,
-    #[fail(display = "Input not accepted")]
-    InputNotAccepted,
 }
 
 /// An Binary Agreement result.

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -56,7 +56,7 @@
 //! extern crate rand;
 //!
 //! use hbbft::broadcast::{Broadcast, Error, Step};
-//! use hbbft::{DistAlgorithm, NetworkInfo, SourcedMessage, Target, TargetedMessage};
+//! use hbbft::{NetworkInfo, SourcedMessage, Target, TargetedMessage};
 //! use rand::{thread_rng, Rng};
 //! use std::collections::{BTreeMap, BTreeSet, VecDeque};
 //! use std::iter::once;
@@ -111,7 +111,7 @@
 //!     // Now we can start the algorithm, its input is the payload.
 //!     let initial_step = {
 //!         let proposer = nodes.get_mut(&PROPOSER_ID).unwrap();
-//!         proposer.handle_input(payload.clone()).unwrap()
+//!         proposer.broadcast(payload.clone()).unwrap()
 //!     };
 //!     on_step(
 //!         PROPOSER_ID,

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -117,7 +117,7 @@
 //!     secret_key_shares.insert(id, sks);
 //! }
 //!
-//! // Three out of four nodes can now sign a message. Each share can be verified individually.
+//! // Two out of four nodes can now sign a message. Each share can be verified individually.
 //! let msg = "Nodes 0 and 1 does not agree with this.";
 //! let mut sig_shares: BTreeMap<usize, SignatureShare> = BTreeMap::new();
 //! for (&id, sks) in &secret_key_shares {

--- a/src/threshold_decryption.rs
+++ b/src/threshold_decryption.rs
@@ -89,6 +89,7 @@ impl<N: NodeIdT> ThresholdDecryption<N> {
 
     /// Sets the ciphertext, sends the decryption share, and tries to decrypt it.
     /// This must be called exactly once, with the same ciphertext in all participating nodes.
+    /// If we have enough shares, outputs the plaintext.
     pub fn set_ciphertext(&mut self, ct: Ciphertext) -> Result<Step<N>> {
         if self.ciphertext.is_some() {
             return Err(Error::MultipleInputs(Box::new(ct)));
@@ -115,7 +116,8 @@ impl<N: NodeIdT> ThresholdDecryption<N> {
         self.shares.keys()
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Message) -> Result<Step<N>> {
+    /// Handles an incoming message. If we have collected enough shares, outputs the plaintext.
+    pub fn handle_message(&mut self, sender_id: &N, message: Message) -> Result<Step<N>> {
         if self.terminated {
             return Ok(Step::default()); // Don't waste time on redundant shares.
         }


### PR DESCRIPTION
Extends all APIs so that the user doesn't need to import the
`DistAlgorithm` trait.

Also, removes the error on inputting too late into `BinaryAgreement`:
whether the input still matters is an implementation detail.