### PR TITLE
Change the `Target` variants.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
     - 1.36.0
 cache:
   cargo: true
-  timeout: 1200
+  timeout: 2400
 addons:
   apt:
     packages:
@@ -21,4 +21,4 @@ before_install:
 #   # causing a CI slowdown, so this option is commented out by default. It can
 #   # be enabled per-branch to debug issues.
 #   - sudo tail -n 250 /var/log/syslog
-script: ./ci.sh
+script: travis_wait 40 ./ci.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ colored = "1.7"
 crossbeam = "0.7.1"
 crossbeam-channel = "0.3"
 docopt = "1.0"
-hbbft_testing = { path = "hbbft_testing" }
+hbbft_testing = { path = "hbbft_testing", features = ["use-insecure-test-only-mock-crypto"] }
 itertools = "0.8.0"
 signifix = "0.10.0"
 proptest = "0.9.2"

--- a/ci.sh
+++ b/ci.sh
@@ -17,13 +17,11 @@ cargo fmt -- --check
 cargo test --features=use-insecure-test-only-mock-crypto --release
 cargo doc
 cargo deadlinks --dir target/doc/hbbft/
-# TODO: Remove exception once https://github.com/poanetwork/hbbft/issues/415 is fixed.
-cargo audit --ignore RUSTSEC-2019-0011
+cargo audit
 
 cd hbbft_testing
 cargo clippy --all-targets -- --deny clippy::all
 cargo fmt -- --check
 cargo test --features=use-insecure-test-only-mock-crypto --release
-# TODO: Remove exception once https://github.com/poanetwork/hbbft/issues/415 is fixed.
-cargo audit --ignore RUSTSEC-2019-0011
+cargo audit
 cd ..

--- a/ci.sh
+++ b/ci.sh
@@ -23,7 +23,7 @@ cargo audit --ignore RUSTSEC-2019-0011
 cd hbbft_testing
 cargo clippy --all-targets -- --deny clippy::all
 cargo fmt -- --check
-cargo test --release
+cargo test --features=use-insecure-test-only-mock-crypto --release
 # TODO: Remove exception once https://github.com/poanetwork/hbbft/issues/415 is fixed.
 cargo audit --ignore RUSTSEC-2019-0011
 cd ..

--- a/examples/network/messaging.rs
+++ b/examples/network/messaging.rs
@@ -85,6 +85,8 @@ impl<M: Send> Messaging<M> {
     }
 
     /// Spawns the message delivery thread in a given thread scope.
