### PR TITLE
Use Rust 2018 idioms consistently.

### DIFF
--- a/examples/network/commst.rs
+++ b/examples/network/commst.rs
@@ -14,7 +14,7 @@ use hbbft::SourcedMessage;
 
 /// A communication task connects a remote node to the thread that manages the
 /// consensus algorithm.
-pub struct CommsTask<'a, M: 'a> {
+pub struct CommsTask<'a, M> {
     /// The transmit side of the multiple producer channel from comms threads.
     tx: &'a Sender<SourcedMessage<M, usize>>,
     /// The receive side of the channel to the comms thread.

--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -522,7 +522,7 @@ impl<N: NodeIdT, S: SessionIdT> BinaryAgreement<N, S> {
 }
 
 impl<N: NodeIdT, S: SessionIdT> fmt::Display for BinaryAgreement<N, S> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(
             f,
             "{:?} BA {} epoch {} ({})",

--- a/src/binary_agreement/bool_multimap.rs
+++ b/src/binary_agreement/bool_multimap.rs
@@ -34,7 +34,7 @@ impl<'a, N: Ord> IntoIterator for &'a BoolMultimap<N> {
     }
 }
 
-pub struct Iter<'a, N: 'a> {
+pub struct Iter<'a, N> {
     key: bool,
     set_iter: btree_set::Iter<'a, N>,
     map: &'a BoolMultimap<N>,

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -410,7 +410,7 @@ impl<N: NodeIdT> Broadcast<N> {
 }
 
 impl<N: NodeIdT> fmt::Display for Broadcast<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(f, "{:?} Broadcast({:?})", self.our_id(), self.proposer_id)
     }
 }

--- a/src/broadcast/message.rs
+++ b/src/broadcast/message.rs
@@ -43,7 +43,7 @@ impl Distribution<Message> for Standard {
 }
 
 impl Debug for Message {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Message::Value(ref v) => f.debug_tuple("Value").field(&HexProof(v)).finish(),
             Message::Echo(ref v) => f.debug_tuple("Echo").field(&HexProof(v)).finish(),
@@ -52,10 +52,10 @@ impl Debug for Message {
     }
 }
 /// Wrapper for a `Proof`, to print the bytes as a shortened hexadecimal number.
-pub struct HexProof<'a, T: 'a>(pub &'a Proof<T>);
+pub struct HexProof<'a, T>(pub &'a Proof<T>);
 
 impl<'a, T: AsRef<[u8]>> fmt::Debug for HexProof<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "Proof {{ #{}, root_hash: {:0.10}, value: {:0.10}, .. }}",

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -536,7 +536,7 @@ where
     C: Contribution + Serialize + DeserializeOwned,
     N: NodeIdT + Serialize + DeserializeOwned,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(f, "{:?} DHB(era: {})", self.our_id(), self.era)
     }
 }

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -404,7 +404,7 @@ struct EpochId {
 }
 
 impl Display for EpochId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(f, "{}/{}", self.hb_id, self.epoch)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 #![allow(clippy::module_inception, clippy::new_ret_no_self)]
 #![warn(missing_docs)]
 
-pub extern crate threshold_crypto as crypto;
+pub use threshold_crypto as crypto;
 
 mod fault_log;
 mod messaging;

--- a/src/subset/subset.rs
+++ b/src/subset/subset.rs
@@ -170,7 +170,7 @@ impl<N: NodeIdT, S: SessionIdT> Subset<N, S> {
 }
 
 impl<N: NodeIdT, S: SessionIdT> fmt::Display for Subset<N, S> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(f, "{:?} Subset({})", self.our_id(), self.session_id)
     }
 }
