### PR TITLE
Add `honey_badger` getter for `DynamicHoneyBadger`

### DIFF
--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -230,6 +230,11 @@ where
         &self.netinfo
     }
 
+    /// Returns a reference to the internal managed `HoneyBadger` instance.
+    pub fn honey_badger(&self) -> &HoneyBadger<InternalContrib<C, N>, N> {
+        &self.honey_badger
+    }
+
     /// Returns `true` if we should make our contribution for the next epoch, even if we don't have
     /// content ourselves, to avoid stalling the network.
     ///

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -196,7 +196,7 @@ impl<N: NodeIdT> KeyGenState<N> {
 /// The contribution for the internal `HoneyBadger` instance: this includes a user-defined
 /// application-level contribution as well as internal signed messages.
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, Hash)]
-struct InternalContrib<C, N: Ord> {
+pub struct InternalContrib<C, N: Ord> {
     /// A user-defined contribution.
     contrib: C,
     /// Key generation messages that get committed via Honey Badger to communicate synchronously.


### PR DESCRIPTION
related to issue #381 
Makes possible to get an immutable reference to the `HoneyBadger` contained in a `DynamicHoneyBadger`