### PR TITLE
Rename `ThresholdDecryption` to `ThresholdDecrypt`

### DIFF
--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -9,7 +9,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::{Change, ChangeState, DynamicHoneyBadger, JoinPlan, Result, Step, VoteCounter};
 use honey_badger::{HoneyBadger, SubsetHandlingStrategy};
-use threshold_decryption::EncryptionSchedule;
+use threshold_decrypt::EncryptionSchedule;
 use util::SubRng;
 use {Contribution, NetworkInfo, NodeIdT};
 

--- a/src/dynamic_honey_badger/change.rs
+++ b/src/dynamic_honey_badger/change.rs
@@ -1,6 +1,6 @@
 use crypto::PublicKey;
 use serde_derive::{Deserialize, Serialize};
-use threshold_decryption::EncryptionSchedule;
+use threshold_decrypt::EncryptionSchedule;
 
 #[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub enum NodeChange<N> {

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -19,7 +19,7 @@ use fault_log::{Fault, FaultKind, FaultLog};
 use honey_badger::{self, HoneyBadger, Message as HbMessage};
 
 use sync_key_gen::{Ack, AckOutcome, Part, PartOutcome, SyncKeyGen};
-use threshold_decryption::EncryptionSchedule;
+use threshold_decrypt::EncryptionSchedule;
 use util::{self, SubRng};
 use {Contribution, DistAlgorithm, NetworkInfo, NodeIdT, Target};
 

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -80,7 +80,7 @@ use rand::Rand;
 use serde_derive::{Deserialize, Serialize};
 
 use self::votes::{SignedVote, VoteCounter};