@@ -185,7 +185,7 @@ pub struct BaSessionId<S> {
 }
 
 impl<S: fmt::Display> fmt::Display for BaSessionId<S> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(
             f,
             "subset {}, proposer #{}",

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -225,7 +225,7 @@ impl From<bincode::Error> for Error {
 pub struct Part(BivarCommitment, Vec<Ciphertext>);
 
 impl Debug for Part {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Part")
             .field(&format!("<degree {}>", self.0.degree()))
             .field(&format!("<{} rows>", self.1.len()))
@@ -242,7 +242,7 @@ impl Debug for Part {
 pub struct Ack(u64, Vec<Ciphertext>);
 
 impl Debug for Ack {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Ack")
             .field(&self.0)
             .field(&format!("<{} values>", self.1.len()))

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -271,7 +271,7 @@ impl<N: NodeIdT> ThresholdSign<N> {
 }
 
 impl<N: NodeIdT> fmt::Display for ThresholdSign<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(f, "{:?} TS({:?})", self.our_id(), self.doc_hash)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use hex_fmt::HexFmt;
 
 /// Prints a byte slice as shortened hexadecimal in debug output.
-pub fn fmt_hex<T: AsRef<[u8]>>(bytes: T, f: &mut fmt::Formatter) -> fmt::Result {
+pub fn fmt_hex<T: AsRef<[u8]>>(bytes: T, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "{:10}", HexFmt(bytes))
 }
 

--- a/tests/binary_agreement_mitm.rs
+++ b/tests/binary_agreement_mitm.rs
@@ -295,7 +295,7 @@ impl AbaCommonCoinAdversary {
         }
     }
 
-    fn inject_stage_messages(&mut self, net: &mut NetMutHandle<Algo, Self>) {
+    fn inject_stage_messages(&mut self, net: &mut NetMutHandle<'_, Algo, Self>) {
         if self.sent_stage_messages {
             return;
         }
@@ -378,7 +378,7 @@ impl AbaCommonCoinAdversary {
 }
 
 impl Adversary<Algo> for AbaCommonCoinAdversary {
-    fn pre_crank<R: Rng>(&mut self, mut net: NetMutHandle<Algo, Self>, rng: &mut R) {
+    fn pre_crank<R: Rng>(&mut self, mut net: NetMutHandle<'_, Algo, Self>, rng: &mut R) {
         self.inject_stage_messages(&mut net);
         net.sort_messages_by(|a, b| {
             a.payload()
@@ -414,7 +414,7 @@ impl Adversary<Algo> for AbaCommonCoinAdversary {
 
     fn tamper<R: Rng>(
         &mut self,
-        _: NetMutHandle<Algo, Self>,
+        _: NetMutHandle<'_, Algo, Self>,
         msg: NetMessage<Algo>,
         _rng: &mut R,
     ) -> Result<CpStep<Algo>, CrankError<Algo>> {

--- a/tests/net/err.rs
+++ b/tests/net/err.rs
@@ -66,7 +66,7 @@ impl<D> Display for CrankError<D>
 where
     D: ConsensusProtocol,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CrankError::HandleInput(err) => {
                 write!(f, "The algorithm could not process input: {:?}", err)
@@ -122,7 +122,7 @@ impl<D> Debug for CrankError<D>
 where
     D: ConsensusProtocol,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CrankError::HandleInput(err) => {
                 f.debug_struct("HandleInput").field("err", err).finish()
@@ -170,7 +170,7 @@ impl<D> failure::Fail for CrankError<D>
 where
     D: ConsensusProtocol + 'static,
 {
-    fn cause(&self) -> Option<&failure::Fail> {
+    fn cause(&self) -> Option<&dyn failure::Fail> {
         match self {
             CrankError::HandleInput(err) | CrankError::HandleInputAll(err) => Some(err),
             CrankError::HandleMessage { err, .. } => Some(err),

--- a/tests/net/mod.rs
+++ b/tests/net/mod.rs
@@ -82,7 +82,7 @@ impl<D> fmt::Debug for Node<D>
 where
     D: ConsensusProtocol,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Node")
             .field("algorithm", &"yes")
             .field("is_faulty", &self.is_faulty)
@@ -317,7 +317,7 @@ where
     /// Number of faulty nodes in the network.
     num_faulty: usize,
     /// Dist-algorithm constructor function.
-    cons: Option<Box<Fn(NewNodeInfo<D>) -> (D, CpStep<D>)>>,
+    cons: Option<Box<dyn Fn(NewNodeInfo<D>) -> (D, CpStep<D>)>>,
     /// Network adversary.
     adversary: Option<A>,
     /// Trace-enabling flag. `None` means use environment.
@@ -338,7 +338,7 @@ where
     D: ConsensusProtocol,
     A: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NetBuilder")
             .field("node_ids", &())
             .field("num_faulty", &self.num_faulty)

--- a/tests/network/mod.rs
+++ b/tests/network/mod.rs
@@ -142,7 +142,7 @@ pub struct MessageWithSender<D: ConsensusProtocol> {
 // The Debug implementation cannot be derived automatically, possibly due to a compiler bug. For
 // this reason, it is implemented manually here.
 impl<D: ConsensusProtocol> fmt::Debug for MessageWithSender<D> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "MessageWithSender {{ sender: {:?}, tm: {:?} }}",


### PR DESCRIPTION
Apply `cargo fix --edition-idioms`.