### PR TITLE
Make the incoming message queue finite in Binary Agreement

### DIFF
--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -107,8 +107,7 @@ impl ReceivedMessages {
         None
     }
 
-    /// Creates message content from `ReceivedMessages`. That message content, together with a
-    /// target node ID, forms messages that can be sent to the target node.
+    /// Creates message content from `ReceivedMessages`. That message content can then be handled.
     fn messages(self) -> Vec<MessageContent> {
         let ReceivedMessages {
             bval,

--- a/src/binary_agreement/mod.rs
+++ b/src/binary_agreement/mod.rs
@@ -119,7 +119,7 @@ pub enum MessageContent {
 
 impl MessageContent {
     /// Creates an message with a given epoch number.
-    pub fn with_epoch(self, epoch: u32) -> Message {
+    pub fn with_epoch(self, epoch: u64) -> Message {
         Message {
             epoch,
             content: self,
@@ -138,7 +138,7 @@ impl MessageContent {
 /// Messages sent during the Binary Agreement stage.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
 pub struct Message {
-    pub epoch: u32,
+    pub epoch: u64,
     pub content: MessageContent,
 }
 

--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -22,7 +22,7 @@ use {NetworkInfo, NodeIdT, Target};
 
 pub type Step<N> = ::Step<Message, BoolSet, N>;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Message {
     BVal(bool),
     Aux(bool),

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -69,6 +69,12 @@ pub enum FaultKind {
     DuplicateBVal,
     /// `BinaryAgreement` received a duplicate `Aux` message.
     DuplicateAux,
+    /// `BinaryAgreement` received multiple `Conf` messages.
+    MultipleConf,
+    /// `BinaryAgreement` received multiple `Term` messages.
+    MultipleTerm,
+    /// `BinaryAgreement` received a message with an epoch too far ahead.
+    AgreementEpoch,
 }
 
 /// A structure representing the context of a faulty node. This structure

--- a/tests/binary_agreement_mitm.rs
+++ b/tests/binary_agreement_mitm.rs
@@ -232,7 +232,7 @@ struct AbaCommonCoinAdversary {
     stage: usize,
     stage_progress: usize,
     sent_stage_messages: bool,
-    epoch: u32,
+    epoch: u64,
     coin_state: CoinState<NodeId>,
     /// The estimated value for nodes in A.
     a_estimated: bool,
@@ -250,7 +250,7 @@ impl AbaCommonCoinAdversary {
 
     fn new_with_epoch(
         netinfo_mutex: Arc<Mutex<Option<Arc<NetworkInfo<NodeId>>>>>,
-        epoch: u32,
+        epoch: u64,
         a_estimated: bool,
     ) -> Self {
         AbaCommonCoinAdversary {


### PR DESCRIPTION
Closes #43 

This is the second and last part of #43. In includes

- limitation on the number of future Binary Agreement epochs for which we accept and queue messages from remote nodes;

- finite representation of incoming messages in a future epoch.