### PR TITLE
Fixed early output from Subset

### DIFF
--- a/src/subset.rs
+++ b/src/subset.rs
@@ -311,7 +311,11 @@ impl<N: NodeIdT + Rand> Subset<N> {
                     }
                 }
             }
-            if let Some(Some(value)) = self.broadcast_results.insert(proposer_id.clone(), None) {
+            if let Some(value) = self
+                .broadcast_results
+                .get_mut(proposer_id)
+                .and_then(Option::take)
+            {
                 debug!("    {:?} → {:0.10}", proposer_id, HexFmt(&value));
                 step.output
                     .extend(Some(SubsetOutput::Contribution(proposer_id.clone(), value)));


### PR DESCRIPTION
Fixes #282 

Let me know if you think a specialized test is needed. This bug is only covered by tests in https://github.com/poanetwork/hbbft/tree/vk-extern-sender-queue. It should be possible to trigger the bug (and the fault) by sending _some_ `Aux` messages before the corresponding `Proof` messages, so that `Agreement` instances finish before _some_ `Broadcast` instances.