-use super::threshold_decryption::EncryptionSchedule;
+use super::threshold_decrypt::EncryptionSchedule;
 use honey_badger::Message as HbMessage;
 use sync_key_gen::{Ack, Part, SyncKeyGen};
 use {Epoched, NodeIdT};

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -22,7 +22,7 @@ pub enum FaultKind {
     InvalidCiphertext,
     /// `HoneyBadger` received a message with an invalid epoch.
     UnexpectedHbMessageEpoch,
-    /// `ThresholdDecryption` received multiple shares from the same sender.
+    /// `ThresholdDecrypt` received multiple shares from the same sender.
     MultipleDecryptionShares,
     /// `Broadcast` received a `Value` from a node other than the proposer.
     ReceivedValueFromNonProposer,

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -7,7 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::HoneyBadger;
 use honey_badger::SubsetHandlingStrategy;
-use threshold_decryption::EncryptionSchedule;
+use threshold_decrypt::EncryptionSchedule;
 use util::SubRng;
 use {Contribution, NetworkInfo, NodeIdT};
 

--- a/src/honey_badger/error.rs
+++ b/src/honey_badger/error.rs
@@ -4,7 +4,7 @@ use bincode;
 use failure::{Backtrace, Context, Fail};
 
 use subset;
-use threshold_decryption;
+use threshold_decrypt;
 
 /// Honey badger error variants.
 #[derive(Debug, Fail)]
@@ -18,7 +18,7 @@ pub enum ErrorKind {
     #[fail(display = "Failed to handle Subset message: {}", _0)]
     HandleSubsetMessage(subset::Error),
     #[fail(display = "Threshold decryption error: {}", _0)]
-    ThresholdDecryption(threshold_decryption::Error),
+    ThresholdDecrypt(threshold_decrypt::Error),
     #[fail(display = "Unknown sender")]
     UnknownSender,
 }

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -11,7 +11,7 @@ use super::{Batch, Error, ErrorKind, HoneyBadgerBuilder, Message, Result};
 use {util, Contribution, DistAlgorithm, Epoched, Fault, FaultKind, NetworkInfo, NodeIdT};
 
 pub use super::epoch_state::SubsetHandlingStrategy;
-use threshold_decryption::EncryptionSchedule;
+use threshold_decrypt::EncryptionSchedule;
 
 /// An instance of the Honey Badger Byzantine fault tolerant consensus algorithm.
 #[derive(Derivative)]

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -3,7 +3,7 @@ use rand_derive::Rand;
 use serde_derive::{Deserialize, Serialize};
 
 use subset;
-use threshold_decryption;
+use threshold_decrypt;
 
 use Epoched;
 
@@ -15,7 +15,7 @@ pub enum MessageContent<N: Rand> {
     /// A decrypted share of the output of `proposer_id`.
     DecryptionShare {
         proposer_id: N,
-        share: threshold_decryption::Message,
+        share: threshold_decrypt::Message,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //! receive a valid signature. The outcome cannot be known by the adversary before at least one
 //! correct node has provided input, and can be used as a source of pseudorandomness.
 //!
-//! [**Threshold Decryption**](threshold_decryption/index.html)
+//! [**Threshold Decrypt**](threshold_decrypt/index.html)
 //!
 //! Each node inputs the same ciphertext, encrypted to the public master key. Once _f + 1_
 //! validators have received input, all nodes output the decrypted data.
@@ -144,7 +144,7 @@ pub mod queueing_honey_badger;
 pub mod sender_queue;
 pub mod subset;
 pub mod sync_key_gen;
-pub mod threshold_decryption;
+pub mod threshold_decrypt;
 pub mod threshold_sign;
 pub mod transaction_queue;
 pub mod util;

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -65,10 +65,10 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
 pub struct Message(pub DecryptionShare);
 
-/// A Threshold Decryption algorithm instance. If every node inputs the same data, encrypted to the
+/// A Threshold Decrypt algorithm instance. If every node inputs the same data, encrypted to the
 /// network's public key, every node will output the decrypted data.
 #[derive(Debug)]
-pub struct ThresholdDecryption<N> {
+pub struct ThresholdDecrypt<N> {
     netinfo: Arc<NetworkInfo<N>>,
     /// The encrypted data.
     ciphertext: Option<Ciphertext>,
@@ -80,9 +80,9 @@ pub struct ThresholdDecryption<N> {
     terminated: bool,
 }
 
-pub type Step<N> = ::Step<ThresholdDecryption<N>>;
+pub type Step<N> = ::Step<ThresholdDecrypt<N>>;
 
-impl<N: NodeIdT> DistAlgorithm for ThresholdDecryption<N> {
+impl<N: NodeIdT> DistAlgorithm for ThresholdDecrypt<N> {
     type NodeId = N;
     type Input = ();
     type Output = Vec<u8>;
@@ -106,10 +106,10 @@ impl<N: NodeIdT> DistAlgorithm for ThresholdDecryption<N> {
     }
 }
 
-impl<N: NodeIdT> ThresholdDecryption<N> {
-    /// Creates a new Threshold Decryption instance.
+impl<N: NodeIdT> ThresholdDecrypt<N> {
+    /// Creates a new Threshold Decrypt instance.
     pub fn new(netinfo: Arc<NetworkInfo<N>>) -> Self {
-        ThresholdDecryption {
+        ThresholdDecrypt {
             netinfo,
             ciphertext: None,
             shares: BTreeMap::new(),
@@ -118,10 +118,10 @@ impl<N: NodeIdT> ThresholdDecryption<N> {
         }
     }
 
-    /// Creates a new instance of `ThresholdDecryption`, including setting the ciphertext to
+    /// Creates a new instance of `ThresholdDecrypt`, including setting the ciphertext to
     /// decrypt.
     pub fn new_with_ciphertext(netinfo: Arc<NetworkInfo<N>>, ct: Ciphertext) -> Result<Self> {
-        let mut td = ThresholdDecryption::new(netinfo);
+        let mut td = ThresholdDecrypt::new(netinfo);
         td.set_ciphertext(ct)?;
         Ok(td)
     }

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -24,7 +24,7 @@ use rand::Rng;
 use hbbft::honey_badger::{Batch, HoneyBadger, MessageContent};
 use hbbft::sender_queue::{self, SenderQueue, Step};
 use hbbft::transaction_queue::TransactionQueue;
-use hbbft::{threshold_decryption, DistAlgorithm, Epoched, NetworkInfo, Target, TargetedMessage};
+use hbbft::{threshold_decrypt, DistAlgorithm, Epoched, NetworkInfo, Target, TargetedMessage};
 
 use network::{
     Adversary, MessageScheduler, MessageWithSender, NodeId, RandomAdversary, SilentAdversary,
@@ -110,7 +110,7 @@ impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
                             Target::All.message(sender_queue::Message::Algo(
                                 MessageContent::DecryptionShare {
                                     proposer_id: NodeId(proposer_id),
-                                    share: threshold_decryption::Message(share.clone()),
+                                    share: threshold_decrypt::Message(share.clone()),
                                 }.with_epoch(*epoch),
                             )),
                         ))


### PR DESCRIPTION
This is a very simple rename.

Closes #326.