### PR TITLE
Allow arbitrary validator set changes in DHB.

### DIFF
--- a/src/dynamic_honey_badger/batch.rs
+++ b/src/dynamic_honey_badger/batch.rs
@@ -9,7 +9,7 @@ use {NetworkInfo, NodeIdT};
 
 /// A batch of transactions the algorithm has output.
 #[derive(Clone, Debug)]
-pub struct Batch<C, N> {
+pub struct Batch<C, N: Ord> {
     /// The sequence number: there is exactly one batch in each epoch.
     pub(super) epoch: u64,
     /// The current `DynamicHoneyBadger` era.

--- a/src/dynamic_honey_badger/change.rs
+++ b/src/dynamic_honey_badger/change.rs
@@ -1,49 +1,23 @@
+use std::collections::BTreeMap;
+
 use crypto::PublicKey;
 use serde_derive::{Deserialize, Serialize};
 
 use super::EncryptionSchedule;
 
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
-pub enum NodeChange<N> {
-    /// Add a node. The public key is used only temporarily, for key generation.
-    Add(N, PublicKey),
-    /// Remove a node.
-    Remove(N),
-}
-
-impl<N> NodeChange<N> {
-    /// Returns the ID of the current candidate for being added, if any.
-    pub fn candidate(&self) -> Option<&N> {
-        match *self {
-            NodeChange::Add(ref id, _) => Some(id),
-            NodeChange::Remove(_) => None,
-        }
-    }
-}
-
 /// A node change action: adding or removing a node.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
-pub enum Change<N> {
-    // Add or Remove a node from the set of validators
-    NodeChange(NodeChange<N>),
+pub enum Change<N: Ord> {
+    /// Add or remove node from the set of validators. Contains the full new set of validators.
+    NodeChange(BTreeMap<N, PublicKey>),
     /// Change the threshold encryption schedule.
     /// Increase frequency to prevent censorship or decrease frequency for increased throughput.
     EncryptionSchedule(EncryptionSchedule),
 }
 
-impl<N> Change<N> {
-    /// Returns the ID of the current candidate for being added, if any.
-    pub fn candidate(&self) -> Option<&N> {
-        match self {
-            Change::NodeChange(node_change) => node_change.candidate(),
-            _ => None,
-        }
-    }
-}
-
 /// A change status: whether a change to the network is currently in progress or completed.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
-pub enum ChangeState<N> {
+pub enum ChangeState<N: Ord> {
     /// No change is currently being considered.
     None,
     /// A change is currently in progress. If it is a node addition, all broadcast messages must be

--- a/src/dynamic_honey_badger/change.rs
+++ b/src/dynamic_honey_badger/change.rs
@@ -8,7 +8,9 @@ use super::EncryptionSchedule;
 /// A node change action: adding or removing a node.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub enum Change<N: Ord> {
-    /// Add or remove node from the set of validators. Contains the full new set of validators.
+    /// Change the set of validators to the one in the provided map. There are no restrictions on
+    /// the new set of validators. In particular, it can be disjoint with the current set of
+    /// validators.
     NodeChange(BTreeMap<N, PublicKey>),
     /// Change the threshold encryption schedule.
     /// Increase frequency to prevent censorship or decrease frequency for increased throughput.

--- a/src/sender_queue/dynamic_honey_badger.rs
+++ b/src/sender_queue/dynamic_honey_badger.rs
@@ -20,7 +20,7 @@ where
     C: Contribution,
     N: NodeIdT + Rand,
 {
-    fn new_nodes(&self) -> Vec<N> {
+    fn added_peers(&self) -> Vec<N> {
         if let ChangeState::InProgress(Change::NodeChange(pub_keys)) = self.change() {
             // Register the new node to send broadcast messages to it from now on.
             pub_keys.keys().cloned().collect()

--- a/src/sender_queue/dynamic_honey_badger.rs
+++ b/src/sender_queue/dynamic_honey_badger.rs
@@ -12,7 +12,7 @@ use super::{
 use {Contribution, DaStep, NodeIdT};
 
 use dynamic_honey_badger::{
-    Batch, Change, ChangeState, DynamicHoneyBadger, Error as DhbError, Message, NodeChange,
+    Batch, Change, ChangeState, DynamicHoneyBadger, Error as DhbError, Message,
 };
 
 impl<C, N> SenderQueueableOutput<N, Message<N>> for Batch<C, N>
@@ -20,21 +20,19 @@ where
     C: Contribution,
     N: NodeIdT + Rand,
 {
-    fn added_node(&self) -> Option<N> {
-        if let ChangeState::InProgress(Change::NodeChange(NodeChange::Add(ref id, _))) =
-            self.change()
-        {
+    fn new_nodes(&self) -> Vec<N> {
+        if let ChangeState::InProgress(Change::NodeChange(pub_keys)) = self.change() {
             // Register the new node to send broadcast messages to it from now on.
-            Some(id.clone())
+            pub_keys.keys().cloned().collect()
         } else {
-            None
+            Vec::new()
         }
     }
 }
 
 impl<N> SenderQueueableMessage for Message<N>
 where
-    N: Rand,
+    N: Rand + Ord,
 {
     type Epoch = (u64, u64);
 
@@ -114,7 +112,7 @@ where
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_to_remove(&mut self, node_id: N) -> Result<C, N> {
+    pub fn vote_to_remove(&mut self, node_id: &N) -> Result<C, N> {
         self.apply(|algo| algo.vote_to_remove(node_id))
     }
 }

--- a/src/sender_queue/honey_badger.rs
+++ b/src/sender_queue/honey_badger.rs
@@ -10,8 +10,8 @@ where
     C: Contribution,
     N: NodeIdT + Rand,
 {
-    fn added_node(&self) -> Option<N> {
-        None
+    fn new_nodes(&self) -> Vec<N> {
+        Vec::new()
     }
 }
 

--- a/src/sender_queue/honey_badger.rs
+++ b/src/sender_queue/honey_badger.rs
@@ -10,7 +10,7 @@ where
     C: Contribution,
     N: NodeIdT + Rand,
 {
-    fn new_nodes(&self) -> Vec<N> {
+    fn added_peers(&self) -> Vec<N> {
         Vec::new()
     }
 }

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -41,9 +41,9 @@ pub trait SenderQueueableOutput<N, M>
 where
     N: NodeIdT,
 {
-    /// Returns the new set of validator that this batch is starting key generation for, including
-    /// the existing ones. These should be added to the set of all nodes.
-    fn new_nodes(&self) -> Vec<N>;
+    /// Returns the new set of validator that this batch is starting or completing key generation
+    /// for, including the existing ones. These should be added to the set of all nodes.
+    fn added_peers(&self) -> Vec<N>;
 }
 
 pub trait SenderQueueableDistAlgorithm: Epoched + DistAlgorithm {
@@ -206,7 +206,7 @@ where
             return Step::<D>::default();
         }
         // Look up `DynamicHoneyBadger` epoch updates and collect any added peers.
-        for node in step.output.iter().flat_map(|batch| batch.new_nodes()) {
+        for node in step.output.iter().flat_map(|batch| batch.added_peers()) {
             if &node != self.our_id() {
                 self.peer_epochs.entry(node).or_default();
             }

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -41,9 +41,9 @@ pub trait SenderQueueableOutput<N, M>
 where
     N: NodeIdT,
 {
-    /// Returns an optional new node added with the batch. This node should be added to the set of
-    /// all nodes.
-    fn added_node(&self) -> Option<N>;
+    /// Returns the new set of validator that this batch is starting key generation for, including
+    /// the existing ones. These should be added to the set of all nodes.
+    fn new_nodes(&self) -> Vec<N>;
 }
 
 pub trait SenderQueueableDistAlgorithm: Epoched + DistAlgorithm {
@@ -206,7 +206,7 @@ where
             return Step::<D>::default();
         }
         // Look up `DynamicHoneyBadger` epoch updates and collect any added peers.
-        for node in step.output.iter().filter_map(|batch| batch.added_node()) {
+        for node in step.output.iter().flat_map(|batch| batch.new_nodes()) {
             if &node != self.our_id() {
                 self.peer_epochs.entry(node).or_default();
             }

--- a/src/sender_queue/queueing_honey_badger.rs
+++ b/src/sender_queue/queueing_honey_badger.rs
@@ -75,7 +75,7 @@ where
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_to_remove(&mut self, node_id: N) -> Result<T, N, Q> {
+    pub fn vote_to_remove(&mut self, node_id: &N) -> Result<T, N, Q> {
         self.apply(|algo| algo.vote_to_remove(node_id))
     }
 }

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -351,6 +351,11 @@ impl<N: NodeIdT> SyncKeyGen<N> {
         Ok((key_gen, Some(Part(commit, rows))))
     }
 
+    /// Returns the map of participating nodes and their public keys.
+    pub fn public_keys(&self) -> &BTreeMap<N, PublicKey> {
+        &self.pub_keys
+    }
+
     /// Handles a `Part` message. If it is valid, returns an `Ack` message to be broadcast.
     ///
     /// If we are only an observer, `None` is returned instead and no messages need to be sent.

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -105,24 +105,20 @@ impl MessageScheduler {
         &self,
         nodes: &BTreeMap<D::NodeId, TestNode<D>>,
     ) -> D::NodeId {
-        match *self {
-            MessageScheduler::First => nodes
-                .iter()
-                .find(|(_, node)| !node.queue.is_empty())
-                .map(|(id, _)| id.clone())
-                .expect("no more messages in queue"),
-            MessageScheduler::Random => {
-                let ids: Vec<D::NodeId> = nodes
-                    .iter()
-                    .filter(|(_, node)| !node.queue.is_empty())
-                    .map(|(id, _)| id.clone())
-                    .collect();
-                rand::thread_rng()
-                    .choose(&ids)
-                    .expect("no more messages in queue")
-                    .clone()
-            }
-        }
+        let mut ids = nodes
+            .iter()
+            .filter(|(_, node)| !node.queue.is_empty())
+            .map(|(id, _)| id.clone());
+        let rand_node = match *self {
+            MessageScheduler::First => rand::thread_rng().gen_weighted_bool(10),
+            MessageScheduler::Random => true,
+        };
+        if rand_node {
+            let ids: Vec<D::NodeId> = ids.collect();
+            rand::thread_rng().choose(&ids).cloned()
+        } else {
+            ids.next()
+        }.expect("no more messages in queue")
     }
 }
 


### PR DESCRIPTION
This replaces `NodeChange` with a full list of IDs and public keys, instead of just a single to-be-added or to-be-removed node, to allow completely replacing the set of validators by any arbitrary new set in a single key generation step.

Closes #330.