### PR TITLE
Fix abbreviations from the paper: ABA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,12 @@ Our implementation modifies the protocols described in "[The Honey Badger of BFT
 
 We have simplified algorithm naming conventions from the original paper.
 
-|  Algorithm Name  | Original Name                    |
-| ---------------- | -------------------------------- |
-| Honey Badger     | HoneyBadgerBFT                   |
-| Subset           | Asynchronous Common Subset (ACS) |
-| Broadcast        | Reliable Broadcast (RBC)         |
-| Binary Agreement | Binary Byzantine Agreement (BBA) |
+|  Algorithm Name  | Original Name                                 |
+| ---------------- | --------------------------------------------- |
+| Honey Badger     | HoneyBadgerBFT                                |
+| Subset           | Asynchronous Common Subset (ACS)              |
+| Broadcast        | Reliable Broadcast (RBC)                      |
+| Binary Agreement | Asynchronous Binary Byzantine Agreement (ABA) |
 
 ## Contributing
 


### PR DESCRIPTION
The Binary Agreement is mostly referred to as "ABA" in the [paper](https://eprint.iacr.org/2016/199.pdf).
(Unfortunately not consistently: the box with the message flow just says "BA".)