+    // TODO: Remove this once https://github.com/crossbeam-rs/crossbeam/issues/404 is resolved.
+    #[allow(clippy::drop_copy, clippy::zero_ptr)]
     pub fn spawn<'a, 'scope>(
         &self,
         scope: &'scope Scope<'a>,

--- a/examples/network/messaging.rs
+++ b/examples/network/messaging.rs
@@ -2,7 +2,6 @@
 use crossbeam::thread::{Scope, ScopedJoinHandle};
 use crossbeam_channel::{self, bounded, select, unbounded, Receiver, Sender};
 use hbbft::{SourcedMessage, Target, TargetedMessage};
-use std::collections::BTreeSet;
 
 /// The queue functionality for messages sent between algorithm instances.
 /// The messaging struct allows for targeted message exchange between comms
@@ -108,43 +107,15 @@ impl<M: Send> Messaging<M> {
                 select! {
                     recv(rx_from_algo) -> tm => {
                         if let Ok(tm) = tm {
-                            match &tm.target {
-                                Target::All => {
-                                    // Send the message to all remote nodes, stopping at the first
-                                    // error.
-                                    result = txs_to_comms.iter()
-                                        .fold(Ok(()), |result, tx| {
-                                            if result.is_ok() {
-                                                tx.send(tm.message.clone())
-                                            } else {
-                                                result
-                                            }
-                                        }).map_err(Error::from);
-                                },
-                                Target::AllExcept(exclude) => {
-                                    // Send the message to all remote nodes not in `exclude`, stopping at the first
-                                    // error.
-                                    let filtered_txs: Vec<_> = (0..txs_to_comms.len())
-                                        .collect::<BTreeSet<_>>()
-                                        .difference(exclude)
-                                        .cloned()
-                                        .collect();
-                                    result = filtered_txs.iter()
-                                        .fold(Ok(()), |result, i| {
-                                            if result.is_ok() {
-                                                txs_to_comms[*i].send(tm.message.clone())
-                                            } else {
-                                                result
-                                            }
-                                        }).map_err(Error::from);
-                                },
-                                Target::Node(i) => {
-                                    result = if *i < txs_to_comms.len() {
-                                        txs_to_comms[*i].send(tm.message)
-                                            .map_err(Error::from)
-                                    } else {
-                                        Err(Error::NoSuchTarget)
-                                    };
+                            if match tm.target {
+                                Target::AllExcept(ref ids) => ids,
+                                Target::Nodes(ref ids) => ids,
+                            }.iter().any(|i| *i >= txs_to_comms.len()) {
+                                return Err(Error::NoSuchTarget);
+                            }
+                            for (i, tx) in txs_to_comms.iter().enumerate() {
+                                if tm.target.contains(&i) {
+                                    tx.send(tm.message.clone())?;
                                 }
                             }
                         }

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -273,25 +273,9 @@ where
         Q: IntoIterator<Item = TimestampedMessage<D>>,
     {
         for ts_msg in msgs {
-            match &ts_msg.target {
-                Target::All => {
-                    for node in self.nodes.values_mut() {
-                        if node.id != ts_msg.sender_id {
-                            node.add_message(ts_msg.clone())
-                        }
-                    }
-                }
-                Target::AllExcept(exclude) => {
-                    for node in self.nodes.values_mut().filter(|n| !exclude.contains(&n.id)) {
-                        if node.id != ts_msg.sender_id {
-                            node.add_message(ts_msg.clone())
-                        }
-                    }
-                }
-                Target::Node(to_id) => {
-                    if let Some(node) = self.nodes.get_mut(&to_id) {
-                        node.add_message(ts_msg);
-                    }
+            for node in self.nodes.values_mut() {
+                if ts_msg.target.contains(&node.id) && node.id != ts_msg.sender_id {
+                    node.add_message(ts_msg.clone())
                 }
             }
         }

--- a/hbbft_testing/Cargo.toml
+++ b/hbbft_testing/Cargo.toml
@@ -29,3 +29,6 @@ proptest = "0.9.2"
 rand = "0.6.5"
 rand_xorshift = "0.1.1"
 threshold_crypto = "0.3.1"
+
+[features]
+use-insecure-test-only-mock-crypto = ["hbbft/use-insecure-test-only-mock-crypto"]

--- a/hbbft_testing/src/lib.rs
+++ b/hbbft_testing/src/lib.rs
@@ -237,9 +237,8 @@ where
 
     // Queue all messages for processing.
     for tmsg in &step.messages {
-        match &tmsg.target {
-            // Single target message.
-            hbbft::Target::Node(to) => {
+        for to in nodes.keys() {
+            if tmsg.target.contains(to) && to != &stepped_id {
                 if !faulty {
                     message_count = message_count.saturating_add(1);
                 }
@@ -249,36 +248,6 @@ where
                     tmsg.message.clone(),
                     to.clone(),
                 ));
-            }
-            // Broadcast messages get expanded into multiple direct messages.
-            hbbft::Target::All => {
-                for to in nodes.keys().filter(|&to| to != &stepped_id) {
-                    if !faulty {
-                        message_count = message_count.saturating_add(1);
-                    }
-
-                    dest.push_back(NetworkMessage::new(
-                        stepped_id.clone(),
-                        tmsg.message.clone(),
-                        to.clone(),
-                    ));
-                }
-            }
-            hbbft::Target::AllExcept(exclude) => {
-                for to in nodes
-                    .keys()
-                    .filter(|&to| to != &stepped_id && !exclude.contains(to))
-                {
-                    if !faulty {
-                        message_count = message_count.saturating_add(1);
-                    }
-
-                    dest.push_back(NetworkMessage::new(
-                        stepped_id.clone(),
-                        tmsg.message.clone(),
-                        to.clone(),
-                    ));
-                }
             }
         }
     }

--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -386,7 +386,7 @@ impl<N: NodeIdT, S: SessionIdT> BinaryAgreement<N, S> {
         if !self.netinfo.is_validator() {
             return Ok(Step::default());
         }
-        let step: Step<N> = Target::All
+        let step: Step<N> = Target::all()
             .message(content.clone().with_epoch(self.epoch))
             .into();
         let our_id = &self.our_id().clone();
@@ -462,7 +462,7 @@ impl<N: NodeIdT, S: SessionIdT> BinaryAgreement<N, S> {
         debug!("{}: decision: {}", self, b);
         if self.netinfo.is_validator() {
             let msg = MessageContent::Term(b).with_epoch(self.epoch + 1);
-            step.messages.push(Target::All.message(msg));
+            step.messages.push(Target::all().message(msg));
         }
         step
     }

--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -141,7 +141,7 @@ impl<N: NodeIdT> SbvBroadcast<N> {
         if !self.netinfo.is_validator() {
             return self.try_output();
         }
-        let step: Step<_> = Target::All.message(msg.clone()).into();
+        let step: Step<_> = Target::all().message(msg.clone()).into();
         let our_id = &self.netinfo.our_id().clone();
         Ok(step.join(self.handle_message(our_id, &msg)?))
     }

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -209,27 +209,10 @@
 //!         message: TargetedMessage { target, message },
 //!     }) = messages.pop_front()
 //!     {
-//!         match target {
-//!             Target::All => {
-//!                 for (id, node) in &mut nodes {
-//!                     let step = node.handle_message(&source, message.clone())?;
-//!                     on_step(*id, step, &mut messages, &mut finished_nodes);
-//!                 }
-//!             }
-//!             Target::AllExcept(exclude) => {
-//!                for (id, node) in nodes.iter_mut().filter(|&(id, _)| !exclude.contains(id)) {
-//!                    let step = node.handle_message(&source, message.clone())?;
-//!                    on_step(*id, step, &mut messages, &mut finished_nodes);
-//!                }
-//!            }
-//!             Target::Node(id) => {
-//!                 let step = {
-//!                     let node = nodes.get_mut(&id).unwrap();
-//!                     node.handle_message(&source, message)?
-//!                 };
-//!                 on_step(id, step, &mut messages, &mut finished_nodes);
-//!             }
-//!         };
+//!         for (id, node) in nodes.iter_mut().filter(|&(id, _)| target.contains(id)) {
+//!             let step = node.handle_message(&source, message.clone())?;
+//!             on_step(*id, step, &mut messages, &mut finished_nodes);
+//!         }
 //!     }
 //!     // Every node should output exactly once. Here we check the second half of this statement,
 //!     // namely that every node outputs.

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -172,7 +172,7 @@ where
         }
         let signed_vote = self.vote_counter.sign_vote_for(change)?.clone();
         let msg = Message::SignedVote(signed_vote);
-        Ok(Target::All.message(msg).into())
+        Ok(Target::all().message(msg).into())
     }
 
     /// Casts a vote to add a node as a validator.
@@ -494,7 +494,7 @@ where
             self.key_gen_msg_buffer.push(signed_msg);
         }
         let msg = Message::KeyGen(self.era, kg_msg, sig);
-        Ok(Target::All.message(msg).into())
+        Ok(Target::all().message(msg).into())
     }
 
     /// If the current Key Generation process is ready, returns the `KeyGenState`.

--- a/src/dynamic_honey_badger/mod.rs
+++ b/src/dynamic_honey_badger/mod.rs
@@ -34,7 +34,7 @@
 //! New observers can only join the network after an epoch where `change` was not `None`. These
 //! epochs' batches contain a `JoinPlan`, which can be sent as an invitation to the new node: The
 //! `DynamicHoneyBadger` instance created from a `JoinPlan` will start as an observer in the
-//! following epoch. All `Target::All` messages from that and later epochs must be sent to the new
+//! following epoch. All `Target::all()` messages from that and later epochs must be sent to the new
 //! node.
 //!
 //! Observer nodes can leave the network at any time.

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -258,7 +258,7 @@ where
             .filter_map(|key| queue.remove(&key))
             .flatten()
             .filter(|msg| !msg.is_obsolete(epoch))
-            .map(|msg| Target::Node(sender_id.clone()).message(Message::Algo(msg)))
+            .map(|msg| Target::node(sender_id.clone()).message(Message::Algo(msg)))
             .into()
     }
 
@@ -318,9 +318,8 @@ where
         }
         if !self.is_removed || send_last_epoch_started {
             // Announce the new epoch.
-            Target::All
-                .message(Message::EpochStarted(self.algo.epoch()))
-                .into()
+            let msg = Message::EpochStarted(self.algo.epoch());
+            Target::all().message(msg).into()
         } else {
             // If removed, do not announce the new epoch to prevent peers from sending messages to
             // this node.
@@ -329,7 +328,7 @@ where
     }
 
     /// Removes any messages to nodes at earlier epochs from the given `Step`. This may involve
-    /// decomposing a `Target::All` message into `Target::Node` messages and sending some of the
+    /// decomposing a `Target::all()` message into `Target::Nodes` messages and sending some of the
     /// resulting messages while placing onto the queue those remaining messages whose recipient is
     /// currently at an earlier epoch.
     fn defer_messages(&mut self, step: &mut CpStep<D>) {
@@ -444,7 +443,7 @@ where
             participants_after_change: BTreeSet::new(),
             is_removed: false,
         };
-        let step = Target::All.message(Message::EpochStarted(epoch)).into();
+        let step = Target::all().message(Message::EpochStarted(epoch)).into();
         (sq, step)
     }
 }

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -162,7 +162,7 @@ impl<N: NodeIdT> ThresholdDecrypt<N> {
             (_, _) => return Ok(step.join(self.try_output()?)), // Not a validator.
         };
         let our_id = self.our_id().clone();
-        let msg = Target::All.message(Message(share.clone()));
+        let msg = Target::all().message(Message(share.clone()));
         step.messages.push(msg);
         self.shares.insert(our_id, (idx, share));
         step.extend(self.try_output()?);

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -167,7 +167,7 @@ impl<N: NodeIdT> ThresholdSign<N> {
             Some(sks) => Message(sks.sign_g2(hash)),
             None => return Ok(step.join(self.try_output()?)), // Not a validator.
         };
-        step.messages.push(Target::All.message(msg.clone()));
+        step.messages.push(Target::all().message(msg.clone()));
         let id = self.our_id().clone();
         step.extend(self.handle_message(&id, msg)?);
         Ok(step)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -285,9 +285,7 @@ where
                             }
                         }
                     }
