### PR TITLE
Add a `Params` struct with HB parameters.

### DIFF
--- a/src/honey_badger/mod.rs
+++ b/src/honey_badger/mod.rs
@@ -28,9 +28,12 @@ mod epoch_state;
 mod error;
 mod honey_badger;
 mod message;
+mod params;
 
 pub use self::batch::Batch;
 pub use self::builder::HoneyBadgerBuilder;
+pub use self::epoch_state::SubsetHandlingStrategy;
 pub use self::error::{Error, ErrorKind, Result};
-pub use self::honey_badger::{EncryptionSchedule, HoneyBadger, Step, SubsetHandlingStrategy};
+pub use self::honey_badger::{EncryptionSchedule, HoneyBadger, Step};
 pub use self::message::{Message, MessageContent};
+pub use self::params::Params;

--- a/src/honey_badger/params.rs
+++ b/src/honey_badger/params.rs
@@ -1,0 +1,25 @@
+use super::{EncryptionSchedule, SubsetHandlingStrategy};
+
+/// Parameters controlling Honey Badger's behavior and performance.
+#[derive(Debug, Clone)]
+pub struct Params {
+    /// The maximum number of future epochs for which we handle messages simultaneously.
+    pub max_future_epochs: u64,
+    /// Strategy used to handle the output of the `Subset` algorithm.
+    pub subset_handling_strategy: SubsetHandlingStrategy,
+    /// Whether to generate a pseudorandom value in each epoch.
+    pub random_value: bool,
+    /// Schedule for adding threshold encryption to some percentage of rounds
+    pub encryption_schedule: EncryptionSchedule,
+}
+
+impl Default for Params {
+    fn default() -> Params {
+        Params {
+            max_future_epochs: 3,
+            subset_handling_strategy: SubsetHandlingStrategy::Incremental,
+            random_value: false,
+            encryption_schedule: EncryptionSchedule::Always,
+        }
+    }
+}


### PR DESCRIPTION
This removes some duplication between DHB, HB and their builders.

See #333.