### PR TITLE
Fix BA message handling on epoch change.

### DIFF
--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -112,12 +112,10 @@ impl<N: NodeIdT> SbvBroadcast<N> {
     /// Upon receiving _f + 1_ `BVal(b)`, multicasts `BVal(b)`. Upon receiving _2 f + 1_ `BVal(b)`,
     /// updates `bin_values`. When `bin_values` gets its first entry, multicasts `Aux(b)`.
     pub fn handle_bval(&mut self, sender_id: &N, b: bool) -> Result<Step<N>> {
-        let count_bval = {
-            if !self.received_bval[b].insert(sender_id.clone()) {
-                return Ok(Fault::new(sender_id.clone(), FaultKind::DuplicateBVal).into());
-            }
-            self.received_bval[b].len()
-        };
+        if !self.received_bval[b].insert(sender_id.clone()) {
+            return Ok(Fault::new(sender_id.clone(), FaultKind::DuplicateBVal).into());
+        }
+        let count_bval = self.received_bval[b].len();
 
         let mut step = Step::default();
 


### PR DESCRIPTION
Binary agreement erroneously kept handling queued incoming messages for an epoch `n`, even if during the handling, the epoch was incremented to `n + 1`. This caused `DuplicateAux` faults in the tests, but it could potentially break consensus.

Closes #392.