### PR TITLE
Remove unwrap and expect calls from production code.

### DIFF
--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -439,7 +439,7 @@ fn main() {
             .build_with_transactions(txs.clone(), rng)
             .expect("instantiate QueueingHoneyBadger");
         let (sq, mut step) = SenderQueue::builder(qhb, peer_ids.into_iter()).build(our_id);
-        step.extend_with(qhb_step, Message::from);
+        assert!(step.extend_with(qhb_step, Message::from).is_empty());
         (sq, step)
     };
 

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -157,9 +157,7 @@ impl<N: NodeIdT> Broadcast<N> {
         let mut shards: Vec<&mut [u8]> = shards_iter.collect();
 
         // Construct the parity chunks/shards
-        self.coding
-            .encode(&mut shards)
-            .expect("incorrect shard size or number");
+        self.coding.encode(&mut shards)?;
 
         debug!(
             "{}: Value: {} bytes, {} per shard. Shards: {:0.10}",

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -55,8 +55,8 @@ where
             voter: voter.clone(),
             sig: self.netinfo.secret_key().sign(ser_vote),
         };
-        self.pending.insert(voter.clone(), signed_vote);
-        Ok(self.pending.get(&voter).expect("entry was just inserted"))
+        self.pending.remove(&voter);
+        Ok(self.pending.entry(voter).or_insert(signed_vote))
     }
 
     /// Inserts a pending vote into the buffer, if it has a higher number than the existing one.

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -90,16 +90,7 @@ where
             return Ok(Step::default());
         }
         self.has_input = true;
-        let epoch = self.epoch;
-        let step = {
-            let epoch_state = {
-                self.epoch_state_mut(epoch)?;
-                self.epochs.get_mut(&epoch).expect(
-                    "We created the epoch_state in `self.epoch_state_mut(...)` just a moment ago.",
-                )
-            };
-            epoch_state.propose(proposal, rng)?
-        };
+        let step = self.epoch_state_mut(self.epoch)?.propose(proposal, rng)?;
         Ok(step.join(self.try_output_batches()?))
     }
 

--- a/src/queueing_honey_badger/mod.rs
+++ b/src/queueing_honey_badger/mod.rs
@@ -117,10 +117,7 @@ where
     }
 
     /// Creates a new Queueing Honey Badger instance with an empty buffer.
-    pub fn build<R: Rng>(self, rng: &mut R) -> Result<QueueingHoneyBadgerWithStep<T, N, Q>>
-    where
-        R: 'static + Rng + Send + Sync,
-    {
+    pub fn build<R: Rng>(self, rng: &mut R) -> Result<QueueingHoneyBadgerWithStep<T, N, Q>> {
         self.build_with_transactions(None, rng)
     }
 

--- a/src/queueing_honey_badger/mod.rs
+++ b/src/queueing_honey_badger/mod.rs
@@ -117,9 +117,11 @@ where
     }
 
     /// Creates a new Queueing Honey Badger instance with an empty buffer.