-                    if exclude.len() < peer_epochs.len() {
-                        passed_msgs.push(Target::AllExcept(exclude).message(msg.message));
-                    }
+                    passed_msgs.push(Target::AllExcept(exclude).message(msg.message));
                 }
             }
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -255,56 +255,38 @@ where
         let mut passed_msgs: Vec<_> = Vec::new();
         for msg in self.messages.drain(..) {
             match msg.target.clone() {
-                Target::Node(id) => {
-                    if let Some(&them) = peer_epochs.get(&id) {
-                        if msg.message.is_premature(them, max_future_epochs) {
-                            deferred_msgs.push((id, msg.message));
-                        } else if !msg.message.is_obsolete(them) {
-                            passed_msgs.push(msg);
-                        }
-                    }
-                }
-                Target::All => {
-                    let is_accepted = |&them| msg.message.is_accepted(them, max_future_epochs);
+                Target::Nodes(mut ids) => {
                     let is_premature = |&them| msg.message.is_premature(them, max_future_epochs);
                     let is_obsolete = |&them| msg.message.is_obsolete(them);
-                    if peer_epochs.values().all(is_accepted) {
-                        passed_msgs.push(msg);
-                    } else {
-                        // The `Target::All` message is split into two sets of point messages: those
-                        // which can be sent without delay and those which should be postponed.
-                        for (id, them) in peer_epochs {
+                    for (id, them) in peer_epochs {
+                        if ids.contains(id) {
                             if is_premature(them) {
                                 deferred_msgs.push((id.clone(), msg.message.clone()));
-                            } else if !is_obsolete(them) {
-                                passed_msgs
-                                    .push(Target::Node(id.clone()).message(msg.message.clone()));
+                                ids.remove(id);
+                            } else if is_obsolete(them) {
+                                ids.remove(id);
                             }
                         }
                     }
+                    if !ids.is_empty() {
+                        passed_msgs.push(Target::Nodes(ids).message(msg.message));
+                    }
                 }
-                Target::AllExcept(exclude) => {
-                    let is_accepted = |&them| msg.message.is_accepted(them, max_future_epochs);
+                Target::AllExcept(mut exclude) => {
                     let is_premature = |&them| msg.message.is_premature(them, max_future_epochs);
                     let is_obsolete = |&them| msg.message.is_obsolete(them);
-                    let filtered_nodes: BTreeMap<_, _> = peer_epochs
-                        .iter()
-                        .filter(|(id, _)| !exclude.contains(id))
-                        .map(|(k, v)| (k.clone(), *v))
-                        .collect();
-                    if filtered_nodes.values().all(is_accepted) {
-                        passed_msgs.push(msg);
-                    } else {
-                        // The `Target::AllExcept` message is split into two sets of point messages: those
-                        // which can be sent without delay and those which should be postponed.
-                        for (id, them) in &filtered_nodes {
+                    for (id, them) in peer_epochs {
+                        if !exclude.contains(id) {
                             if is_premature(them) {
                                 deferred_msgs.push((id.clone(), msg.message.clone()));
-                            } else if !is_obsolete(them) {
-                                passed_msgs
-                                    .push(Target::Node(id.clone()).message(msg.message.clone()));
+                                exclude.insert(id.clone());
+                            } else if is_obsolete(them) {
+                                exclude.insert(id.clone());
                             }
                         }
+                    }
+                    if exclude.len() < peer_epochs.len() {
+                        passed_msgs.push(Target::AllExcept(exclude).message(msg.message));
                     }
                 }
             }

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -108,7 +108,7 @@ impl Adversary<UsizeHoneyBadger> for FaultyShareAdversary {
                     // Send the share to remote nodes.
                     for proposer_id in &all_node_ids {
                         step.messages.push(
-                            Target::All.message(sender_queue::Message::Algo(
+                            Target::all().message(sender_queue::Message::Algo(
                                 MessageContent::DecryptionShare {
                                     proposer_id: *proposer_id,
                                     share: threshold_decrypt::Message(share.clone()),


### PR DESCRIPTION
`Target` now only has a `Nodes` and an `AllExcept` variant, to specify
a message's target via a whitelist or blacklist. This avoids cloning
the message content and simplifies the code in several places.

Closes #408, closes #415.