### PR TITLE
Fix minimal NetworkDimension in tests, and Subset bug.

### DIFF
--- a/src/subset.rs
+++ b/src/subset.rs
@@ -247,7 +247,9 @@ impl<N: NodeIdT + Rand> Subset<N> {
             error!("Duplicate insert in broadcast_results: {:?}", inval)
         }
         let set_binary_agreement_input = |ba: &mut BinaryAgreement<N>| ba.handle_input(true);
-        Ok(step.join(self.process_binary_agreement(proposer_id, set_binary_agreement_input)?))
+        Ok(step
+            .join(self.process_binary_agreement(proposer_id, set_binary_agreement_input)?)
+            .with_output(self.try_binary_agreement_completion()))
     }
 
     /// Callback to be invoked on receipt of the decision value of the Binary Agreement
@@ -351,7 +353,8 @@ impl<N: NodeIdT + Rand> Subset<N> {
             .map(|(k, _)| k)
             .collect();
         debug!(
-            "Binary Agreement instances that delivered 1: {:?}",
+            "{:?} Binary Agreement instances that delivered 1: {:?}",
+            self.our_id(),
             delivered_1
         );
 

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -135,7 +135,7 @@ impl NetworkDimensionTree {
         NetworkDimensionTree {
             high: high.into(),
             current: high.into(),
-            low: 0,
+            low: min_size as u32,
         }
     }
 }

--- a/tests/net/proptest.rs
+++ b/tests/net/proptest.rs
@@ -135,7 +135,7 @@ impl NetworkDimensionTree {
         NetworkDimensionTree {
             high: high.into(),
             current: high.into(),
-            low: min_size as u32,
+            low: u32::from(min_size),
         }
     }
 }


### PR DESCRIPTION
The `NetworkDimension` should not go below `min_size`.

The `Subset` problem was that if we received the `BinaryAgreement` result _first_, then when receiving the `Broadcast` output, `process_binary_agreement` wouldn't call `try_binary_agreement_completion` anymore, and never output.