### PR TITLE
Use the serde derive feature and update other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.31.0
+    - 1.33.0
 cache:
   cargo: true
   timeout: 1200

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hbbft"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Vladimir Komendantskiy <komendantsky@gmail.com>",
     "Andreas Fackler <AndreasFackler@gmx.de>",
@@ -21,20 +21,20 @@ edition = "2018"
 travis-ci = { repository = "poanetwork/hbbft" }
 
 [dependencies]
-bincode = "1.0.0"
-byteorder = "1.2.3"
-derivative = "1.0.1"
-env_logger = "0.6.0"
-failure = "0.1"
+bincode = "1.1.2"
+byteorder = "1.3.1"
+derivative = "1.0.2"
+env_logger = "0.6.1"
+failure = "0.1.5"
 hex_fmt = "0.3"
 init_with = "1.1.0"
-log = "0.4.1"
-rand = "0.6.1"
+log = "0.4.6"
+rand = "0.6.5"
 rand_derive = "0.5.0"
 reed-solomon-erasure = "3.1.1"
-serde = "1.0.82"
-serde_derive = "1.0.82"
-threshold_crypto = "0.3.0"
+serde = { version = "1.0.89", features = ["derive"] }
+# FIXME: update to threshold_crypto = "0.3.1" as soon as that is uploaded to crates.io
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "vk-serde-derive-feature" }
 tiny-keccak = "1.4"
 
 [dev-dependencies]
@@ -43,10 +43,10 @@ crossbeam = "0.6"
 crossbeam-channel = "0.3"
 docopt = "1.0"
 itertools = "0.8.0"
-rand_xorshift = "0.1.0"
+rand_xorshift = "0.1.1"
 signifix = "0.9"
 proptest = "0.8.7"
-integer-sqrt = "0.1.1"
+integer-sqrt = "0.1.2"
 
 [[example]]
 name = "consensus-node"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ rand = "0.6.5"
 rand_derive = "0.5.0"
 reed-solomon-erasure = "3.1.1"
 serde = { version = "1.0.89", features = ["derive"] }
-# FIXME: update to threshold_crypto = "0.3.1" as soon as that is uploaded to crates.io
-threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "vk-serde-derive-feature" }
+threshold_crypto = "0.3.1"
 tiny-keccak = "1.4"
 
 [dev-dependencies]

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -7,9 +7,7 @@ use docopt::Docopt;
 use itertools::Itertools;
 use rand::{distributions::Standard, rngs::OsRng, seq::SliceRandom, Rng};
 use rand_derive::Rand;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use serde_derive::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use signifix::{metric, TryFrom};
 
 use hbbft::dynamic_honey_badger::DynamicHoneyBadger;

--- a/src/binary_agreement/bool_set.rs
+++ b/src/binary_agreement/bool_set.rs
@@ -1,7 +1,7 @@
 //! A single-byte representation of a set of boolean values.
 
 use rand_derive::Rand;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// The empty set of boolean values.
 pub const NONE: BoolSet = BoolSet(0b00);

--- a/src/binary_agreement/mod.rs
+++ b/src/binary_agreement/mod.rs
@@ -73,7 +73,7 @@ use failure::Fail;
 use rand::distributions::{Distribution, Standard};
 use rand::{seq::SliceRandom, Rng};
 use rand_derive::Rand;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use self::bool_set::BoolSet;
 use crate::threshold_sign;

--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use rand::distributions::{Distribution, Standard};
 use rand::{seq::SliceRandom, Rng};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::bool_multimap::BoolMultimap;
 use super::bool_set::{self, BoolSet};

--- a/src/broadcast/merkle.rs
+++ b/src/broadcast/merkle.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tiny_keccak::sha3_256;
 
 pub type Digest = [u8; 32];

--- a/src/broadcast/message.rs
+++ b/src/broadcast/message.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Debug};
 use hex_fmt::HexFmt;
 use rand::distributions::{Distribution, Standard};
 use rand::{self, seq::SliceRandom, Rng};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::merkle::{Digest, MerkleTree, Proof};
 

--- a/src/dynamic_honey_badger/change.rs
+++ b/src/dynamic_honey_badger/change.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::crypto::PublicKey;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::EncryptionSchedule;
 

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -75,7 +75,7 @@ mod votes;
 use std::collections::BTreeMap;
 
 use crate::crypto::{PublicKey, PublicKeySet, Signature};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use self::votes::{SignedVote, VoteCounter};
 use crate::honey_badger::{EncryptionSchedule, Message as HbMessage, Params};

--- a/src/dynamic_honey_badger/votes.rs
+++ b/src/dynamic_honey_badger/votes.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use crate::crypto::Signature;
 use bincode;
-use serde::Serialize;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::{Change, Error, FaultKind, Result};
 use crate::fault_log;

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -10,8 +10,7 @@ use crate::crypto::Ciphertext;
 use bincode;
 use log::error;
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
-use serde_derive::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::{Batch, Error, FaultKind, FaultLog, MessageContent, Result, Step};
 use crate::fault_log::Fault;

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use derivative::Derivative;
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
-use serde_derive::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::epoch_state::EpochState;
 use super::{Batch, Error, FaultKind, HoneyBadgerBuilder, Message, Result};

--- a/src/honey_badger/message.rs
+++ b/src/honey_badger/message.rs
@@ -3,7 +3,7 @@
 
 use rand::distributions::{Distribution, Standard};
 use rand::{seq::SliceRandom, Rng};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::subset;
 use crate::threshold_decrypt;

--- a/src/honey_badger/params.rs
+++ b/src/honey_badger/params.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::{EncryptionSchedule, SubsetHandlingStrategy};
 

--- a/src/sender_queue/message.rs
+++ b/src/sender_queue/message.rs
@@ -1,6 +1,6 @@
 use rand::distributions::{Distribution, Standard};
 use rand::{seq::SliceRandom, Rng};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::SenderQueueableMessage;
 

--- a/src/subset/message.rs
+++ b/src/subset/message.rs
@@ -1,7 +1,7 @@
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use rand_derive::Rand;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::binary_agreement;
 use crate::broadcast;

--- a/src/subset/subset.rs
+++ b/src/subset/subset.rs
@@ -5,7 +5,7 @@ use std::{fmt, result};
 use derivative::Derivative;
 use hex_fmt::HexFmt;
 use log::debug;
-use serde_derive::Serialize;
+use serde::Serialize;
 
 use super::proposal_state::{ProposalState, Step as ProposalStep};
 use super::{Error, FaultKind, Message, MessageContent, Result};

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -187,7 +187,7 @@ use crate::pairing::{CurveAffine, Field};
 use bincode;
 use failure::Fail;
 use rand;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{NetworkInfo, NodeIdT};
 

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -18,7 +18,7 @@ use crate::crypto::{self, Ciphertext, DecryptionShare};
 use failure::Fail;
 use rand::Rng;
 use rand_derive::Rand;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::fault_log::{self, Fault};
 use crate::{ConsensusProtocol, NetworkInfo, NodeIdT, Target};

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -24,7 +24,7 @@ use failure::Fail;
 use log::debug;
 use rand::Rng;
 use rand_derive::Rand;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::fault_log::{Fault, FaultLog};
 use crate::{ConsensusProtocol, NetworkInfo, NodeIdT, Target};


### PR DESCRIPTION
This addresses the problem in poanetwork/threshold_crypto#78. The `threshold_crypto` dependency in this PR needs to be changed after `threshold_crypto` 0.3.1 is uploaded to crates.io.