### PR TITLE
Fix a SyncKeyGen and a DHB test issue.

### DIFF
--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -487,7 +487,7 @@ impl<N: NodeIdT> SyncKeyGen<N> {
             return Err(PartFault::RowCount);
         }
         if let Some(state) = self.parts.get(&sender_idx) {
-            if *state != ProposalState::new(commit) {
+            if state.commit != commit {
                 return Err(PartFault::MultipleParts);
             }
             return Ok(None); // We already handled this `Part` before.


### PR DESCRIPTION
`SyncKeyGen` should tolerate duplicate `Part` messages as long as they are identical.

The `drop_and_re_add` test had an arithmetic overflow, because it tried to remove more faulty nodes than nodes in total.

I also renamed `shutdown_epoch` to `re_add_epoch` in the test, because that's what it seems to actually do.