### PR TITLE
Make the BA session ID generic.

### DIFF
--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -1,12 +1,16 @@
 use std::collections::BTreeMap;
+use std::fmt::{self, Display};
+use std::result;
 use std::sync::Arc;
+
+use bincode;
 
 use super::bool_multimap::BoolMultimap;
 use super::bool_set::BoolSet;
 use super::sbv_broadcast::{self, SbvBroadcast};
-use super::{Error, Message, MessageContent, Nonce, Result, Step};
+use super::{Error, Message, MessageContent, Result, Step};
 use threshold_sign::{self, ThresholdSign};
-use {DistAlgorithm, NetworkInfo, NodeIdT, Target};
+use {DistAlgorithm, NetworkInfo, NodeIdT, SessionIdT, Target};
 
 /// The state of the current epoch's coin. In some epochs this is fixed, in others it starts
 /// with in `InProgress`.
@@ -36,13 +40,11 @@ impl<N> From<bool> for CoinState<N> {
 
 /// Binary Agreement instance
 #[derive(Debug)]
-pub struct BinaryAgreement<N> {
+pub struct BinaryAgreement<N, S> {
     /// Shared network information.
     netinfo: Arc<NetworkInfo<N>>,
-    /// Session ID, e.g, the Honey Badger algorithm epoch.
-    session_id: u64,
-    /// The ID of the proposer of the value for this Binary Agreement instance.
-    proposer_id: N,
+    /// Session identifier, to prevent replaying messages in other instances.
+    session_id: S,
     /// Binary Agreement algorithm epoch.
     epoch: u32,
     /// This epoch's Synchronized Binary Value Broadcast instance.
@@ -69,19 +71,19 @@ pub struct BinaryAgreement<N> {
     coin_state: CoinState<N>,
 }
 
-impl<N: NodeIdT> DistAlgorithm for BinaryAgreement<N> {
+impl<N: NodeIdT, S: SessionIdT> DistAlgorithm for BinaryAgreement<N, S> {
     type NodeId = N;
     type Input = bool;
     type Output = bool;
     type Message = Message;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input(&mut self, input: Self::Input) -> Result<Step<N, S>> {
         self.propose(input)
     }
 
     /// Receive input from a remote node.
-    fn handle_message(&mut self, sender_id: &Self::NodeId, msg: Message) -> Result<Step<N>> {
+    fn handle_message(&mut self, sender_id: &Self::NodeId, msg: Message) -> Result<Step<N, S>> {
         self.handle_message(sender_id, msg)
     }
 
@@ -95,19 +97,13 @@ impl<N: NodeIdT> DistAlgorithm for BinaryAgreement<N> {
     }
 }
 
-impl<N: NodeIdT> BinaryAgreement<N> {
-    /// Creates a new `BinaryAgreement` instance. The `session_id` and `proposer_id` are used to
-    /// uniquely identify this instance: its messages cannot be replayed in an instance with
-    /// different values.
-    // TODO: Use a generic type argument for that instead of something `Subset`-specific.
-    pub fn new(netinfo: Arc<NetworkInfo<N>>, session_id: u64, proposer_id: N) -> Result<Self> {
-        if !netinfo.is_node_validator(&proposer_id) {
-            return Err(Error::UnknownProposer);
-        }
+impl<N: NodeIdT, S: SessionIdT> BinaryAgreement<N, S> {
+    /// Creates a new `BinaryAgreement` instance with the given session identifier, to prevent
+    /// replaying messages in other instances.
+    pub fn new(netinfo: Arc<NetworkInfo<N>>, session_id: S) -> Result<Self> {
         Ok(BinaryAgreement {
             netinfo: netinfo.clone(),
             session_id,
-            proposer_id,
             epoch: 0,
             sbv_broadcast: SbvBroadcast::new(netinfo),
             received_conf: BTreeMap::new(),
@@ -126,13 +122,13 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     /// output. Otherwise either output is possible.
     ///
     /// Note that if `can_propose` returns `false`, it is already too late to affect the outcome.
-    pub fn propose(&mut self, input: bool) -> Result<Step<N>> {
+    pub fn propose(&mut self, input: bool) -> Result<Step<N, S>> {
         if !self.can_propose() {
             return Ok(Step::default());
         }
         // Set the initial estimated value to the input value.
         self.estimated = Some(input);
-        debug!("{:?}/{:?} Input {}", self.our_id(), self.proposer_id, input);
+        debug!("{}: Input {}", self, input);
         let sbvb_step = self.sbv_broadcast.handle_input(input)?;
         self.handle_sbvb_step(sbvb_step)
     }
@@ -140,7 +136,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     /// Handles a message received from `sender_id`.
     ///
     /// This must be called with every message we receive from another node.
-    pub fn handle_message(&mut self, sender_id: &N, msg: Message) -> Result<Step<N>> {
+    pub fn handle_message(&mut self, sender_id: &N, msg: Message) -> Result<Step<N, S>> {
         let Message { epoch, content } = msg;
         if self.decision.is_some() || (epoch < self.epoch && content.can_expire()) {
             // Message is obsolete: We are already in a later epoch or terminated.
@@ -166,7 +162,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
         &mut self,
         sender_id: &N,
         content: MessageContent,
-    ) -> Result<Step<N>> {
+    ) -> Result<Step<N, S>> {
         match content {
             MessageContent::SbvBroadcast(msg) => self.handle_sbv_broadcast(sender_id, msg),
             MessageContent::Conf(v) => self.handle_conf(sender_id, v),
@@ -180,14 +176,14 @@ impl<N: NodeIdT> BinaryAgreement<N> {
         &mut self,
         sender_id: &N,
         msg: sbv_broadcast::Message,
-    ) -> Result<Step<N>> {
+    ) -> Result<Step<N, S>> {
         let sbvb_step = self.sbv_broadcast.handle_message(sender_id, msg)?;
         self.handle_sbvb_step(sbvb_step)
     }
 
     /// Handles a Synchronized Binary Value Broadcast step. On output, starts the `Conf` round or
     /// decides.
-    fn handle_sbvb_step(&mut self, sbvb_step: sbv_broadcast::Step<N>) -> Result<Step<N>> {
+    fn handle_sbvb_step(&mut self, sbvb_step: sbv_broadcast::Step<N>) -> Result<Step<N, S>> {
         let mut step = Step::default();
         let output = step.extend_with(sbvb_step, |msg| {
             MessageContent::SbvBroadcast(msg).with_epoch(self.epoch)
@@ -213,7 +209,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
 
     /// Handles a `Conf` message. When _N - f_ `Conf` messages with values in `bin_values` have
     /// been received, updates the epoch or decides.
-    fn handle_conf(&mut self, sender_id: &N, v: BoolSet) -> Result<Step<N>> {
+    fn handle_conf(&mut self, sender_id: &N, v: BoolSet) -> Result<Step<N, S>> {
         self.received_conf.insert(sender_id.clone(), v);
         self.try_finish_conf_round()
     }
@@ -221,7 +217,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     /// Handles a `Term(v)` message. If we haven't yet decided on a value and there are more than
     /// _f_ such messages with the same value from different nodes, performs expedite termination:
     /// decides on `v`, broadcasts `Term(v)` and terminates the instance.
-    fn handle_term(&mut self, sender_id: &N, b: bool) -> Result<Step<N>> {
+    fn handle_term(&mut self, sender_id: &N, b: bool) -> Result<Step<N, S>> {
         self.received_term[b].insert(sender_id.clone());
         // Check for the expedite termination condition.
         if self.decision.is_some() {
@@ -239,7 +235,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
 
     /// Handles a `ThresholdSign` message. If there is output, starts the next epoch. The function
     /// may output a decision value.
-    fn handle_coin(&mut self, sender_id: &N, msg: threshold_sign::Message) -> Result<Step<N>> {
+    fn handle_coin(&mut self, sender_id: &N, msg: threshold_sign::Message) -> Result<Step<N, S>> {
         let ts_step = match self.coin_state {
             CoinState::Decided(_) => return Ok(Step::default()), // Coin value is already decided.
             CoinState::InProgress(ref mut ts) => ts
@@ -250,7 +246,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     }
 
     /// Multicasts a `Conf(values)` message, and handles it.
-    fn send_conf(&mut self, values: BoolSet) -> Result<Step<N>> {
+    fn send_conf(&mut self, values: BoolSet) -> Result<Step<N, S>> {
         if self.conf_values.is_some() {
             // Only one `Conf` message is allowed in an epoch.
             return Ok(Step::default());
@@ -267,11 +263,11 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     }
 
     /// Multicasts and handles a message. Does nothing if we are only an observer.
-    fn send(&mut self, content: MessageContent) -> Result<Step<N>> {
+    fn send(&mut self, content: MessageContent) -> Result<Step<N, S>> {
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
         }
-        let step: Step<_> = Target::All
+        let step: Step<N, S> = Target::All
             .message(content.clone().with_epoch(self.epoch))
             .into();
         let our_id = &self.our_id().clone();
@@ -279,7 +275,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     }
 
     /// Handles a step returned from the `ThresholdSign`.
-    fn on_coin_step(&mut self, ts_step: threshold_sign::Step<N>) -> Result<Step<N>> {
+    fn on_coin_step(&mut self, ts_step: threshold_sign::Step<N>) -> Result<Step<N, S>> {
         let mut step = Step::default();
         let epoch = self.epoch;
         let to_msg = |c_msg| MessageContent::Coin(Box::new(c_msg)).with_epoch(epoch);
@@ -298,7 +294,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     /// With two conf values, the next epoch's estimate is the coin value. If there is only one conf
     /// value and that disagrees with the coin, the conf value is the next epoch's estimate. If
     /// the unique conf value agrees with the coin, terminates and decides on that value.
-    fn try_update_epoch(&mut self) -> Result<Step<N>> {
+    fn try_update_epoch(&mut self) -> Result<Step<N, S>> {
         if self.decision.is_some() {
             // Avoid an infinite regression without making a Binary Agreement step.
             return Ok(Step::default());
@@ -321,24 +317,19 @@ impl<N: NodeIdT> BinaryAgreement<N> {
 
     /// Creates the initial coin state for the current epoch, i.e. sets it to the predetermined
     /// value, or initializes a `ThresholdSign` instance.
-    fn coin_state(&self) -> CoinState<N> {
-        match self.epoch % 3 {
+    fn coin_state(&self) -> Result<CoinState<N>> {
+        Ok(match self.epoch % 3 {
             0 => CoinState::Decided(true),
             1 => CoinState::Decided(false),
             _ => {
-                let nonce = Nonce::new(
-                    self.netinfo.invocation_id().as_ref(),
-                    self.session_id,
-                    self.netinfo.node_index(&self.proposer_id).unwrap(),
-                    self.epoch,
-                );
-                CoinState::InProgress(Box::new(ThresholdSign::new(self.netinfo.clone(), nonce)))
+                let coin_id = bincode::serialize(&(&self.session_id, self.epoch))?;
+                CoinState::InProgress(Box::new(ThresholdSign::new(self.netinfo.clone(), coin_id)))
             }
-        }
+        })
     }
 
     /// Decides on a value and broadcasts a `Term` message with that value.
-    fn decide(&mut self, b: bool) -> Step<N> {
+    fn decide(&mut self, b: bool) -> Step<N, S> {
         if self.decision.is_some() {
             return Step::default();
         }
@@ -347,13 +338,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
         step.output.push(b);
         // Latch the decided state.
         self.decision = Some(b);
-        debug!(
-            "{:?}/{:?} (is_validator: {}) decision: {}",
-            self.our_id(),
-            self.proposer_id,
-            self.netinfo.is_validator(),
-            b
-        );
+        debug!("{}: decision: {}", self, b);
         if self.netinfo.is_validator() {
             let msg = MessageContent::Term(b).with_epoch(self.epoch + 1);
             step.messages.push(Target::All.message(msg));
@@ -362,7 +347,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     }
 
     /// Checks whether the _N - f_ `Conf` messages have arrived, and if so, activates the coin.
-    fn try_finish_conf_round(&mut self) -> Result<Step<N>> {
+    fn try_finish_conf_round(&mut self) -> Result<Step<N, S>> {
         if self.conf_values.is_none() || self.count_conf() < self.netinfo.num_correct() {
             return Ok(Step::default());
         }
@@ -382,7 +367,7 @@ impl<N: NodeIdT> BinaryAgreement<N> {
     }
 
     /// Increments the epoch, sets the new estimate and handles queued messages.
-    fn update_epoch(&mut self, b: bool) -> Result<Step<N>> {
+    fn update_epoch(&mut self, b: bool) -> Result<Step<N, S>> {
         self.sbv_broadcast.clear(&self.received_term);
         self.received_conf.clear();
         for (v, id) in &self.received_term {
@@ -390,12 +375,10 @@ impl<N: NodeIdT> BinaryAgreement<N> {
         }
         self.conf_values = None;
         self.epoch += 1;
-        self.coin_state = self.coin_state();
+        self.coin_state = self.coin_state()?;
         debug!(
-            "{:?} BinaryAgreement instance {:?} started epoch {}, {} terminated",
-            self.our_id(),
-            self.proposer_id,
-            self.epoch,
+            "{}: epoch started, {} terminated",
+            self,
             self.received_conf.len(),
         );
 
@@ -414,5 +397,22 @@ impl<N: NodeIdT> BinaryAgreement<N> {
             }
         }
         Ok(step)
+    }
+}
+
+impl<N: NodeIdT, S: SessionIdT> Display for BinaryAgreement<N, S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+        write!(
+            f,
+            "{:?} BA {} epoch {} ({})",
+            self.our_id(),
+            self.session_id,
+            self.epoch,
+            if self.netinfo.is_validator() {
+                "validator"
+            } else {
+                "observer"
+            }
+        )
     }
 }

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -91,6 +91,7 @@ where
         let max_future_epochs = *max_future_epochs;
         let arc_netinfo = Arc::new(netinfo.clone());
         let honey_badger = HoneyBadger::builder(arc_netinfo.clone())
+            .session_id(epoch)
             .max_future_epochs(max_future_epochs)
             .rng(rng.sub_rng())
             .subset_handling_strategy(subset_handling_strategy.clone())

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -351,6 +351,7 @@ where
         let netinfo = Arc::new(self.netinfo.clone());
         self.vote_counter = VoteCounter::new(netinfo.clone(), epoch);
         self.honey_badger = HoneyBadger::builder(netinfo)
+            .session_id(epoch)
             .max_future_epochs(self.max_future_epochs)
             .rng(self.rng.sub_rng())
             .build();

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -14,6 +14,9 @@ use {Contribution, NetworkInfo, NodeIdT};
 pub struct HoneyBadgerBuilder<C, N> {
     /// Shared network data.
     netinfo: Arc<NetworkInfo<N>>,
+    /// A session identifier. Different session IDs foil replay attacks in two instances with the
+    /// same epoch numbers and the same validators.
+    session_id: u64,
     /// Start in this epoch.
     epoch: u64,
     /// The maximum number of future epochs for which we handle messages simultaneously.
@@ -35,6 +38,7 @@ where
     pub fn new(netinfo: Arc<NetworkInfo<N>>) -> Self {
         HoneyBadgerBuilder {
             netinfo,
+            session_id: 0,
             epoch: 0,
             max_future_epochs: 3,
             rng: Box::new(rand::thread_rng()),
@@ -46,6 +50,15 @@ where
     /// Sets the random number generator for the public key cryptography.
     pub fn rng<R: Rng + 'static>(&mut self, rng: R) -> &mut Self {
         self.rng = Box::new(rng);
+        self
+    }
+
+    /// Sets the session identifier.
+    ///
+    /// Different session IDs foil replay attacks in two instances with the same epoch numbers and
+    /// the same validators.
+    pub fn session_id(&mut self, session_id: u64) -> &mut Self {
+        self.session_id = session_id;
         self
     }
 
@@ -74,6 +87,7 @@ where
     pub fn build(&mut self) -> HoneyBadger<C, N> {
         HoneyBadger {
             netinfo: self.netinfo.clone(),
+            session_id: self.session_id,
             epoch: self.epoch,
             has_input: false,
             epochs: BTreeMap::new(),

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -18,6 +18,9 @@ pub use super::epoch_state::SubsetHandlingStrategy;
 pub struct HoneyBadger<C, N: Rand> {
     /// Shared network data.
     pub(super) netinfo: Arc<NetworkInfo<N>>,
+    /// A session identifier. Different session IDs foil replay attacks in two instances with the
+    /// same epoch numbers and the same validators.
+    pub(super) session_id: u64,
     /// The earliest epoch from which we have not yet received output.
     pub(super) epoch: u64,
     /// Whether we have already submitted a proposal for the current epoch.
@@ -176,6 +179,7 @@ where
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(EpochState::new(
                 self.netinfo.clone(),
+                self.session_id,
                 epoch,
                 self.subset_handling_strategy.clone(),
             )?),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,4 +157,4 @@ pub use crypto::pairing;
 pub use fault_log::{Fault, FaultKind, FaultLog};
 pub use messaging::{SourcedMessage, Target, TargetedMessage};
 pub use network_info::NetworkInfo;
-pub use traits::{Contribution, DistAlgorithm, Message, NodeIdT, Step};
+pub use traits::{Contribution, DistAlgorithm, Message, NodeIdT, SessionIdT, Step};

--- a/src/network_info.rs
+++ b/src/network_info.rs
@@ -128,21 +128,11 @@ impl<N: NodeIdT> NetworkInfo<N> {
         &self.public_keys
     }
 
-    /// The index of a node in a canonical numbering of all nodes.
+    /// The index of a node in a canonical numbering of all nodes. This is the index where the
+    /// node appears in `all_ids`.
     #[inline]
     pub fn node_index(&self, id: &N) -> Option<usize> {
         self.node_indices.get(id).cloned()
-    }
-
-    /// Returns the unique ID of the Honey Badger invocation.
-    ///
-    /// FIXME: Using the public key as the invocation ID either requires agreeing on the keys on
-    /// each invocation, or makes it unsafe to reuse keys for different invocations. A better
-    /// invocation ID would be one that is distributed to all nodes on each invocation and would be
-    /// independent from the public key, so that reusing keys would be safer.
-    #[inline]
-    pub fn invocation_id(&self) -> Vec<u8> {
-        self.public_key_set.public_key().to_bytes()
     }
 
     /// Returns `true` if this node takes part in the consensus itself. If not, it is only an

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,10 +1,11 @@
 //! Common supertraits for distributed algorithms.
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::iter::once;
 
 use failure::Fail;
+use serde::Serialize;
 
 use fault_log::{Fault, FaultLog};
 use TargetedMessage;
@@ -20,6 +21,10 @@ impl<N> NodeIdT for N where N: Eq + Ord + Clone + Debug + Hash + Send + Sync {}
 /// Messages.
 pub trait Message: Debug + Send + Sync {}
 impl<M> Message for M where M: Debug + Send + Sync {}
+
+/// Session identifiers.
+pub trait SessionIdT: Display + Serialize + Send + Sync + Clone {}
+impl<S> SessionIdT for S where S: Display + Serialize + Send + Sync + Clone {}
 
 /// Result of one step of the local state machine of a distributed algorithm. Such a result should
 /// be used and never discarded by the client of the algorithm.

--- a/tests/binary_agreement.rs
+++ b/tests/binary_agreement.rs
@@ -37,8 +37,8 @@ use hbbft::NetworkInfo;
 
 use network::{Adversary, MessageScheduler, NodeId, SilentAdversary, TestNetwork, TestNode};
 
-fn test_binary_agreement<A: Adversary<BinaryAgreement<NodeId>>>(
-    mut network: TestNetwork<A, BinaryAgreement<NodeId>>,
+fn test_binary_agreement<A: Adversary<BinaryAgreement<NodeId, u8>>>(
+    mut network: TestNetwork<A, BinaryAgreement<NodeId, u8>>,
     input: Option<bool>,
 ) {
     let ids: Vec<NodeId> = network.nodes.keys().cloned().collect();
@@ -65,7 +65,7 @@ fn test_binary_agreement<A: Adversary<BinaryAgreement<NodeId>>>(
 
 fn test_binary_agreement_different_sizes<A, F>(new_adversary: F)
 where
-    A: Adversary<BinaryAgreement<NodeId>>,
+    A: Adversary<BinaryAgreement<NodeId, u8>>,
     F: Fn(usize, usize) -> A,
 {
     // This returns an error in all but the first test.
@@ -85,7 +85,7 @@ where
             );
             let adversary = |_| new_adversary(num_good_nodes, num_faulty_nodes);
             let new_ba = |netinfo: Arc<NetworkInfo<NodeId>>| {
-                BinaryAgreement::new(netinfo, 0, NodeId(0)).expect("Binary Agreement instance")
+                BinaryAgreement::new(netinfo, 0).expect("Binary Agreement instance")
             };
             let network = TestNetwork::new(num_good_nodes, num_faulty_nodes, adversary, new_ba);
             test_binary_agreement(network, input);

--- a/tests/subset.rs
+++ b/tests/subset.rs
@@ -25,8 +25,8 @@ use network::{Adversary, MessageScheduler, NodeId, SilentAdversary, TestNetwork,
 
 type ProposedValue = Vec<u8>;
 
-fn test_subset<A: Adversary<Subset<NodeId>>>(
-    mut network: TestNetwork<A, Subset<NodeId>>,
+fn test_subset<A: Adversary<Subset<NodeId, u8>>>(
+    mut network: TestNetwork<A, Subset<NodeId, u8>>,
     inputs: &BTreeMap<NodeId, ProposedValue>,
 ) {
     let ids: Vec<NodeId> = network.nodes.keys().cloned().collect();
@@ -75,9 +75,9 @@ fn new_network<A, F>(
     good_num: usize,
     bad_num: usize,
     adversary: F,
-) -> TestNetwork<A, Subset<NodeId>>
+) -> TestNetwork<A, Subset<NodeId, u8>>
 where
-    A: Adversary<Subset<NodeId>>,
+    A: Adversary<Subset<NodeId, u8>>,
     F: Fn(BTreeMap<NodeId, Arc<NetworkInfo<NodeId>>>) -> A,
 {
     // This returns an error in all but the first test.


### PR DESCRIPTION
This change also fixes a subtle security issue: We were potentially reusing the same coins in some rare cases!

If we are in epoch 41 and are just about to e.g. finish voting on a change, and `max_future_epochs == 2`, an attacker might send contributions for epochs 42 and 43 in the current (old) `HoneyBadger` instance. This would trigger the other nodes to start corresponding `BinaryAgreement`s and potentially flip "HB epoch 42" and "43" coins in them.
Once epoch 41 actually concludes, everyone starts a new `HoneyBadger` instance in epoch 42, where the same coins will be flipped again, and the attacker now knows a few values in advance.

That's probably not critical at all, but it's now addressed: We include the `start_epoch` in the coin name.