### PR TITLE
Fix SbvBroadcast observer issue.

### DIFF
--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -145,7 +145,7 @@ impl<N: NodeIdT> SbvBroadcast<N> {
     /// Multicasts and handles a message. Does nothing if we are only an observer.
     fn send(&mut self, msg: Message) -> Result<Step<N>> {
         if !self.netinfo.is_validator() {
-            return Ok(Step::default());
+            return self.try_output();
         }
         let step: Step<_> = Target::All.message(msg.clone()).into();
         let our_id = &self.our_id().clone();


### PR DESCRIPTION
Make sure observers also try to output when receiving a `BVal` message.

Also, make sure `ThresholdDecryption` doesn't fail for observers without
a key share.