### PR TITLE
OsRng / external RNG Refactoring

### DIFF
--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -108,6 +108,8 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
         let tx_from_algo = messaging.tx_from_algo();
         let stop_tx = messaging.stop_tx();
 
+        let mut rng = rand::OsRng::new().unwrap();
+
         // All spawned threads will have exited by the end of the scope.
         crossbeam::scope(|scope| {
             // Start the centralised message delivery system.
@@ -124,7 +126,7 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                 if let Some(v) = value {
                     // FIXME: Use the output.
                     let step = broadcast
-                        .handle_input(v.clone().into(), &mut rand::thread_rng())
+                        .handle_input(v.clone().into(), &mut rng)
                         .expect("propose value");
                     for msg in step.messages {
                         tx_from_algo.send(msg).expect("send from algo");

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -124,7 +124,7 @@ impl<T: Clone + Debug + AsRef<[u8]> + PartialEq + Send + Sync + From<Vec<u8>> + 
                 if let Some(v) = value {
                     // FIXME: Use the output.
                     let step = broadcast
-                        .handle_input(v.clone().into())
+                        .handle_input(v.clone().into(), &mut rand::thread_rng())
                         .expect("propose value");
                     for msg in step.messages {
                         tx_from_algo.send(msg).expect("send from algo");

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -5,7 +5,7 @@ use std::{cmp, u64};
 use colored::*;
 use docopt::Docopt;
 use itertools::Itertools;
-use rand::{Isaac64Rng, Rng};
+use rand::Rng;
 use rand_derive::Rand;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -177,7 +177,7 @@ where
         let msg = bincode::deserialize::<D::Message>(&ts_msg.message).expect("deserialize");
         let step = self
             .algo
-            .handle_message(&ts_msg.sender_id, msg)
+            .handle_message(&ts_msg.sender_id, msg, &mut rand::thread_rng())
             .expect("handling message");
         self.time += start.elapsed() * self.hw_quality.cpu_factor / 100;
         self.send_output_and_msgs(step)
@@ -436,7 +436,7 @@ fn main() {
         let dhb = DynamicHoneyBadger::builder().build(netinfo);
         let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
             .batch_size(args.flag_b)
-            .build_with_transactions(txs.clone(), rand::thread_rng().gen::<Isaac64Rng>())
+            .build_with_transactions(txs.clone(), &mut rand::thread_rng())
             .expect("instantiate QueueingHoneyBadger");
         let (sq, mut step) = SenderQueue::builder(qhb, peer_ids.into_iter()).build(our_id);
         step.extend_with(qhb_step, Message::from);

--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -178,16 +178,16 @@ impl<N: NodeIdT, S: SessionIdT> DistAlgorithm for BinaryAgreement<N, S> {
     type Message = Message;
     type Error = Error;
 
-    fn handle_input<R: Rng>(&mut self, _rng: &mut R, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, input: Self::Input, _rng: &mut R) -> Result<Step<N>> {
         self.propose(input)
     }
 
     /// Receive input from a remote node.
     fn handle_message<R: Rng>(
         &mut self,
-        _rng: &mut R,
         sender_id: &Self::NodeId,
         message: Message,
+        _rng: &mut R,
     ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }

--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -5,6 +5,7 @@ use std::{fmt, result};
 use crate::crypto::SignatureShare;
 use bincode;
 use log::debug;
+use rand::Rng;
 
 use super::bool_multimap::BoolMultimap;
 use super::bool_set::{self, BoolSet};
@@ -177,13 +178,18 @@ impl<N: NodeIdT, S: SessionIdT> DistAlgorithm for BinaryAgreement<N, S> {
     type Message = Message;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _rng: &mut R, input: Self::Input) -> Result<Step<N>> {
         self.propose(input)
     }
 
     /// Receive input from a remote node.
-    fn handle_message(&mut self, sender_id: &Self::NodeId, msg: Message) -> Result<Step<N>> {
-        self.handle_message(sender_id, msg)
+    fn handle_message<R: Rng>(
+        &mut self,
+        _rng: &mut R,
+        sender_id: &Self::NodeId,
+        message: Message,
+    ) -> Result<Step<N>> {
+        self.handle_message(sender_id, message)
     }
 
     /// Whether the algorithm has terminated.

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -5,6 +5,7 @@ use std::{fmt, result};
 use byteorder::{BigEndian, ByteOrder};
 use hex_fmt::{HexFmt, HexList};
 use log::{debug, warn};
+use rand::Rng;
 use reed_solomon_erasure as rse;
 use reed_solomon_erasure::ReedSolomon;
 
@@ -47,11 +48,16 @@ impl<N: NodeIdT> DistAlgorithm for Broadcast<N> {
     type Message = Message;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _rng: &mut R, input: Self::Input) -> Result<Step<N>> {
         self.broadcast(input)
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<N>> {
+    fn handle_message<R: Rng>(
+        &mut self,
+        _rng: &mut R,
+        sender_id: &Self::NodeId,
+        message: Message,
+    ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }
 

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -48,15 +48,15 @@ impl<N: NodeIdT> DistAlgorithm for Broadcast<N> {
     type Message = Message;
     type Error = Error;
 
-    fn handle_input<R: Rng>(&mut self, _rng: &mut R, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, input: Self::Input, _rng: &mut R) -> Result<Step<N>> {
         self.broadcast(input)
     }
 
     fn handle_message<R: Rng>(
         &mut self,
-        _rng: &mut R,
         sender_id: &Self::NodeId,
         message: Message,
+        _rng: &mut R,
     ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -102,7 +102,7 @@
 //!     const NUM_NODES: u64 = 7;
 //!     const PROPOSER_ID: u64 = 3;
 //!
-//!     let mut rng = OsRng::new();
+//!     let mut rng = OsRng::new().expect("Could not initialize OS random number generator.");
 //!
 //!     // Create a random set of keys for testing.
 //!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES, &mut rng)

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -92,7 +92,7 @@
 //! ```
 //! use hbbft::broadcast::{Broadcast, Error, Step};
 //! use hbbft::{NetworkInfo, SourcedMessage, Target, TargetedMessage};
-//! use rand::{thread_rng, Rng};
+//! use rand::{OsRng, Rng};
 //! use std::collections::{BTreeMap, BTreeSet, VecDeque};
 //! use std::iter::once;
 //! use std::sync::Arc;
@@ -102,7 +102,7 @@
 //!     const NUM_NODES: u64 = 7;
 //!     const PROPOSER_ID: u64 = 3;
 //!
-//!     let mut rng = thread_rng();
+//!     let mut rng = OsRng::new();
 //!
 //!     // Create a random set of keys for testing.
 //!     let netinfos = NetworkInfo::generate_map(0..NUM_NODES, &mut rng)

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -32,7 +32,7 @@ where
     fn default() -> Self {
         DynamicHoneyBadgerBuilder {
             era: 0,
-            rng: Box::new(rand::thread_rng()),
+            rng: Box::new(rand::OsRng::new()),
             params: Params::default(),
             _phantom: PhantomData,
         }

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -106,8 +106,8 @@ where
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
     pub fn build_first_node<R: rand::Rng>(
         &mut self,
-        rng: &mut R,
         our_id: N,
+        rng: &mut R,
     ) -> Result<DynamicHoneyBadger<C, N>> {
         let sk_set = SecretKeySet::random(0, rng);
         let pk_set = sk_set.public_keys();
@@ -125,11 +125,11 @@ where
     #[deprecated]
     pub fn build_joining<R: rand::Rng>(
         &mut self,
-        rng: &mut R,
         our_id: N,
         secret_key: SecretKey,
         join_plan: JoinPlan<N>,
+        rng: &mut R,
     ) -> Result<(DynamicHoneyBadger<C, N>, Step<C, N>)> {
-        DynamicHoneyBadger::new_joining(rng, our_id, secret_key, join_plan)
+        DynamicHoneyBadger::new_joining(our_id, secret_key, join_plan, rng)
     }
 }

--- a/src/dynamic_honey_badger/builder.rs
+++ b/src/dynamic_honey_badger/builder.rs
@@ -4,12 +4,11 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::crypto::{SecretKey, SecretKeySet};
-use rand::{self, Rand, Rng};
+use rand::Rand;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{DynamicHoneyBadger, EncryptionSchedule, JoinPlan, Result, Step, VoteCounter};
 use crate::honey_badger::{HoneyBadger, Params, SubsetHandlingStrategy};
-use crate::util::SubRng;
 use crate::{Contribution, NetworkInfo, NodeIdT};
 
 /// A Dynamic Honey Badger builder, to configure the parameters and create new instances of
@@ -17,9 +16,6 @@ use crate::{Contribution, NetworkInfo, NodeIdT};
 pub struct DynamicHoneyBadgerBuilder<C, N> {
     /// Start in this era.
     era: u64,
-    /// Random number generator passed on to algorithm instance for key generation. Also used to
-    /// instantiate `HoneyBadger`.
-    rng: Box<dyn rand::Rng>,
     /// Parameters controlling Honey Badger's behavior and performance.
     params: Params,
     _phantom: PhantomData<(C, N)>,
@@ -32,7 +28,6 @@ where
     fn default() -> Self {
         DynamicHoneyBadgerBuilder {
             era: 0,
-            rng: Box::new(rand::OsRng::new()),
             params: Params::default(),
             _phantom: PhantomData,
         }
@@ -62,12 +57,6 @@ where
         self
     }
 
-    /// Sets the random number generator to be used to instantiate cryptographic structures.
-    pub fn rng<R: rand::Rng + 'static>(&mut self, rng: R) -> &mut Self {
-        self.rng = Box::new(rng);
-        self
-    }
-
     /// Sets the strategy to use when handling `Subset` output.
     pub fn subset_handling_strategy(
         &mut self,
@@ -93,16 +82,16 @@ where
     pub fn build(&mut self, netinfo: NetworkInfo<N>) -> DynamicHoneyBadger<C, N> {
         let DynamicHoneyBadgerBuilder {
             era,
-            rng,
             params,
             _phantom,
         } = self;
         let arc_netinfo = Arc::new(netinfo.clone());
+
         let honey_badger = HoneyBadger::builder(arc_netinfo.clone())
             .session_id(*era)
             .params(params.clone())
-            .rng(rng.sub_rng())
             .build();
+
         DynamicHoneyBadger {
             netinfo,
             max_future_epochs: params.max_future_epochs,
@@ -111,16 +100,19 @@ where
             key_gen_msg_buffer: Vec::new(),
             honey_badger,
             key_gen_state: None,
-            rng: Box::new(rng.sub_rng()),
         }
     }
 
     /// Creates a new `DynamicHoneyBadger` configured to start a new network as a single validator.
-    pub fn build_first_node(&mut self, our_id: N) -> Result<DynamicHoneyBadger<C, N>> {
-        let sk_set = SecretKeySet::random(0, &mut self.rng);
+    pub fn build_first_node<R: rand::Rng>(
+        &mut self,
+        rng: &mut R,
+        our_id: N,
+    ) -> Result<DynamicHoneyBadger<C, N>> {
+        let sk_set = SecretKeySet::random(0, rng);
         let pk_set = sk_set.public_keys();
         let sks = sk_set.secret_key_share(0);
-        let sk: SecretKey = self.rng.gen();
+        let sk: SecretKey = rng.gen();
         let pub_keys = once((our_id.clone(), sk.public_key())).collect();
         let netinfo = NetworkInfo::new(our_id, sks, pk_set, sk, pub_keys);
         Ok(self.build(netinfo))
@@ -131,12 +123,13 @@ where
     ///
     /// **Deprecated**: Please use `DynamicHoneyBadger::new_joining` instead.
     #[deprecated]
-    pub fn build_joining(
+    pub fn build_joining<R: rand::Rng>(
         &mut self,
+        rng: &mut R,
         our_id: N,
         secret_key: SecretKey,
         join_plan: JoinPlan<N>,
     ) -> Result<(DynamicHoneyBadger<C, N>, Step<C, N>)> {
-        DynamicHoneyBadger::new_joining(our_id, secret_key, join_plan, self.rng.sub_rng())
+        DynamicHoneyBadger::new_joining(rng, our_id, secret_key, join_plan)
     }
 }

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -19,7 +19,7 @@ use crate::fault_log::{Fault, FaultKind, FaultLog};
 use crate::honey_badger::{self, HoneyBadger, Message as HbMessage};
 
 use crate::sync_key_gen::{Ack, AckOutcome, Part, PartOutcome, SyncKeyGen};
-use crate::util::self;
+use crate::util;
 use crate::{Contribution, DistAlgorithm, Epoched, NetworkInfo, NodeIdT, Target};
 
 /// A Honey Badger instance that can handle adding and removing nodes.

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -147,16 +147,16 @@ where
             .filter(|kg_msg| kg_msg.era() == self.era)
             .cloned()
             .collect();
+
+        let contrib = InternalContrib {
+            contrib,
+            key_gen_messages,
+            votes: self.vote_counter.pending_votes().cloned().collect(),
+        };
+
         let step = self
             .honey_badger
-            .propose(
-                &InternalContrib {
-                    contrib,
-                    key_gen_messages,
-                    votes: self.vote_counter.pending_votes().cloned().collect(),
-                },
-                rng,
-            )
+            .propose(&contrib, rng)
             .map_err(Error::ProposeHoneyBadger)?;
         self.process_output(step, rng)
     }

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -6,7 +6,7 @@ use crate::crypto::{PublicKey, SecretKey, Signature};
 use bincode;
 use derivative::Derivative;
 use log::debug;
-use rand::{self, Rand, Rng};
+use rand::{Rand, Rng};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::votes::{SignedVote, VoteCounter};
@@ -53,21 +53,22 @@ where
     type Message = Message<N>;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<C, N>> {
+    fn handle_input<R: Rng>(&mut self, rng: &mut R, input: Self::Input) -> Result<Step<C, N>> {
         // User contributions are forwarded to `HoneyBadger` right away. Votes are signed and
         // broadcast.
-        let mut rng: ::rand::OsRng = unimplemented!();
         match input {
-            // FIXME: Make trait support passing in RNGs.
-            Input::User(contrib) => self.propose(&mut rng, contrib),
+            Input::User(contrib) => self.propose(rng, contrib),
             Input::Change(change) => self.vote_for(change),
         }
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<C, N>> {
-        // FIXME: Obtain proper RNG.
-        let mut rng: rand::OsRng = unimplemented!();
-        self.handle_message(&mut rng, sender_id, message)
+    fn handle_message<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        sender_id: &Self::NodeId,
+        msg: Self::Message,
+    ) -> Result<Step<C, N>> {
+        self.handle_message(rng, sender_id, msg)
     }
 
     fn terminated(&self) -> bool {

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -201,7 +201,7 @@ mod tests {
     /// the vote by node `i` for making `j` the only validator. Each node signed this for nodes
     /// `0`, `1`, ... in order.
     fn setup(node_num: usize, era: u64) -> (Vec<VoteCounter<usize>>, Vec<Vec<SignedVote<usize>>>) {
-        let mut rng = rand::OsRng::new();
+        let mut rng = rand::OsRng::new().expect("could not initialize OsRng");
         // Create keys for threshold cryptography.
         let netinfos = NetworkInfo::generate_map(0..node_num, &mut rng)
             .expect("Failed to generate `NetworkInfo` map");

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -201,7 +201,7 @@ mod tests {
     /// the vote by node `i` for making `j` the only validator. Each node signed this for nodes
     /// `0`, `1`, ... in order.
     fn setup(node_num: usize, era: u64) -> (Vec<VoteCounter<usize>>, Vec<Vec<SignedVote<usize>>>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::OsRng::new();
         // Create keys for threshold cryptography.
         let netinfos = NetworkInfo::generate_map(0..node_num, &mut rng)
             .expect("Failed to generate `NetworkInfo` map");

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -37,7 +37,7 @@ where
             netinfo,
             session_id: 0,
             epoch: 0,
-            rng: Box::new(rand::thread_rng()),
+            rng: Box::new(rand::OsRng::new()),
             params: Params::default(),
             _phantom: PhantomData,
         }

--- a/src/honey_badger/builder.rs
+++ b/src/honey_badger/builder.rs
@@ -2,11 +2,10 @@ use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use rand::{self, Rand, Rng};
+use rand::Rand;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{EncryptionSchedule, HoneyBadger, Params, SubsetHandlingStrategy};
-use crate::util::SubRng;
 use crate::{Contribution, NetworkInfo, NodeIdT};
 
 /// A Honey Badger builder, to configure the parameters and create new instances of `HoneyBadger`.
@@ -18,8 +17,6 @@ pub struct HoneyBadgerBuilder<C, N> {
     session_id: u64,
     /// Start in this epoch.
     epoch: u64,
-    /// Random number generator passed on to algorithm instance for signing and encrypting.
-    rng: Box<dyn Rng>,
     /// Parameters controlling Honey Badger's behavior and performance.
     params: Params,
     _phantom: PhantomData<C>,
@@ -37,16 +34,9 @@ where
             netinfo,
             session_id: 0,
             epoch: 0,
-            rng: Box::new(rand::OsRng::new()),
             params: Params::default(),
             _phantom: PhantomData,
         }
-    }
-
-    /// Sets the random number generator for the public key cryptography.
-    pub fn rng<R: Rng + 'static>(&mut self, rng: R) -> &mut Self {
-        self.rng = Box::new(rng);
-        self
     }
 
     /// Sets the session identifier.
@@ -100,7 +90,6 @@ where
             has_input: false,
             epochs: BTreeMap::new(),
             params: self.params.clone(),
-            rng: Box::new(self.rng.sub_rng()),
         }
     }
 }

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -17,7 +17,7 @@ use super::{Batch, Error, MessageContent, Result, Step};
 use crate::fault_log::{Fault, FaultKind, FaultLog};
 use crate::subset::{self as cs, Subset, SubsetOutput};
 use crate::threshold_decrypt::{self as td, ThresholdDecrypt};
-use crate::{Contribution, DistAlgorithm, NetworkInfo, NodeIdT};
+use crate::{Contribution, NetworkInfo, NodeIdT};
 
 type CsStep<N> = cs::Step<N>;
 
@@ -75,7 +75,7 @@ where
     /// Provides input to the Subset instance, unless it has already completed.
     fn handle_input(&mut self, proposal: Vec<u8>) -> Result<CsStep<N>> {
         match self {
-            SubsetState::Ongoing(ref mut cs) => cs.handle_input(proposal),
+            SubsetState::Ongoing(ref mut cs) => cs.propose(proposal),
             SubsetState::Complete(_) => return Ok(cs::Step::default()),
         }
         .map_err(Error::InputSubset)

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -46,15 +46,15 @@ where
     type Message = Message<N>;
     type Error = Error;
 
-    fn handle_input<R: Rng>(&mut self, rng: &mut R, input: Self::Input) -> Result<Step<C, N>> {
-        self.propose(rng, &input)
+    fn handle_input<R: Rng>(&mut self, input: Self::Input, rng: &mut R) -> Result<Step<C, N>> {
+        self.propose(&input, rng)
     }
 
     fn handle_message<R: Rng>(
         &mut self,
-        _rng: &mut R,
         sender_id: &Self::NodeId,
         message: Self::Message,
+        _rng: &mut R,
     ) -> Result<Step<C, N>> {
         self.handle_message(sender_id, message)
     }
@@ -85,7 +85,7 @@ where
     ///
     /// If we are the only validator, this will immediately output a batch, containing our
     /// proposal.
-    pub fn propose<R: Rng>(&mut self, rng: &mut R, proposal: &C) -> Result<Step<C, N>> {
+    pub fn propose<R: Rng>(&mut self, proposal: &C, rng: &mut R) -> Result<Step<C, N>> {
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
         }

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -46,13 +46,16 @@ where
     type Message = Message<N>;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<C, N>> {
-        // FIXME: Instantiate proper RNG.
-        let mut rng: rand::OsRng = unimplemented!();
-        self.propose(&mut rng, &input)
+    fn handle_input<R: Rng>(&mut self, rng: &mut R, input: Self::Input) -> Result<Step<C, N>> {
+        self.propose(rng, &input)
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<C, N>> {
+    fn handle_message<R: Rng>(
+        &mut self,
+        _rng: &mut R,
+        sender_id: &Self::NodeId,
+        message: Self::Message,
+    ) -> Result<Step<C, N>> {
         self.handle_message(sender_id, message)
     }
 

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -9,7 +9,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use super::epoch_state::EpochState;
 use super::{Batch, Error, HoneyBadgerBuilder, Message, Result};
-use crate::{util, Contribution, DistAlgorithm, Fault, FaultKind, NetworkInfo, NodeIdT};
+use crate::{Contribution, DistAlgorithm, Fault, FaultKind, NetworkInfo, NodeIdT};
 
 use super::Params;
 
@@ -30,10 +30,6 @@ pub struct HoneyBadger<C, N: Rand> {
     pub(super) epochs: BTreeMap<u64, EpochState<C, N>>,
     /// Parameters controlling Honey Badger's behavior and performance.
     pub(super) params: Params,
-    /// A random number generator used for secret key generation.
-    // Boxed to avoid overloading the algorithm's type with more generics.
-    #[derivative(Debug(format_with = "util::fmt_rng"))]
-    pub(super) rng: Box<dyn Rng + Send + Sync>,
 }
 
 /// A `HoneyBadger` step, possibly containing multiple outputs.
@@ -51,7 +47,9 @@ where
     type Error = Error;
 
     fn handle_input(&mut self, input: Self::Input) -> Result<Step<C, N>> {
-        self.propose(&input)
+        // FIXME: Instantiate proper RNG.
+        let mut rng: rand::OsRng = unimplemented!();
+        self.propose(&mut rng, &input)
     }
 
     fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<C, N>> {
@@ -84,7 +82,7 @@ where
     ///
     /// If we are the only validator, this will immediately output a batch, containing our
     /// proposal.
-    pub fn propose(&mut self, proposal: &C) -> Result<Step<C, N>> {
+    pub fn propose<R: Rng>(&mut self, rng: &mut R, proposal: &C) -> Result<Step<C, N>> {
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
         }
@@ -97,7 +95,6 @@ where
                     "We created the epoch_state in `self.epoch_state_mut(...)` just a moment ago.",
                 )
             };
-            let rng = &mut self.rng;
             epoch_state.propose(proposal, rng)?
         };
         Ok(step.join(self.try_output_batches()?))

--- a/src/queueing_honey_badger/mod.rs
+++ b/src/queueing_honey_badger/mod.rs
@@ -156,21 +156,23 @@ where
     type Message = Message<N>;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<T, N>> {
+    fn handle_input<R: Rng>(&mut self, rng: &mut R, input: Self::Input) -> Result<Step<T, N>> {
         // User transactions are forwarded to `HoneyBadger` right away. Internal messages are
         // in addition signed and broadcast.
 
-        // FIXME: Update trait to make this unnecessary.
-        let mut rng: rand::OsRng = unimplemented!();
         match input {
-            Input::User(tx) => self.push_transaction(&mut rng, tx),
-            Input::Change(change) => self.vote_for(&mut rng, change),
+            Input::User(tx) => self.push_transaction(rng, tx),
+            Input::Change(change) => self.vote_for(rng, change),
         }
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Self::Message) -> Result<Step<T, N>> {
-        let mut rng: rand::OsRng = unimplemented!();
-        self.handle_message(&mut rng, sender_id, message)
+    fn handle_message<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        sender_id: &N,
+        message: Self::Message,
+    ) -> Result<Step<T, N>> {
+        self.handle_message(rng, sender_id, message)
     }
 
     fn terminated(&self) -> bool {
@@ -296,7 +298,7 @@ where
             let proposal = self.queue.choose(rng, amount, self.batch_size);
             step.extend(
                 self.dyn_hb
-                    .handle_input(Input::User(proposal))
+                    .handle_input(rng, Input::User(proposal))
                     .map_err(Error::Propose)?,
             );
         }

--- a/src/sender_queue/dynamic_honey_badger.rs
+++ b/src/sender_queue/dynamic_honey_badger.rs
@@ -89,7 +89,7 @@ where
     /// If we are the only validator, this will immediately output a batch, containing our
     /// proposal.
     pub fn propose<R: Rng>(&mut self, rng: &mut R, contrib: C) -> Result<C, N> {
-        self.apply(|algo| algo.propose(rng, contrib))
+        self.apply(|algo| algo.propose(contrib, rng))
     }
 
     /// Casts a vote to change the set of validators or parameters.

--- a/src/sender_queue/dynamic_honey_badger.rs
+++ b/src/sender_queue/dynamic_honey_badger.rs
@@ -3,7 +3,7 @@
 use std::result;
 
 use crate::crypto::PublicKey;
-use rand::Rand;
+use rand::{Rand, Rng};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{
@@ -88,8 +88,8 @@ where
     ///
     /// If we are the only validator, this will immediately output a batch, containing our
     /// proposal.
-    pub fn propose(&mut self, contrib: C) -> Result<C, N> {
-        self.apply(|algo| algo.propose(contrib))
+    pub fn propose<R: Rng>(&mut self, rng: &mut R, contrib: C) -> Result<C, N> {
+        self.apply(|algo| algo.propose(rng, contrib))
     }
 
     /// Casts a vote to change the set of validators or parameters.

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -102,19 +102,19 @@ where
 
     fn handle_input<R: Rng>(
         &mut self,
-        rng: &mut R,
         input: Self::Input,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, D::Error> {
-        self.handle_input(rng, input)
+        self.handle_input(input, rng)
     }
 
     fn handle_message<R: Rng>(
         &mut self,
-        rng: &mut R,
         sender_id: &D::NodeId,
         message: Self::Message,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, D::Error> {
-        self.handle_message(rng, sender_id, message)
+        self.handle_message(sender_id, message, rng)
     }
 
     fn terminated(&self) -> bool {
@@ -145,10 +145,10 @@ where
     /// Handles an input. This will call the wrapped algorithm's `handle_input`.
     pub fn handle_input<R: Rng>(
         &mut self,
-        rng: &mut R,
         input: D::Input,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, D::Error> {
-        self.apply(|algo| algo.handle_input(rng, input))
+        self.apply(|algo| algo.handle_input(input, rng))
     }
 
     /// Handles a message received from `sender_id`.
@@ -156,13 +156,13 @@ where
     /// This must be called with every message we receive from another node.
     pub fn handle_message<R: Rng>(
         &mut self,
-        rng: &mut R,
         sender_id: &D::NodeId,
         message: Message<D::Message>,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, D::Error> {
         match message {
             Message::EpochStarted(epoch) => Ok(self.handle_epoch_started(sender_id, epoch)),
-            Message::Algo(msg) => self.handle_message_content(rng, sender_id, msg),
+            Message::Algo(msg) => self.handle_message_content(sender_id, msg, rng),
         }
     }
 
@@ -220,11 +220,11 @@ where
     /// Handles a Honey Badger algorithm message in a given epoch.
     fn handle_message_content<R: Rng>(
         &mut self,
-        rng: &mut R,
         sender_id: &D::NodeId,
         content: D::Message,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, D::Error> {
-        self.apply(|algo| algo.handle_message(rng, sender_id, content))
+        self.apply(|algo| algo.handle_message(sender_id, content, rng))
     }
 
     /// Updates the current Honey Badger epoch.

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -10,6 +10,7 @@ mod honey_badger;
 mod message;
 mod queueing_honey_badger;
 
+use rand::Rng;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
@@ -99,16 +100,21 @@ where
     type Message = Message<D::Message>;
     type Error = D::Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<DaStep<Self>, D::Error> {
-        self.handle_input(input)
+    fn handle_input<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        input: Self::Input,
+    ) -> Result<DaStep<Self>, D::Error> {
+        self.handle_input(rng, input)
     }
 
-    fn handle_message(
+    fn handle_message<R: Rng>(
         &mut self,
+        rng: &mut R,
         sender_id: &D::NodeId,
         message: Self::Message,
     ) -> Result<DaStep<Self>, D::Error> {
-        self.handle_message(sender_id, message)
+        self.handle_message(rng, sender_id, message)
     }
 
     fn terminated(&self) -> bool {
@@ -137,21 +143,26 @@ where
     }
 
     /// Handles an input. This will call the wrapped algorithm's `handle_input`.
-    pub fn handle_input(&mut self, input: D::Input) -> Result<DaStep<Self>, D::Error> {
-        self.apply(|algo| algo.handle_input(input))
+    pub fn handle_input<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        input: D::Input,
+    ) -> Result<DaStep<Self>, D::Error> {
+        self.apply(|algo| algo.handle_input(rng, input))
     }
 
     /// Handles a message received from `sender_id`.
     ///
     /// This must be called with every message we receive from another node.
-    pub fn handle_message(
+    pub fn handle_message<R: Rng>(
         &mut self,
+        rng: &mut R,
         sender_id: &D::NodeId,
         message: Message<D::Message>,
     ) -> Result<DaStep<Self>, D::Error> {
         match message {
             Message::EpochStarted(epoch) => Ok(self.handle_epoch_started(sender_id, epoch)),
-            Message::Algo(msg) => self.handle_message_content(sender_id, msg),
+            Message::Algo(msg) => self.handle_message_content(rng, sender_id, msg),
         }
     }
 
@@ -207,12 +218,13 @@ where
     }
 
     /// Handles a Honey Badger algorithm message in a given epoch.
-    fn handle_message_content(
+    fn handle_message_content<R: Rng>(
         &mut self,
+        rng: &mut R,
         sender_id: &D::NodeId,
         content: D::Message,
     ) -> Result<DaStep<Self>, D::Error> {
-        self.apply(|algo| algo.handle_message(sender_id, content))
+        self.apply(|algo| algo.handle_message(rng, sender_id, content))
     }
 
     /// Updates the current Honey Badger epoch.

--- a/src/sender_queue/queueing_honey_badger.rs
+++ b/src/sender_queue/queueing_honey_badger.rs
@@ -51,16 +51,16 @@ where
     /// If no proposal has yet been made for the current epoch, this may trigger one. In this case,
     /// a nonempty step will returned, with the corresponding messages. (Or, if we are the only
     /// validator, even with the completed batch as an output.)
-    pub fn push_transaction<R: Rng>(&mut self, rng: &mut R, tx: T) -> Result<T, N, Q> {
-        self.apply(|algo| algo.push_transaction(rng, tx))
+    pub fn push_transaction<R: Rng>(&mut self, tx: T, rng: &mut R) -> Result<T, N, Q> {
+        self.apply(|algo| algo.push_transaction(tx, rng))
     }
 
     /// Casts a vote to change the set of validators or parameters.
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_for<R: Rng>(&mut self, rng: &mut R, change: Change<N>) -> Result<T, N, Q> {
-        self.apply(|algo| algo.vote_for(rng, change))
+    pub fn vote_for<R: Rng>(&mut self, change: Change<N>, rng: &mut R) -> Result<T, N, Q> {
+        self.apply(|algo| algo.vote_for(change, rng))
     }
 
     /// Casts a vote to add a node as a validator.
@@ -69,18 +69,18 @@ where
     /// once enough validators have been voted for the same change, it will take effect.
     pub fn vote_to_add<R: Rng>(
         &mut self,
-        rng: &mut R,
         node_id: N,
         pub_key: PublicKey,
+        rng: &mut R,
     ) -> Result<T, N, Q> {
-        self.apply(|algo| algo.vote_to_add(rng, node_id, pub_key))
+        self.apply(|algo| algo.vote_to_add(node_id, pub_key, rng))
     }
 
     /// Casts a vote to demote a validator to observer.
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_to_remove<R: Rng>(&mut self, rng: &mut R, node_id: &N) -> Result<T, N, Q> {
-        self.apply(|algo| algo.vote_to_remove(rng, node_id))
+    pub fn vote_to_remove<R: Rng>(&mut self, node_id: &N, rng: &mut R) -> Result<T, N, Q> {
+        self.apply(|algo| algo.vote_to_remove(node_id, rng))
     }
 }

--- a/src/sender_queue/queueing_honey_badger.rs
+++ b/src/sender_queue/queueing_honey_badger.rs
@@ -3,7 +3,7 @@
 use std::result;
 
 use crate::crypto::PublicKey;
-use rand::Rand;
+use rand::{Rand, Rng};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{SenderQueue, SenderQueueableDistAlgorithm};
@@ -51,31 +51,36 @@ where
     /// If no proposal has yet been made for the current epoch, this may trigger one. In this case,
     /// a nonempty step will returned, with the corresponding messages. (Or, if we are the only
     /// validator, even with the completed batch as an output.)
-    pub fn push_transaction(&mut self, tx: T) -> Result<T, N, Q> {
-        self.apply(|algo| algo.push_transaction(tx))
+    pub fn push_transaction<R: Rng>(&mut self, rng: &mut R, tx: T) -> Result<T, N, Q> {
+        self.apply(|algo| algo.push_transaction(rng, tx))
     }
 
     /// Casts a vote to change the set of validators or parameters.
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_for(&mut self, change: Change<N>) -> Result<T, N, Q> {
-        self.apply(|algo| algo.vote_for(change))
+    pub fn vote_for<R: Rng>(&mut self, rng: &mut R, change: Change<N>) -> Result<T, N, Q> {
+        self.apply(|algo| algo.vote_for(rng, change))
     }
 
     /// Casts a vote to add a node as a validator.
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_to_add(&mut self, node_id: N, pub_key: PublicKey) -> Result<T, N, Q> {
-        self.apply(|algo| algo.vote_to_add(node_id, pub_key))
+    pub fn vote_to_add<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        node_id: N,
+        pub_key: PublicKey,
+    ) -> Result<T, N, Q> {
+        self.apply(|algo| algo.vote_to_add(rng, node_id, pub_key))
     }
 
     /// Casts a vote to demote a validator to observer.
     ///
     /// This stores a pending vote for the change. It will be included in some future batch, and
     /// once enough validators have been voted for the same change, it will take effect.
-    pub fn vote_to_remove(&mut self, node_id: &N) -> Result<T, N, Q> {
-        self.apply(|algo| algo.vote_to_remove(node_id))
+    pub fn vote_to_remove<R: Rng>(&mut self, rng: &mut R, node_id: &N) -> Result<T, N, Q> {
+        self.apply(|algo| algo.vote_to_remove(rng, node_id))
     }
 }

--- a/src/subset/subset.rs
+++ b/src/subset/subset.rs
@@ -48,15 +48,15 @@ impl<N: NodeIdT + Rand, S: SessionIdT> DistAlgorithm for Subset<N, S> {
     type Message = Message<N>;
     type Error = Error;
 
-    fn handle_input<R: Rng>(&mut self, _rng: &mut R, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, input: Self::Input, _rng: &mut R) -> Result<Step<N>> {
         self.propose(input)
     }
 
     fn handle_message<R: Rng>(
         &mut self,
-        _rng: &mut R,
         sender_id: &N,
         message: Message<N>,
+        _rng: &mut R,
     ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }

--- a/src/subset/subset.rs
+++ b/src/subset/subset.rs
@@ -10,7 +10,7 @@ use serde_derive::Serialize;
 use super::proposal_state::{ProposalState, Step as ProposalStep};
 use super::{Error, Message, MessageContent, Result};
 use crate::{util, DistAlgorithm, NetworkInfo, NodeIdT, SessionIdT};
-use rand::Rand;
+use rand::{Rand, Rng};
 
 /// A `Subset` step, possibly containing several outputs.
 pub type Step<N> = crate::Step<Message<N>, SubsetOutput<N>, N>;
@@ -48,11 +48,16 @@ impl<N: NodeIdT + Rand, S: SessionIdT> DistAlgorithm for Subset<N, S> {
     type Message = Message<N>;
     type Error = Error;
 
-    fn handle_input(&mut self, input: Self::Input) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _rng: &mut R, input: Self::Input) -> Result<Step<N>> {
         self.propose(input)
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Message<N>) -> Result<Step<N>> {
+    fn handle_message<R: Rng>(
+        &mut self,
+        _rng: &mut R,
+        sender_id: &N,
+        message: Message<N>,
+    ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }
 

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -62,7 +62,7 @@
 //! use hbbft::sync_key_gen::{AckOutcome, PartOutcome, SyncKeyGen};
 //!
 //! // Use the OS random number generator for any randomness:
-//! let mut rng = rand::OsRng::new();
+//! let mut rng = rand::OsRng::new().expect("Could not open OS random number generator.");
 //!
 //! // Two out of four shares will suffice to sign or encrypt something.
 //! let (threshold, node_num) = (1, 4);
@@ -80,8 +80,13 @@
 //! let mut nodes = BTreeMap::new();
 //! let mut parts = Vec::new();
 //! for (id, sk) in sec_keys.into_iter().enumerate() {
-//!     let (sync_key_gen, opt_part) = SyncKeyGen::new(&mut rng, id, sk, pub_keys.clone(), threshold)
-//!         .unwrap_or_else(|_| panic!("Failed to create `SyncKeyGen` instance for node #{}", id));
+//!     let (sync_key_gen, opt_part) = SyncKeyGen::new(
+//!         id,
+//!         sk,
+//!         pub_keys.clone(),
+//!         threshold,
+//!         &mut rng,
+//! ).unwrap_or_else(|_| panic!("Failed to create `SyncKeyGen` instance for node #{}", id));
 //!     nodes.insert(id, sync_key_gen);
 //!     parts.push((id, opt_part.unwrap())); // Would be `None` for observer nodes.
 //! }
@@ -91,7 +96,7 @@
 //! for (sender_id, part) in parts {
 //!     for (&id, node) in &mut nodes {
 //!         match node
-//!             .handle_part(&mut rng, &sender_id, part.clone())
+//!             .handle_part(&sender_id, part.clone(), &mut rng)
 //!             .expect("Failed to handle Part")
 //!         {
 //!             PartOutcome::Valid(Some(ack)) => acks.push((id, ack)),

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -61,7 +61,7 @@
 //! use threshold_crypto::{PublicKey, SecretKey, SignatureShare};
 //! use hbbft::sync_key_gen::{AckOutcome, PartOutcome, SyncKeyGen};
 //!
-//! // Use the os random number generator for any randomness:
+//! // Use the OS random number generator for any randomness:
 //! let mut rng = rand::OsRng::new();
 //!
 //! // Two out of four shares will suffice to sign or encrypt something.

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -61,8 +61,8 @@
 //! use threshold_crypto::{PublicKey, SecretKey, SignatureShare};
 //! use hbbft::sync_key_gen::{AckOutcome, PartOutcome, SyncKeyGen};
 //!
-//! // Use a default random number generator for any randomness:
-//! let mut rng = rand::thread_rng();
+//! // Use the os random number generator for any randomness:
+//! let mut rng = rand::OsRng::new();
 //!
 //! // Two out of four shares will suffice to sign or encrypt something.
 //! let (threshold, node_num) = (1, 4);

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -316,11 +316,11 @@ impl<N: NodeIdT> SyncKeyGen<N> {
     /// If we are not a validator but only an observer, no `Part` message is produced and no
     /// messages need to be sent.
     pub fn new<R: rand::Rng>(
-        rng: &mut R,
         our_id: N,
         sec_key: SecretKey,
         pub_keys: BTreeMap<N, PublicKey>,
         threshold: usize,
+        rng: &mut R,
     ) -> Result<(SyncKeyGen<N>, Option<Part>), Error> {
         let our_idx = pub_keys
             .keys()
@@ -366,9 +366,9 @@ impl<N: NodeIdT> SyncKeyGen<N> {
     /// Note that `handle_part` also needs to explicitly be called with this instance's own `Part`.
     pub fn handle_part<R: rand::Rng>(
         &mut self,
-        rng: &mut R,
         sender_id: &N,
         part: Part,
+        rng: &mut R,
     ) -> Result<PartOutcome, Error> {
         let sender_idx = self.node_index(sender_id).ok_or(Error::UnknownSender)?;
         let row = match self.handle_part_or_fault(sender_idx, part) {

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -75,15 +75,15 @@ impl<N: NodeIdT> DistAlgorithm for ThresholdDecrypt<N> {
     type Message = Message;
     type Error = Error;
 
-    fn handle_input<R: Rng>(&mut self, _rng: &mut R, _input: ()) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _input: (), _rng: &mut R) -> Result<Step<N>> {
         self.start_decryption()
     }
 
     fn handle_message<R: Rng>(
         &mut self,
-        _rng: &mut R,
         sender_id: &Self::NodeId,
         message: Message,
+        _rng: &mut R,
     ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use crate::crypto::{self, Ciphertext, DecryptionShare};
 use failure::Fail;
+use rand::Rng;
 use rand_derive::Rand;
 use serde_derive::{Deserialize, Serialize};
 
@@ -74,11 +75,16 @@ impl<N: NodeIdT> DistAlgorithm for ThresholdDecrypt<N> {
     type Message = Message;
     type Error = Error;
 
-    fn handle_input(&mut self, _input: ()) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _rng: &mut R, _input: ()) -> Result<Step<N>> {
         self.start_decryption()
     }
 
-    fn handle_message(&mut self, sender_id: &N, message: Message) -> Result<Step<N>> {
+    fn handle_message<R: Rng>(
+        &mut self,
+        _rng: &mut R,
+        sender_id: &Self::NodeId,
+        message: Message,
+    ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }
 

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -83,16 +83,16 @@ impl<N: NodeIdT> DistAlgorithm for ThresholdSign<N> {
     type Error = Error;
 
     /// Sends our threshold signature share if not yet sent.
-    fn handle_input<R: Rng>(&mut self, _rng: &mut R, _input: ()) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _input: (), _rng: &mut R) -> Result<Step<N>> {
         self.sign()
     }
 
     /// Receives input from a remote node.
     fn handle_message<R: Rng>(
         &mut self,
-        _rng: &mut R,
         sender_id: &Self::NodeId,
         message: Message,
+        _rng: &mut R,
     ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -22,6 +22,7 @@ use std::{fmt, result};
 use crate::crypto::{self, hash_g2, Signature, SignatureShare, G2};
 use failure::Fail;
 use log::debug;
+use rand::Rng;
 use rand_derive::Rand;
 use serde_derive::{Deserialize, Serialize};
 
@@ -82,12 +83,17 @@ impl<N: NodeIdT> DistAlgorithm for ThresholdSign<N> {
     type Error = Error;
 
     /// Sends our threshold signature share if not yet sent.
-    fn handle_input(&mut self, _input: ()) -> Result<Step<N>> {
+    fn handle_input<R: Rng>(&mut self, _rng: &mut R, _input: ()) -> Result<Step<N>> {
         self.sign()
     }
 
     /// Receives input from a remote node.
-    fn handle_message(&mut self, sender_id: &N, message: Message) -> Result<Step<N>> {
+    fn handle_message<R: Rng>(
+        &mut self,
+        _rng: &mut R,
+        sender_id: &Self::NodeId,
+        message: Message,
+    ) -> Result<Step<N>> {
         self.handle_message(sender_id, message)
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -251,9 +251,8 @@ where
 
 /// A distributed algorithm that defines a message flow.
 ///
-/// Many algorithms require a source of random data, which must be supplied on each call. It is up
-/// to the caller to ensure that these source supply random numbers suitable for cryptographic
-/// applications.
+/// Many algorithms require an RNG which must be supplied on each call. It is up to the caller to
+/// ensure that these source supply random numbers suitable for cryptographic applications.
 pub trait DistAlgorithm: Send + Sync {
     /// Unique node identifier.
     type NodeId: NodeIdT;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -269,8 +269,8 @@ pub trait DistAlgorithm: Send + Sync {
     /// Handles an input provided by the user, and returns
     fn handle_input<R: Rng>(
         &mut self,
-        rng: &mut R,
         input: Self::Input,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, Self::Error>
     where
         Self: Sized;
@@ -278,9 +278,9 @@ pub trait DistAlgorithm: Send + Sync {
     /// Handles a message received from node `sender_id`.
     fn handle_message<R: Rng>(
         &mut self,
-        rng: &mut R,
         sender_id: &Self::NodeId,
         message: Self::Message,
+        rng: &mut R,
     ) -> Result<DaStep<Self>, Self::Error>
     where
         Self: Sized;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -252,7 +252,7 @@ where
 /// A distributed algorithm that defines a message flow.
 ///
 /// Many algorithms require an RNG which must be supplied on each call. It is up to the caller to
-/// ensure that these source supply random numbers suitable for cryptographic applications.
+/// ensure that this random number generator is cryptographically secure.
 pub trait DistAlgorithm: Send + Sync {
     /// Unique node identifier.
     type NodeId: NodeIdT;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use std::iter::once;
 
 use failure::Fail;
+use rand::Rng;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::fault_log::{Fault, FaultLog};
@@ -249,6 +250,10 @@ where
 }
 
 /// A distributed algorithm that defines a message flow.
+///
+/// Many algorithms require a source of random data, which must be supplied on each call. It is up
+/// to the caller to ensure that these source supply random numbers suitable for cryptographic
+/// applications.
 pub trait DistAlgorithm: Send + Sync {
     /// Unique node identifier.
     type NodeId: NodeIdT;
@@ -263,13 +268,18 @@ pub trait DistAlgorithm: Send + Sync {
     type Error: Fail;
 
     /// Handles an input provided by the user, and returns
-    fn handle_input(&mut self, input: Self::Input) -> Result<DaStep<Self>, Self::Error>
+    fn handle_input<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        input: Self::Input,
+    ) -> Result<DaStep<Self>, Self::Error>
     where
         Self: Sized;
 
     /// Handles a message received from node `sender_id`.
-    fn handle_message(
+    fn handle_message<R: Rng>(
         &mut self,
+        rng: &mut R,
         sender_id: &Self::NodeId,
         message: Self::Message,
     ) -> Result<DaStep<Self>, Self::Error>

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,31 +6,6 @@
 use std::fmt;
 
 use hex_fmt::HexFmt;
-use rand;
-
-/// Workaround trait for creating new random number generators
-pub trait SubRng {
-    /// Returns a new random number generator in a `Box`.
-    fn sub_rng(&mut self) -> Box<dyn rand::Rng + Send + Sync>;
-}
-
-impl<R> SubRng for R
-where
-    R: rand::Rng,
-{
-    fn sub_rng(&mut self) -> Box<dyn rand::Rng + Send + Sync> {
-        // Currently hard-coded to be an `Isaac64Rng`, until better options emerge. This is either
-        // dependant on `rand` 0.5 support or an API re-design of parts of `threshold_crypto` and
-        // `hbbft`.
-        let rng = self.gen::<rand::isaac::Isaac64Rng>();
-        Box::new(rng)
-    }
-}
-
-/// Prints "`<RNG>`" as a placeholder for a random number generator in debug output.
-pub fn fmt_rng<T>(_: T, f: &mut fmt::Formatter) -> fmt::Result {
-    f.write_str("<RNG>")
-}
 
 /// Prints a byte slice as shortened hexadecimal in debug output.
 pub fn fmt_hex<T: AsRef<[u8]>>(bytes: T, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/binary_agreement.rs
+++ b/tests/binary_agreement.rs
@@ -79,12 +79,12 @@ impl VirtualNet<BinaryAgreement<NodeId, u8>> {
     {
         let ids: Vec<NodeId> = self.nodes().map(|n| *n.id()).collect();
         for id in ids {
-            let _ = self.send_input(id, input.unwrap_or_else(|| rng.gen::<bool>()));
+            let _ = self.send_input(id, input.unwrap_or_else(|| rng.gen::<bool>()), &mut rng);
         }
 
         // Handle messages in random order until all nodes have output the proposed value.
         while !self.nodes().all(|node| node.algorithm().terminated()) {
-            let _ = self.crank_expect();
+            let _ = self.crank_expect(&mut rng);
         }
         // Verify that all instances output the same value.
         let mut expected = input;

--- a/tests/binary_agreement.rs
+++ b/tests/binary_agreement.rs
@@ -120,13 +120,12 @@ fn binary_agreement(cfg: TestConfig) {
         .num_faulty(num_faulty_nodes as usize)
         .message_limit(10_000 * size as usize)
         .time_limit(time::Duration::from_secs(30 * size as u64))
-        .rng(rng.gen::<TestRng>())
         .adversary(ReorderingAdversary::new(rng.gen::<TestRng>()))
         .using(move |node_info: NewNodeInfo<_>| {
             BinaryAgreement::new(Arc::new(node_info.netinfo), 0)
                 .expect("Failed to create a BinaryAgreement instance.")
         })
-        .build()
+        .build(&mut rng)
         .expect("Could not construct test network.");
     net.test_binary_agreement(cfg.input, rng.gen::<TestRng>());
     println!(

--- a/tests/binary_agreement.rs
+++ b/tests/binary_agreement.rs
@@ -26,7 +26,7 @@ use rand::{Rng, SeedableRng};
 use hbbft::binary_agreement::BinaryAgreement;
 use hbbft::DistAlgorithm;
 
-use crate::net::adversary::ReorderingAdversary;
+use crate::net::adversary::{Adversary, ReorderingAdversary};
 use crate::net::proptest::{gen_seed, NetworkDimension, TestRng, TestRngSeed};
 use crate::net::{NetBuilder, NewNodeInfo, VirtualNet};
 
@@ -72,7 +72,10 @@ proptest! {
 
 type NodeId = u16;
 
-impl VirtualNet<BinaryAgreement<NodeId, u8>> {
+impl<A> VirtualNet<BinaryAgreement<NodeId, u8>, A>
+where
+    A: Adversary<BinaryAgreement<NodeId, u8>>,
+{
     fn test_binary_agreement<R>(&mut self, input: Option<bool>, mut rng: R)
     where
         R: Rng + 'static,

--- a/tests/binary_agreement.rs
+++ b/tests/binary_agreement.rs
@@ -120,7 +120,7 @@ fn binary_agreement(cfg: TestConfig) {
         .num_faulty(num_faulty_nodes as usize)
         .message_limit(10_000 * size as usize)
         .time_limit(time::Duration::from_secs(30 * size as u64))
-        .adversary(ReorderingAdversary::new(rng.gen::<TestRng>()))
+        .adversary(ReorderingAdversary::new())
         .using(move |node_info: NewNodeInfo<_>| {
             BinaryAgreement::new(Arc::new(node_info.netinfo), 0)
                 .expect("Failed to create a BinaryAgreement instance.")

--- a/tests/binary_agreement_mitm.rs
+++ b/tests/binary_agreement_mitm.rs
@@ -449,7 +449,7 @@ fn reordering_attack() {
             BinaryAgreement::new(netinfo, 0).expect("failed to create BinaryAgreement instance")
         })
         .num_faulty(1)
-        .build()
+        .build(&mut rng)
         .unwrap();
 
     for id in ids {

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -48,6 +48,7 @@ impl Adversary<Broadcast<NodeId>> for ProposeAdversary {
     }
 
     fn step(&mut self) -> Vec<MessageWithSender<Broadcast<NodeId>>> {
+        let mut rng = rand::thread_rng();
         if self.has_sent {
             return vec![];
         }
@@ -57,7 +58,7 @@ impl Adversary<Broadcast<NodeId>> for ProposeAdversary {
             .flat_map(|(&id, netinfo)| {
                 Broadcast::new(netinfo.clone(), id)
                     .expect("broadcast instance")
-                    .handle_input(b"Fake news".to_vec())
+                    .handle_input(b"Fake news".to_vec(), &mut rng)
                     .expect("propose")
                     .messages
                     .into_iter()

--- a/tests/net/adversary.rs
+++ b/tests/net/adversary.rs
@@ -143,8 +143,12 @@ where
     }
 
     /// Normally dispatch a message
-    pub fn dispatch_message(&mut self, msg: NetMessage<D>) -> Result<DaStep<D>, CrankError<D>> {
-        self.0.dispatch_message(msg)
+    pub fn dispatch_message<R: Rng>(
+        &mut self,
+        msg: NetMessage<D>,
+        rng: &mut R,
+    ) -> Result<DaStep<D>, CrankError<D>> {
+        self.0.dispatch_message(msg, rng)
     }
 
     /// Injects a message into the network.
@@ -337,7 +341,9 @@ where
         mut net: NetMutHandle<D>,
         msg: NetMessage<D>,
     ) -> Result<DaStep<D>, CrankError<D>> {
-        net.dispatch_message(msg)
+        // FIXME: RETHINK INTERFACE TO AVOID GENERIC TYPE PARAMETERS!
+        let mut rng = rand::thread_rng();
+        net.dispatch_message(msg, &mut rng)
     }
 }
 

--- a/tests/net/adversary.rs
+++ b/tests/net/adversary.rs
@@ -33,8 +33,8 @@
 //! some cases be upgraded to actual references, if the underlying node is faulty (see
 //! `NodeHandle::node()` and `NodeHandle::node_mut()`).
 
+use std::cmp;
 use std::collections::VecDeque;
-use std::{cmp, fmt};
 
 use rand::Rng;
 
@@ -418,26 +418,12 @@ where
 /// An adversary that swaps the message at the front of the message queue for a random message
 /// within the queue before every `crank`. Thus the order in which messages are received by nodes is
 /// random, which allows to test randomized message delivery.
-pub struct ReorderingAdversary {
-    /// Random number generator to reorder messages.
-    rng: Box<dyn Rng>,
-}
-
-impl fmt::Debug for ReorderingAdversary {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ReorderingAdversary")
-            .field("rng", &"<RNG>")
-            .finish()
-    }
-}
+#[derive(Copy, Clone, Debug)]
+pub struct ReorderingAdversary {}
 
 impl ReorderingAdversary {
-    #[inline]
-    pub fn new<R>(rng: R) -> Self
-    where
-        R: 'static + Rng,
-    {
-        ReorderingAdversary { rng: Box::new(rng) }
+    pub fn new() -> Self {
+        ReorderingAdversary {}
     }
 }
 
@@ -448,10 +434,10 @@ where
     D::Output: Clone,
 {
     #[inline]
-    fn pre_crank<R: Rng>(&mut self, mut net: NetMutHandle<D, Self>, _rng: &mut R) {
+    fn pre_crank<R: Rng>(&mut self, mut net: NetMutHandle<D, Self>, rng: &mut R) {
         let l = net.0.messages_len();
         if l > 0 {
-            net.swap_messages(0, self.rng.gen_range(0, l));
+            net.swap_messages(0, rng.gen_range(0, l));
         }
     }
 }

--- a/tests/net/adversary.rs
+++ b/tests/net/adversary.rs
@@ -418,7 +418,7 @@ where
 /// An adversary that swaps the message at the front of the message queue for a random message
 /// within the queue before every `crank`. Thus the order in which messages are received by nodes is
 /// random, which allows to test randomized message delivery.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct ReorderingAdversary {}
 
 impl ReorderingAdversary {

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -283,6 +283,7 @@ where
 /// New network node construction information.
 ///
 /// Helper structure passed to node constructors when building virtual networks.
+#[derive(Debug)]
 pub struct NewNodeInfo<D>
 where
     D: DistAlgorithm,
@@ -293,20 +294,6 @@ where
     pub netinfo: NetworkInfo<D::NodeId>,
     /// Whether or not the node is marked faulty.
     pub faulty: bool,
-}
-
-impl<D> fmt::Debug for NewNodeInfo<D>
-where
-    D: DistAlgorithm,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("NewNodeInfo")
-            .field("id", &self.id)
-            .field("netinfo", &self.netinfo)
-            .field("faulty", &self.faulty)
-            .field("rng", &"<RNG>")
-            .finish()
-    }
 }
 
 /// Virtual network builder.
@@ -568,6 +555,7 @@ where
 ///
 /// An adversary can be hooked into the network to affect the order of message delivery or the
 /// behaviour of faulty nodes.
+#[derive(Debug)]
 pub struct VirtualNet<D, A>
 where
     D: DistAlgorithm,
@@ -599,28 +587,6 @@ where
     /// `false` switches allows to carry on with the test despite `Fault`s reported for a correct
     /// node.
     error_on_fault: bool,
-}
-
-impl<D, A> fmt::Debug for VirtualNet<D, A>
-where
-    D: DistAlgorithm,
-    D::Message: Clone,
-    D::Output: Clone,
-    A: Adversary<D> + fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("VirtualNet")
-            .field("nodes", &self.nodes.len())
-            .field("messages", &self.messages)
-            .field("adversary", &self.adversary)
-            .field("trace", &self.trace.is_some())
-            .field("crank_count", &self.crank_count)
-            .field("crank_limit", &self.crank_limit)
-            .field("message_count", &self.message_count)
-            .field("message_limit", &self.message_limit)
-            .field("error_on_fault", &self.error_on_fault)
-            .finish()
-    }
 }
 
 impl<D, A> VirtualNet<D, A>

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -1024,17 +1024,11 @@ where
     ///
     /// If an error occurs, the first error is returned and broadcasting aborted.
     #[inline]
+    pub fn broadcast_input<'a, R: Rng>(
         &'a mut self,
         input: &'a D::Input,
         rng: &mut R,
     ) -> Result<Vec<(D::NodeId, DaStep<D>)>, CrankError<D>> {
-        // Note: The tricky lifetime annotation basically says that the input value given must
-        //       live as long as the iterator returned lives (because it is cloned on every step,
-        //       with steps only evaluated each time `next()` is called. For the same reason the
-        //       network should not go away ealier either.
-
-        // Note: It's unfortunately not possible to loop and call `send_input`,
-
         let steps: Vec<_> = self
             .nodes
             .values_mut()

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -92,8 +92,6 @@ fn do_drop_and_readd(cfg: TestConfig) {
         .message_limit(15_000 * cfg.dimension.size() as usize)
         // 30 secs per node.
         .time_limit(time::Duration::from_secs(30 * cfg.dimension.size() as u64))
-        // Ensure runs are reproducible.
-        .rng(rng.gen::<TestRng>())
         .adversary(ReorderingAdversary::new(rng.gen::<TestRng>()))
         .using_step(move |node: NewNodeInfo<SenderQueue<_>>| {
             let id = node.id;
@@ -105,7 +103,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
             )
             .build(node.id)
         })
-        .build()
+        .build(&mut rng)
         .expect("could not construct test network");
 
     // We will use the first correct node as the node we will remove from and re-add to the network.

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -8,7 +8,7 @@ use crate::net::{NetBuilder, NewNodeInfo};
 use hbbft::dynamic_honey_badger::{Change, ChangeState, DynamicHoneyBadger, Input};
 use hbbft::sender_queue::SenderQueue;
 use proptest::{prelude::ProptestConfig, prop_compose, proptest, proptest_helper};
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
 
 /// Choose a node's contribution for an epoch.
 ///
@@ -92,7 +92,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
         .message_limit(15_000 * cfg.dimension.size() as usize)
         // 30 secs per node.
         .time_limit(time::Duration::from_secs(30 * cfg.dimension.size() as u64))
-        .adversary(ReorderingAdversary::new(rng.gen::<TestRng>()))
+        .adversary(ReorderingAdversary::new())
         .using_step(move |node: NewNodeInfo<SenderQueue<_>>| {
             let id = node.id;
             println!("Constructing new dynamic honey badger node #{}", id);

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -98,9 +98,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
         .using_step(move |node: NewNodeInfo<SenderQueue<_>>| {
             let id = node.id;
             println!("Constructing new dynamic honey badger node #{}", id);
-            let dhb = DynamicHoneyBadger::builder()
-                .rng(node.rng)
-                .build(node.netinfo.clone());
+            let dhb = DynamicHoneyBadger::builder().build(node.netinfo.clone());
             SenderQueue::builder(
                 dhb,
                 node.netinfo.all_ids().filter(|&&them| them != id).cloned(),
@@ -133,7 +131,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
 
         // The step will have its messages added to the queue automatically, we ignore the output.
         let _ = net
-            .send_input(*id, Input::User(proposal))
+            .send_input(*id, Input::User(proposal), &mut rng)
             .expect("could not send initial transaction");
     }
 
@@ -148,8 +146,11 @@ fn do_drop_and_readd(cfg: TestConfig) {
     let pub_keys_add = netinfo.public_key_map().clone();
     let mut pub_keys_rm = pub_keys_add.clone();
     pub_keys_rm.remove(&pivot_node_id);
-    net.broadcast_input(&Input::Change(Change::NodeChange(pub_keys_rm.clone())))
-        .expect("broadcasting failed");
+    net.broadcast_input(
+        &Input::Change(Change::NodeChange(pub_keys_rm.clone())),
+        &mut rng,
+    )
+    .expect("broadcasting failed");
 
     // We are tracking (correct) nodes' state through the process by ticking them off individually.
     let mut awaiting_removal: collections::BTreeSet<_> =
@@ -164,7 +165,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
 
     // Run the network:
     loop {
-        let (node_id, step) = net.crank_expect();
+        let (node_id, step) = net.crank_expect(&mut rng);
         if !net[node_id].is_faulty() {
             for batch in &step.output {
                 // Check that correct nodes don't output different batches for the same epoch.
@@ -219,6 +220,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
                         .send_input(
                             node_id,
                             Input::Change(Change::NodeChange(pub_keys_add.clone())),
+                            &mut rng,
                         )
                         .expect("failed to send `Add` input");
                 }
@@ -291,7 +293,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
                 choose_contribution(&mut rng, queue, cfg.batch_size, cfg.contribution_size);
 
             let _ = net
-                .send_input(node_id, Input::User(proposal))
+                .send_input(node_id, Input::User(proposal), &mut rng)
                 .expect("could not send follow-up transaction");
         }
     }

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -90,8 +90,10 @@ fn new_queueing_hb(
         .cloned()
         .chain(iter::once(observer));
     let dhb = DynamicHoneyBadger::builder().build((*netinfo).clone());
-    let rng = rand::thread_rng().gen::<Isaac64Rng>();
-    let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb).batch_size(3).build(rng);
+    let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
+    let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
+        .batch_size(3)
+        .build(&mut rng);
     let (sq, mut step) = SenderQueue::builder(qhb, peer_ids).build(our_id);
     step.extend_with(qhb_step, Message::from);
     (sq, step)

--- a/tests/sync_key_gen.rs
+++ b/tests/sync_key_gen.rs
@@ -23,7 +23,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
         .enumerate()
         .map(|(id, sk)| {
             let (sync_key_gen, proposal) =
-                SyncKeyGen::new(&mut rand::thread_rng(), id, sk, pub_keys.clone(), threshold)
+                SyncKeyGen::new(id, sk, pub_keys.clone(), threshold, &mut rand::thread_rng())
                     .unwrap_or_else(|_err| {
                         panic!("Failed to create `SyncKeyGen` instance #{}", id)
                     });
@@ -38,7 +38,7 @@ fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
         for (node_id, node) in nodes.iter_mut().enumerate() {
             let proposal = proposal.clone().expect("proposal");
             let ack = match node
-                .handle_part(&mut rand::thread_rng(), &sender_id, proposal)
+                .handle_part(&sender_id, proposal, &mut rand::thread_rng())
                 .expect("failed to handle part")
             {
                 PartOutcome::Valid(Some(ack)) => ack,

--- a/tests/threshold_sign.rs
+++ b/tests/threshold_sign.rs
@@ -7,7 +7,6 @@ use std::iter::once;
 
 use log::info;
 use rand::Rng;
-use rand_derive::Rand;
 
 use hbbft::{crypto::Signature, threshold_sign::ThresholdSign, util};
 

--- a/tests/threshold_sign.rs
+++ b/tests/threshold_sign.rs
@@ -7,6 +7,7 @@ use std::iter::once;
 
 use log::info;
 use rand::Rng;
+use rand_derive::Rand;
 
 use hbbft::{crypto::Signature, threshold_sign::ThresholdSign, util};
 
@@ -18,8 +19,11 @@ fn test_threshold_sign<A>(mut network: TestNetwork<A, ThresholdSign<NodeId>>) ->
 where
     A: Adversary<ThresholdSign<NodeId>>,
 {
+    let mut rng = rand::thread_rng();
+
     network.input_all(());
-    network.observer.handle_input(()); // Observer will only return after `input` was called.
+
+    network.observer.handle_input((), &mut rng); // Observer will only return after `input` was called.
 
     // Handle messages until all good nodes have terminated.
     while !network.nodes.values().all(TestNode::terminated) {


### PR DESCRIPTION
This is a WIP PR, as the tests won't pass (I have not updated them yet). I want feedback on these changes first, before I undertake updating and refactoring all the tests.

Here's the issue: Someone noticed that the default RNG for both `HoneyBadger` and `DynamicHoneyBadger` was the suboptimal `thread_rng()` (see Issue #356).

We cannot simply put in an `OsRng` and call it a day, since Hydrabadger uses tokio, which requires all of our algorithms to be send and sync. Our boxed RNG model has to go (I mentioned this a month back, but we kinda put off this refactoring until now, since it was not apparent what the gain was). There already was a plan to make all RNGs to be passed in from the outside, now we just had to accelerate that schedule.

The first commit shows what does not work, namely just plopping in `OsRng` - which is not `Send+Sync`. It still changes all the tests to use `OsRng`, because why not (makes grepping for `thread_rng` really convenient).

The second commit takes care of adding an extra `rng: &mut R` parameter to all relevant methods but cuts off at the boundary to `DistAlgorithm`.

The third commit takes the final step and changes the `DistAlgorithm` interface.

One open question is whether the change in `epoch_state.rs:78` is allowed; the function used to call `handle_input`, but now calls `propose` instead, which works out the same, but removes a layer of abstraction. The rationale behind this is to avoid introducing a chain of completely unnecessary `R: Rng` parameters in that area. Any feedback @afck ?

The PR is rather long and messy, it's a fairly unpleasant refactoring. Still, I am grateful for early feedback.