### PR TITLE
Issue #286: make ThresholdDecryption consistent with ThresholdSign

### DIFF
--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -1,9 +1,9 @@
+use crypto::DecryptionShare;
 use rand::Rand;
 use rand_derive::Rand;
 use serde_derive::{Deserialize, Serialize};
 
 use subset;
-use threshold_decryption;
 
 /// The content of a `HoneyBadger` message. It should be further annotated with an epoch.
 #[derive(Clone, Debug, Deserialize, Rand, Serialize)]
@@ -13,7 +13,7 @@ pub enum MessageContent<N: Rand> {
     /// A decrypted share of the output of `proposer_id`.
     DecryptionShare {
         proposer_id: N,
-        share: threshold_decryption::Message,
+        share: DecryptionShare,
     },
 }
 

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -22,7 +22,7 @@ use rand::Rng;
 
 use hbbft::honey_badger::{self, Batch, HoneyBadger, MessageContent};
 use hbbft::transaction_queue::TransactionQueue;
-use hbbft::{threshold_decryption, NetworkInfo, Target, TargetedMessage};
+use hbbft::{NetworkInfo, Target, TargetedMessage};
 
 use network::{
     Adversary, MessageScheduler, MessageWithSender, NodeId, RandomAdversary, SilentAdversary,
@@ -108,7 +108,7 @@ impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
                             Target::All.message(
                                 MessageContent::DecryptionShare {
                                     proposer_id: NodeId(proposer_id),
-                                    share: threshold_decryption::Message(share.clone()),
+                                    share: share.clone(),
                                 }.with_epoch(*epoch),
                             ),
                         ))


### PR DESCRIPTION
Turns threshold_decryption messages into an enum that can pass `DecryptionShare`s or `Ciphertext`. This allows  `ThresholdDecryption` instances to be asynchronously populated through the common handle_message interface. `ThresholdDecryption`'s `handle_input` function can now simply be used to see if output is available for the instance.