### PR TITLE
Add HoneyBadger::skip_to_epoch and NetworkInfo::other_ids.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.35.0
+    - 1.36.0
 cache:
   cargo: true
   timeout: 1200

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ _**Note:** Additional examples are currently in progress._
 
 ### Build
 
-Requires Rust 1.30 or higher and `cargo`: [installation instructions.](https://www.rust-lang.org/en-US/install.html) The library is tested against the `stable` release channel.
+Requires Rust 1.36 or higher and `cargo`: [installation instructions.](https://www.rust-lang.org/en-US/install.html) The library is tested against the `stable` release channel.
 
 ```
 $ cargo build [--release]

--- a/ci.sh
+++ b/ci.sh
@@ -17,13 +17,13 @@ cargo fmt -- --check
 cargo test --features=use-insecure-test-only-mock-crypto --release
 cargo doc
 cargo deadlinks --dir target/doc/hbbft/
-# TODO: Re-enable once https://github.com/poanetwork/hbbft/issues/415 is fixed.
-# cargo audit
+# TODO: Remove exception once https://github.com/poanetwork/hbbft/issues/415 is fixed.
+cargo audit --ignore RUSTSEC-2019-0011
 
 cd hbbft_testing
 cargo clippy --all-targets -- --deny clippy::all
 cargo fmt -- --check
 cargo test --release
-# TODO: Re-enable once https://github.com/poanetwork/hbbft/issues/415 is fixed.
-# cargo audit
+# TODO: Remove exception once https://github.com/poanetwork/hbbft/issues/415 is fixed.
+cargo audit --ignore RUSTSEC-2019-0011
 cd ..

--- a/ci.sh
+++ b/ci.sh
@@ -17,11 +17,13 @@ cargo fmt -- --check
 cargo test --features=use-insecure-test-only-mock-crypto --release
 cargo doc
 cargo deadlinks --dir target/doc/hbbft/
-cargo audit
+# TODO: Re-enable once https://github.com/poanetwork/hbbft/issues/415 is fixed.
+# cargo audit
 
 cd hbbft_testing
 cargo clippy --all-targets -- --deny clippy::all
 cargo fmt -- --check
 cargo test --release
-cargo audit
+# TODO: Re-enable once https://github.com/poanetwork/hbbft/issues/415 is fixed.
+# cargo audit
 cd ..

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -434,11 +434,7 @@ fn main() {
 
     let new_honey_badger = |netinfo: NetworkInfo<NodeId>, rng: &mut OsRng| {
         let our_id = *netinfo.our_id();
-        let peer_ids: Vec<_> = netinfo
-            .all_ids()
-            .filter(|&&them| them != our_id)
-            .cloned()
-            .collect();
+        let peer_ids: Vec<_> = netinfo.other_ids().cloned().collect();
         let dhb = DynamicHoneyBadger::builder().build(netinfo);
         let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
             .batch_size(args.flag_b)

--- a/src/honey_badger/honey_badger.rs
+++ b/src/honey_badger/honey_badger.rs
@@ -131,6 +131,16 @@ where
         self.epoch
     }
 
+    /// Skips all epochs before the specified one.
+    ///
+    /// This must only be called if it is guaranteed to be called in all instances that have not
+    /// progressed to that epoch yet. Otherwise an instance can be left behind in a skipped epoch.
+    pub fn skip_to_epoch(&mut self, epoch: u64) {
+        while self.epoch < epoch {
+            self.update_epoch();
+        }
+    }
+
     /// Returns the number of validators from which we have already received a proposal for the
     /// current epoch.
     ///

--- a/src/network_info.rs
+++ b/src/network_info.rs
@@ -86,6 +86,13 @@ impl<N: NodeIdT> NetworkInfo<N> {
         self.public_keys.keys()
     }
 
+    /// ID of all nodes in the network except this one.
+    #[inline]
+    pub fn other_ids(&self) -> impl Iterator<Item = &N> + Clone {
+        let our_id = self.our_id.clone();
+        self.public_keys.keys().filter(move |id| **id != our_id)
+    }
+
     /// The total number _N_ of nodes.
     #[inline]
     pub fn num_nodes(&self) -> usize {

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -109,11 +109,7 @@ fn do_drop_and_re_add(cfg: TestConfig) {
                 id
             );
             let dhb = DynamicHoneyBadger::builder().build(node.netinfo.clone());
-            SenderQueue::builder(
-                dhb,
-                node.netinfo.all_ids().filter(|&&them| them != id).cloned(),
-            )
-            .build(node.id)
+            SenderQueue::builder(dhb, node.netinfo.other_ids().cloned()).build(node.id)
         })
         .build(&mut rng)
         .expect("could not construct test network");

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -188,12 +188,12 @@ where
 fn new_honey_badger(
     netinfo: Arc<NetworkInfo<NodeId>>,
 ) -> (UsizeHoneyBadger, Step<HoneyBadger<Vec<usize>, NodeId>>) {
-    let our_id = *netinfo.our_id();
     let nc = netinfo.clone();
-    let peer_ids = nc.all_ids().filter(|&&them| them != our_id).cloned();
+    let peer_ids = nc.other_ids().cloned();
     let hb = HoneyBadger::builder(netinfo)
         .encryption_schedule(EncryptionSchedule::EveryNthEpoch(2))
         .build();
+    let our_id = *nc.our_id();
     SenderQueue::builder(hb, peer_ids).build(our_id)
 }
 

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -225,13 +225,13 @@ fn new_queueing_hb(
     seed: TestRngSeed,
 ) -> (QHB, Step<QueueingHoneyBadger<usize, NodeId, Vec<usize>>>) {
     let mut rng: TestRng = TestRng::from_seed(seed);
-    let our_id = *netinfo.our_id();
-    let peer_ids = netinfo.all_ids().filter(|&&them| them != our_id).cloned();
+    let peer_ids = netinfo.other_ids().cloned();
     let dhb = DynamicHoneyBadger::builder().build((*netinfo).clone());
     let (qhb, qhb_step) = QueueingHoneyBadger::builder(dhb)
         .batch_size(3)
         .build(&mut rng)
         .expect("failed to build QueueingHoneyBadger");
+    let our_id = *netinfo.our_id();
     let (sq, mut step) = SenderQueue::builder(qhb, peer_ids).build(our_id);
     let output = step.extend_with(qhb_step, |fault| fault, Message::from);
     assert!(output.is_empty());


### PR DESCRIPTION
This also disables `cargo audit` until #415 is fixed.

Closes #413.