### PR TITLE
Fixes the net_dynamic_hb test

### DIFF
--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -218,12 +218,6 @@ where
                     .map(FaultLog::into),
             }
         } else if message.era() > self.era {
-            println!(
-                "Us: {:?}, them: {:?}, message: {:?}",
-                self.era,
-                message.era(),
-                message
-            );
             Ok(Fault::new(sender_id.clone(), FaultKind::UnexpectedDhbMessageEra).into())
         } else {
             // The message is late; discard it.
@@ -425,7 +419,6 @@ where
 
     /// Starts a new `HoneyBadger` instance and resets the vote counter.
     fn restart_honey_badger(&mut self, era: u64, params: Params) {
-        println!("Restarting DHB at {:?} in era {}.", self.netinfo.our_id(), era);
         self.era = era;
         self.key_gen_msg_buffer.retain(|kg_msg| kg_msg.0 >= era);
         let netinfo = Arc::new(self.netinfo.clone());

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -218,6 +218,12 @@ where
                     .map(FaultLog::into),
             }
         } else if message.era() > self.era {
+            println!(
+                "Us: {:?}, them: {:?}, message: {:?}",
+                self.era,
+                message.era(),
+                message
+            );
             Ok(Fault::new(sender_id.clone(), FaultKind::UnexpectedDhbMessageEra).into())
         } else {
             // The message is late; discard it.
@@ -419,6 +425,7 @@ where
 
     /// Starts a new `HoneyBadger` instance and resets the vote counter.
     fn restart_honey_badger(&mut self, era: u64, params: Params) {
+        println!("Restarting DHB at {:?} in era {}.", self.netinfo.our_id(), era);
         self.era = era;
         self.key_gen_msg_buffer.retain(|kg_msg| kg_msg.0 >= era);
         let netinfo = Arc::new(self.netinfo.clone());

--- a/src/sender_queue/dynamic_honey_badger.rs
+++ b/src/sender_queue/dynamic_honey_badger.rs
@@ -148,7 +148,7 @@ where
         let id = self.algo().netinfo().our_id().clone();
         let (dhb, dhb_step) =
             DynamicHoneyBadger::new_joining(id.clone(), secret_key, join_plan, rng)?;
-        let (sq, mut sq_step) = SenderQueue::builder(dhb, peer_ids.into_iter()).build(id);
+        let (sq, mut sq_step) = SenderQueue::builder(dhb, peer_ids).build(id);
         sq_step.extend(dhb_step.map(|output| output, Message::from));
         *self = sq;
         Ok(sq_step)

--- a/src/sender_queue/dynamic_honey_badger.rs
+++ b/src/sender_queue/dynamic_honey_badger.rs
@@ -149,7 +149,7 @@ where
         let (dhb, dhb_step) =
             DynamicHoneyBadger::new_joining(id.clone(), secret_key, join_plan, rng)?;
         let (sq, mut sq_step) = SenderQueue::builder(dhb, peer_ids).build(id);
-        sq_step.extend(dhb_step.map(|output| output, Message::from));
+        sq_step.extend(dhb_step.map(|output| output, |fault| fault, Message::from));
         *self = sq;
         Ok(sq_step)
     }

--- a/src/sender_queue/error.rs
+++ b/src/sender_queue/error.rs
@@ -1,0 +1,19 @@
+use failure::Fail;
+use std::fmt::Debug;
+
+/// Sender queue error variants.
+#[derive(Debug, Fail)]
+pub enum Error<E>
+where
+    E: Debug + Fail,
+{
+    /// Failed to apply a function to the managed algorithm.
+    #[fail(display = "Function application failure: {}", _0)]
+    Apply(E),
+    /// Failed to restart `DynamicHoneyBadger` because it had not been removed.
+    #[fail(display = "DynamicHoneyBadger was not removed before restarting")]
+    DynamicHoneyBadgerNotRemoved,
+    /// Failed to start a new joining `DynamicHoneyBadger`.
+    #[fail(display = "Failed to start a new joining DynamicHoneyBadger: {}", _0)]
+    DynamicHoneyBadgerNewJoining(E),
+}

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -228,12 +228,6 @@ where
 
     /// Handles an epoch start announcement.
     fn handle_epoch_started(&mut self, sender_id: &D::NodeId, epoch: D::Epoch) -> DaStep<Self> {
-        println!(
-            "Node {:?} got node {:?} epoch {:?}",
-            self.our_id(),
-            sender_id,
-            epoch
-        );
         self.peer_epochs
             .entry(sender_id.clone())
             .and_modify(|e| {
@@ -351,12 +345,6 @@ where
     /// superseded by a new set of participants of which it is not a member. Returns `true` if the
     /// participant has been removed and `false` otherwise.
     fn remove_participant_after(&mut self, id: &D::NodeId, last_epoch: &D::Epoch) -> bool {
-        println!(
-            "Node {:?} will remove participant {:?} after epoch {:?}.",
-            self.our_id(),
-            id,
-            last_epoch
-        );
         self.last_epochs.insert(id.clone(), last_epoch.clone());
         self.remove_participant_if_old(id)
     }
@@ -383,36 +371,17 @@ where
         if id == self.our_id() {
             // TODO: Schedule our own shutdown?
             self.is_removed = true;
-            println!("Node {:?} removed itself as participant.", self.our_id());
         } else {
             if let Some(peer_epoch) = self.peer_epochs.get(id) {
                 if last_epoch >= *peer_epoch {
                     return false;
                 }
-                // if let Some(q) = self.outgoing_queue.get(id) {
-                //     if q.keys().any(|&epoch| epoch <= last_epoch) {
-                //         return false;
-                //     }
-                // }
             }
             self.peer_epochs.remove(&id);
             self.outgoing_queue.remove(&id);
-            println!(
-                "Node {:?} removed {:?}. Remaining messages: {:?}",
-                self.our_id(),
-                id,
-                self.outgoing_queue.get(&id)
-            );
         }
         self.last_epochs.remove(&id);
         true
-    }
-
-    /// Cancels participant removal if there is one in progress. Returns the scheduled last epoch of
-    /// the participant if there was removal in progress and `None` otherwise.
-    pub fn cancel_participant_removal(&mut self, id: &D::NodeId) -> Option<D::Epoch> {
-        println!("Cancelling removal of node {:?}", id);
-        self.last_epochs.remove(&id)
     }
 
     /// Returns a reference to the managed algorithm.

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -203,16 +203,6 @@ where
         self.is_removed
     }
 
-    /// Tells whether the sender queue is empty.
-    pub fn has_messages_for_peer(&self, id: &D::NodeId) -> bool {
-        self.outgoing_queue.get(id).map_or(false, |q| q.is_empty())
-    }
-
-    /// Returns the epoch of a given node if the epoch is known.
-    pub fn get_peer_epoch(&self, id: &D::NodeId) -> Option<&D::Epoch> {
-        self.peer_epochs.get(id)
-    }
-
     /// Applies `f` to the wrapped algorithm and converts the step in the result to a sender queue
     /// step, deferring or dropping messages, where necessary.
     fn apply<F>(&mut self, f: F) -> Result<DaStep<Self>, D::Error>

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -361,7 +361,7 @@ where
     /// Returns `true` if the participant has been removed and `false` otherwise.
     fn remove_participant_if_old(&mut self, id: &D::NodeId) -> bool {
         let last_epoch = if let Some(epoch) = self.last_epochs.get(id) {
-            epoch.clone()
+            *epoch
         } else {
             return false;
         };

--- a/src/sender_queue/queueing_honey_badger.rs
+++ b/src/sender_queue/queueing_honey_badger.rs
@@ -7,7 +7,7 @@ use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use serde::{de::DeserializeOwned, Serialize};
 
-use super::{SenderQueue, SenderQueueableDistAlgorithm};
+use super::{Error, SenderQueue, SenderQueueableDistAlgorithm};
 use crate::queueing_honey_badger::{Change, Error as QhbError, QueueingHoneyBadger};
 use crate::transaction_queue::TransactionQueue;
 use crate::{Contribution, DaStep, Epoched, NodeIdT};
@@ -38,7 +38,8 @@ where
     }
 }
 
-type Result<T, N, Q> = result::Result<DaStep<SenderQueue<QueueingHoneyBadger<T, N, Q>>>, QhbError>;
+type Result<T, N, Q> =
+    result::Result<DaStep<SenderQueue<QueueingHoneyBadger<T, N, Q>>>, Error<QhbError>>;
 
 impl<T, N, Q> SenderQueue<QueueingHoneyBadger<T, N, Q>>
 where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -265,18 +265,18 @@ where
                     }
                 }
                 Target::All => {
-                    if peer_epochs
-                        .values()
-                        .all(|&them| msg.message.is_accepted(them, max_future_epochs))
-                    {
+                    let is_accepted = |&them| msg.message.is_accepted(them, max_future_epochs);
+                    let is_premature = |&them| msg.message.is_premature(them, max_future_epochs);
+                    let is_obsolete = |&them| msg.message.is_obsolete(them);
+                    if peer_epochs.values().all(is_accepted) {
                         passed_msgs.push(msg);
                     } else {
                         // The `Target::All` message is split into two sets of point messages: those
                         // which can be sent without delay and those which should be postponed.
-                        for (id, &them) in peer_epochs {
-                            if msg.message.is_premature(them, max_future_epochs) {
+                        for (id, them) in peer_epochs {
+                            if is_premature(them) {
                                 deferred_msgs.push((id.clone(), msg.message.clone()));
-                            } else if !msg.message.is_obsolete(them) {
+                            } else if !is_obsolete(them) {
                                 passed_msgs
                                     .push(Target::Node(id.clone()).message(msg.message.clone()));
                             }

--- a/tests/net/err.rs
+++ b/tests/net/err.rs
@@ -40,10 +40,10 @@ where
     MessageLimitExceeded(usize),
     /// The execution time limit has been reached or exceeded.
     TimeLimitHit(time::Duration),
-    /// A `Fault` is encountered in a step of a `DistAlgorithm`.
+    /// A `Fault` was reported by a correct node in a step of a `DistAlgorithm`.
     Fault {
         /// The ID of the node that reported the fault.
-        reported_by_id: D::NodeId,
+        reported_by: D::NodeId,
         /// The reported fault.
         fault: D::FaultKind,
     },
@@ -98,13 +98,10 @@ where
             CrankError::TimeLimitHit(lim) => {
                 write!(f, "Time limit of {} seconds exceeded.", lim.as_secs())
             }
-            CrankError::Fault {
-                reported_by_id,
-                fault,
-            } => write!(
+            CrankError::Fault { reported_by, fault } => write!(
                 f,
-                "Node {:?} reported another node {:?} as faulty: {:?}.",
-                reported_by_id, fault.node_id, fault.kind
+                "Correct node {:?} reported node {:?} as faulty: {:?}.",
+                reported_by, fault.node_id, fault.kind
             ),
             CrankError::InitialKeyGeneration(err) => write!(
                 f,
@@ -146,12 +143,9 @@ where
                 f.debug_tuple("MessageLimitExceeded").field(max).finish()
             }
             CrankError::TimeLimitHit(lim) => f.debug_tuple("TimeLimitHit").field(lim).finish(),
-            CrankError::Fault {
-                reported_by_id,
-                fault,
-            } => f
+            CrankError::Fault { reported_by, fault } => f
                 .debug_struct("Fault")
-                .field("reported_by_id", reported_by_id)
+                .field("reported_by", reported_by)
                 .field("err", fault)
                 .finish(),
             CrankError::InitialKeyGeneration(err) => {

--- a/tests/net/err.rs
+++ b/tests/net/err.rs
@@ -6,7 +6,7 @@ use std::time;
 use failure;
 use threshold_crypto as crypto;
 
-use hbbft::{DistAlgorithm, Fault};
+use hbbft::DistAlgorithm;
 
 use super::NetMessage;
 
@@ -44,8 +44,10 @@ where
     Fault {
         /// The ID of the node that reported the fault.
         reported_by: D::NodeId,
+        /// The ID of the faulty node.
+        faulty_id: D::NodeId,
         /// The reported fault.
-        fault: D::FaultKind,
+        fault_kind: D::FaultKind,
     },
     /// An error occurred while generating initial keys for threshold cryptography.
     InitialKeyGeneration(crypto::error::Error),
@@ -98,10 +100,14 @@ where
             CrankError::TimeLimitHit(lim) => {
                 write!(f, "Time limit of {} seconds exceeded.", lim.as_secs())
             }
-            CrankError::Fault { reported_by, fault } => write!(
+            CrankError::Fault {
+                reported_by,
+                faulty_id,
+                fault_kind,
+            } => write!(
                 f,
                 "Correct node {:?} reported node {:?} as faulty: {:?}.",
-                reported_by, fault.node_id, fault.kind
+                reported_by, faulty_id, fault_kind
             ),
             CrankError::InitialKeyGeneration(err) => write!(
                 f,
@@ -143,10 +149,15 @@ where
                 f.debug_tuple("MessageLimitExceeded").field(max).finish()
             }
             CrankError::TimeLimitHit(lim) => f.debug_tuple("TimeLimitHit").field(lim).finish(),
-            CrankError::Fault { reported_by, fault } => f
+            CrankError::Fault {
+                reported_by,
+                faulty_id,
+                fault_kind,
+            } => f
                 .debug_struct("Fault")
                 .field("reported_by", reported_by)
-                .field("err", fault)
+                .field("faulty_id", faulty_id)
+                .field("fault_kind", fault_kind)
                 .finish(),
             CrankError::InitialKeyGeneration(err) => {
                 f.debug_tuple("InitialKeyGeneration").field(err).finish()

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -217,7 +217,7 @@ pub type NetMessage<D> =
 #[allow(clippy::needless_pass_by_value)]
 fn process_step<'a, D>(
     nodes: &'a mut BTreeMap<D::NodeId, Node<D>>,
-    sender: D::NodeId,
+    stepped_id: D::NodeId,
     step: &DaStep<D>,
     dest: &mut VecDeque<NetMessage<D>>,
     error_on_fault: bool,
@@ -229,7 +229,7 @@ where
 {
     // For non-faulty nodes, we count the number of messages.
     let faulty = nodes
-        .get(&sender)
+        .get(&stepped_id)
         .expect("Trying to process a step with non-existing node ID")
         .is_faulty();
     let mut message_count: usize = 0;
@@ -244,20 +244,20 @@ where
                 }
 
                 dest.push_back(NetworkMessage::new(
-                    sender.clone(),
+                    stepped_id.clone(),
                     tmsg.message.clone(),
                     to.clone(),
                 ));
             }
             // Broadcast messages get expanded into multiple direct messages.
             hbbft::Target::All => {
-                for to in nodes.keys().filter(|&to| to != &sender) {
+                for to in nodes.keys().filter(|&to| to != &stepped_id) {
                     if !faulty {
                         message_count = message_count.saturating_add(1);
                     }
 
                     dest.push_back(NetworkMessage::new(
-                        sender.clone(),
+                        stepped_id.clone(),
                         tmsg.message.clone(),
                         to.clone(),
                     ));
@@ -267,14 +267,17 @@ where
     }
 
     nodes
-        .get_mut(&sender)
+        .get_mut(&stepped_id)
         .expect("Trying to process a step with non-existing node ID")
         .store_step(step);
-    if error_on_fault {
-        // Verify that no correct node is reported as faulty.
+    // Verify that no correct node is reported as faulty by a correct node.
+    if error_on_fault && !nodes[&stepped_id].is_faulty() {
         for fault in &step.fault_log.0 {
             if nodes.get(&fault.node_id).map_or(false, |n| !n.is_faulty()) {
-                return Err(CrankError::Fault(fault.clone()));
+                return Err(CrankError::Fault {
+                    reported_by_id: stepped_id.clone(),
+                    fault: fault.clone(),
+                });
             }
         }
     }
@@ -588,6 +591,9 @@ where
     /// `false` switches allows to carry on with the test despite `Fault`s reported for a correct
     /// node.
     error_on_fault: bool,
+    /// IDs of nodes that have been removed from the network. This is used to discard messages that
+    /// may be sent to those nodes cleanly.
+    removed_nodes: BTreeSet<D::NodeId>,
 }
 
 impl<D, A> VirtualNet<D, A>
@@ -637,13 +643,15 @@ where
     /// the network at the time of insertion.
     #[inline]
     pub fn insert_node(&mut self, node: Node<D>) -> Option<Node<D>> {
+        self.removed_nodes.remove(node.id());
         self.nodes.insert(node.id().clone(), node)
     }
 
-    /// Removes a node with the given ID from the network. Returns the removed node if there was a
-    /// node with this ID at the time of removal.
+    /// Removes a node with the given ID from the network and all messages addressed to
+    /// it. Returns the removed node if there was a node with this ID at the time of removal.
     #[inline]
     pub fn remove_node(&mut self, id: &D::NodeId) -> Option<Node<D>> {
+        self.removed_nodes.insert(id.clone());
         self.messages.retain(|msg| msg.to != *id);
         self.nodes.remove(id)
     }
@@ -777,10 +785,10 @@ where
 
         let mut message_count: usize = 0;
         // For every recorded step, apply it.
-        for (sender, step) in &steps {
+        for (stepped_id, step) in &steps {
             let n = process_step(
                 &mut nodes,
-                sender.clone(),
+                stepped_id.clone(),
                 step,
                 &mut messages,
                 error_on_fault,
@@ -801,6 +809,7 @@ where
                 time_limit: None,
                 start_time: time::Instant::now(),
                 error_on_fault: true,
+                removed_nodes: BTreeSet::new(),
             },
             steps.into_iter().collect(),
         ))
@@ -914,7 +923,14 @@ where
         self.adversary = adv;
 
         // Step 1: Pick a message from the queue and deliver it; returns `None` if queue is empty.
-        let msg = self.messages.pop_front()?;
+        // We use a do-while loop to remove the prefix of messages addressed to removed nodes.
+        let mut msg;
+        while {
+            msg = self.messages.pop_front()?;
+            self.removed_nodes.contains(&msg.to)
+        } {
+            // Empty body. The work was done evaluating the condition.
+        }
 
         net_trace!(
             self,
@@ -923,15 +939,15 @@ where
             msg.to,
             msg.payload
         );
-        let receiver = msg.to.clone();
+        let stepped_id = msg.to.clone();
 
         // Unfortunately, we have to re-borrow the target node further down to make the borrow
         // checker happy. First, we check if the receiving node is faulty, so we can dispatch
         // through the adversary if it is.
-        let is_faulty = try_some!(self
-            .nodes
-            .get(&msg.to)
-            .ok_or_else(|| CrankError::NodeDisappearedInCrank(msg.to.clone())))
+        let is_faulty = try_some!(self.nodes.get(&stepped_id).ok_or_else(|| {
+            println!("Cannot send message: {:?}", msg);
+            CrankError::NodeDisappearedInCrank(msg.to.clone())
+        }))
         .is_faulty();
 
         let step: Step<_, _, _, _> = if is_faulty {
@@ -956,12 +972,12 @@ where
 
         // All messages are expanded and added to the queue. We opt for copying them, so we can
         // return unaltered step later on for inspection.
-        try_some!(self.process_step(receiver.clone(), &step));
+        try_some!(self.process_step(stepped_id.clone(), &step));
 
         // Increase the crank count.
         self.crank_count += 1;
 
-        Some(Ok((receiver, step)))
+        Some(Ok((stepped_id, step)))
     }
 
     /// Convenience function for cranking.
@@ -1046,6 +1062,16 @@ where
             }
         }
         for node in self.correct_nodes().filter(|n| n.id() != full_node.id()) {
+            let id = node.id();
+            let actual_epochs: BTreeSet<_> =
+                node.outputs.iter().map(|batch| batch.epoch()).collect();
+            let expected_epochs: BTreeSet<_> =
+                expected[id].iter().map(|batch| batch.epoch()).collect();
+            assert_eq!(
+                expected_epochs, actual_epochs,
+                "Output epochs of {:?} don't match the expectation.",
+                id
+            );
             assert_eq!(
                 node.outputs.len(),
                 expected[node.id()].len(),

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -276,7 +276,8 @@ where
             if nodes.get(&fault.node_id).map_or(false, |n| !n.is_faulty()) {
                 return Err(CrankError::Fault {
                     reported_by: stepped_id.clone(),
-                    fault: fault.clone(),
+                    faulty_id: fault.node_id.clone(),
+                    fault_kind: fault.kind.clone(),
                 });
             }
         }

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -944,10 +944,10 @@ where
         // Unfortunately, we have to re-borrow the target node further down to make the borrow
         // checker happy. First, we check if the receiving node is faulty, so we can dispatch
         // through the adversary if it is.
-        let is_faulty = try_some!(self.nodes.get(&stepped_id).ok_or_else(|| {
-            println!("Cannot send message: {:?}", msg);
-            CrankError::NodeDisappearedInCrank(msg.to.clone())
-        }))
+        let is_faulty = try_some!(self
+            .nodes
+            .get(&stepped_id)
+            .ok_or_else(|| CrankError::NodeDisappearedInCrank(msg.to.clone())))
         .is_faulty();
 
         let step: Step<_, _, _, _> = if is_faulty {

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -506,18 +506,15 @@ where
     /// Observes the given step and collects useful information from it.
     fn observe_step(&mut self, id: usize, step: &Step<DynamicHoneyBadger<Vec<usize>, usize>>) {
         for msg in &step.messages {
-            match msg.message {
-                Message::EpochStarted(epoch) => {
-                    self.epochs
-                        .entry(id)
-                        .and_modify(|e| {
-                            if *e < epoch {
-                                *e = epoch;
-                            }
-                        })
-                        .or_insert(epoch);
-                }
-                _ => {}
+            if let Message::EpochStarted(epoch) = msg.message {
+                self.epochs
+                    .entry(id)
+                    .and_modify(|e| {
+                        if *e < epoch {
+                            *e = epoch;
+                        }
+                    })
+                    .or_insert(epoch);
             }
         }
     }

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -282,7 +282,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
         if node_id != pivot_node_id
             && awaiting_addition_input.contains(&node_id)
             && state.shutdown_epoch.is_some()
-            && era + hb_epoch > state.shutdown_epoch.unwrap()
+            && era + hb_epoch == state.shutdown_epoch.unwrap()
         {
             // Now we can add the node again. Public keys will be reused.
             let step = state

--- a/tests/net_dynamic_hb.rs
+++ b/tests/net_dynamic_hb.rs
@@ -276,10 +276,10 @@ fn do_drop_and_readd(cfg: TestConfig) {
         if node_id != pivot_node_id
             && awaiting_addition_input.contains(&node_id)
             && state.shutdown_epoch.is_some()
-            && era + hb_epoch == state.shutdown_epoch.unwrap()
+            && era + hb_epoch >= state.shutdown_epoch.unwrap()
         {
             // Now we can add the node again. Public keys will be reused.
-            let _ = state
+            let step = state
                 .net
                 .send_input(
                     node_id,
@@ -287,6 +287,7 @@ fn do_drop_and_readd(cfg: TestConfig) {
                     &mut rng,
                 )
                 .expect("failed to send `Add` input");
+            assert!(step.output.is_empty());
             awaiting_addition_input.remove(&node_id);
             println!("Node {} started readding.", node_id);
         }


### PR DESCRIPTION
Fixes #369.

The fix mostly amounts to improving how removed nodes are handled in `VirtualNet`.

The sender queue algorithm now flags itself if it was removed. The user can check the flag `is_removed` to shut down the node.