### PR TITLE
Don't drop re-added peers from sender queue.

### DIFF
--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -287,6 +287,11 @@ where
                 for id in &next_participants {
                     if id != self.our_id() {
                         self.peer_epochs.entry(id.clone()).or_default();
+                        if let Some(&last) = self.last_epochs.get(id) {
+                            if last < batch.output_epoch() {
+                                self.last_epochs.remove(id);
+                            }
+                        }
                     }
                 }
                 debug!(


### PR DESCRIPTION
If a previously removed peer gets added back as a validator, `SenderQueue` now removes that peer from `last_epochs`, so it doesn't drop it later.

(Also minor cleanups in the `net_dynamic_hb` test module.)

Closes #390.