-    pub fn build<R: Rng>(self, rng: &mut R) -> QueueingHoneyBadgerWithStep<T, N, Q> {
+    pub fn build<R: Rng>(self, rng: &mut R) -> Result<QueueingHoneyBadgerWithStep<T, N, Q>>
+    where
+        R: 'static + Rng + Send + Sync,
+    {
         self.build_with_transactions(None, rng)
-            .expect("building without transactions cannot fail")
     }
 
     /// Returns a new Queueing Honey Badger instance that starts with the given transactions in its

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -58,7 +58,7 @@ pub struct ThresholdDecrypt<N> {
     /// The encrypted data.
     ciphertext: Option<Ciphertext>,
     /// All received threshold decryption shares.
-    shares: BTreeMap<N, DecryptionShare>,
+    shares: BTreeMap<N, (usize, DecryptionShare)>,
     /// Whether we already sent our shares.
     had_input: bool,
     /// Whether we have already returned the output.
@@ -141,14 +141,15 @@ impl<N: NodeIdT> ThresholdDecrypt<N> {
         let mut step = Step::default();
         step.fault_log.extend(self.remove_invalid_shares());
         self.had_input = true;
-        let share = match self.netinfo.secret_key_share() {
-            Some(sks) => sks.decrypt_share_no_verify(&ct),
-            None => return Ok(step.join(self.try_output()?)), // Not a validator.
+        let opt_idx = self.netinfo.node_index(self.our_id());
+        let (idx, share) = match (opt_idx, self.netinfo.secret_key_share()) {
+            (Some(idx), Some(sks)) => (idx, sks.decrypt_share_no_verify(&ct)),
+            (_, _) => return Ok(step.join(self.try_output()?)), // Not a validator.
         };
         let our_id = self.our_id().clone();
         let msg = Target::All.message(Message(share.clone()));
         step.messages.push(msg);
-        self.shares.insert(our_id, share);
+        self.shares.insert(our_id, (idx, share));
         step.extend(self.try_output()?);
         Ok(step)
     }
@@ -168,15 +169,17 @@ impl<N: NodeIdT> ThresholdDecrypt<N> {
             return Ok(Step::default()); // Don't waste time on redundant shares.
         }
         // Before checking the share, ensure the sender is a known validator
-        self.netinfo
-            .public_key_share(sender_id)
+        let idx = self
+            .netinfo
+            .node_index(sender_id)
             .ok_or(Error::UnknownSender)?;
         let Message(share) = message;
         if !self.is_share_valid(sender_id, &share) {
             let fault_kind = FaultKind::UnverifiedDecryptionShareSender;
             return Ok(Fault::new(sender_id.clone(), fault_kind).into());
         }
-        if self.shares.insert(sender_id.clone(), share).is_some() {
+        let entry = (idx, share);
+        if self.shares.insert(sender_id.clone(), entry).is_some() {
             return Ok(Fault::new(sender_id.clone(), FaultKind::MultipleDecryptionShares).into());
         }
         self.try_output()
@@ -187,7 +190,7 @@ impl<N: NodeIdT> ThresholdDecrypt<N> {
         let faulty_senders: Vec<N> = self
             .shares
             .iter()
-            .filter(|(id, share)| !self.is_share_valid(id, share))
+            .filter(|(id, (_, share))| !self.is_share_valid(id, share))
             .map(|(id, _)| id.clone())
             .collect();
         let mut fault_log = FaultLog::default();
@@ -221,20 +224,15 @@ impl<N: NodeIdT> ThresholdDecrypt<N> {
         };
         self.terminated = true;
         let step = self.start_decryption()?; // Before terminating, make sure we sent our share.
-        let plaintext = {
-            let to_idx = |(id, share)| {
-                let idx = self
-                    .netinfo
-                    .node_index(id)
-                    .expect("we put only validators' shares in the map; qed");
-                (idx, share)
-            };
-            let share_itr = self.shares.iter().map(to_idx);
-            self.netinfo
-                .public_key_set()
-                .decrypt(share_itr, &ct)
-                .map_err(Error::Decryption)?
-        };
+        let share_itr = self
+            .shares
+            .values()
+            .map(|&(ref idx, ref share)| (idx, share));
+        let plaintext = self
+            .netinfo
+            .public_key_set()
+            .decrypt(share_itr, &ct)
+            .map_err(Error::Decryption)?;
         Ok(step.with_output(plaintext))
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -114,6 +114,7 @@ impl<M, O, N> Step<M, O, N> {
     }
 
     /// Extends `self` with `other`s messages and fault logs, and returns `other.output`.
+    #[must_use]
     pub fn extend_with<M2, O2, FM>(&mut self, other: Step<M2, O2, N>, f_msg: FM) -> Vec<O2>
     where
         FM: Fn(M2) -> M,

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -190,7 +190,8 @@ fn new_queueing_hb(
     let mut rng = rand::thread_rng().gen::<Isaac64Rng>();
     let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
         .batch_size(3)
-        .build(&mut rng);
+        .build(&mut rng)
+        .expect("failed to build QueueingHoneyBadger");
     let (sq, mut step) = SenderQueue::builder(qhb, peer_ids).build(our_id);
     step.extend(qhb_step.map(|output| output, Message::from));
     (sq, step)


### PR DESCRIPTION
Also make `Step::extend_with` `#[must_use]`, so the user doesn't forget to handle the output.