### PR TITLE
Test that self is always omitted from Target.

### DIFF
--- a/hbbft_testing/src/lib.rs
+++ b/hbbft_testing/src/lib.rs
@@ -33,7 +33,7 @@ use hbbft::dynamic_honey_badger::Batch;
 use hbbft::sender_queue::SenderQueueableOutput;
 use hbbft::{
     self, to_pub_keys, ConsensusProtocol, Contribution, CpStep, Fault, NetworkInfo, NodeIdT,
-    PubKeyMap, Step,
+    PubKeyMap, Step, Target,
 };
 
 pub use self::adversary::Adversary;
@@ -241,6 +241,13 @@ where
 
     // Queue all messages for processing.
     for tmsg in &step.messages {
+        // Message targets never explicitly mention ourselves.
+        if !faulty {
+            match &tmsg.target {
+                Target::AllExcept(nodes) => assert!(!nodes.contains(&stepped_id)),
+                Target::Nodes(nodes) => assert!(!nodes.contains(&stepped_id)),
+            }
+        }
         for to in nodes.keys() {
             if tmsg.target.contains(to) && to != &stepped_id {
                 if !faulty {

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -494,18 +494,18 @@ impl<N: NodeIdT> Broadcast<N> {
         let can_decode_msg = Message::CanDecode(*hash);
         let mut step = Step::default();
 
+        let our_id = &self.our_id().clone();
         let recipients = self
             .val_set
             .all_ids()
             .filter(|id| match self.echos.get(id) {
-                Some(EchoContent::Hash(_)) | None => true,
+                Some(EchoContent::Hash(_)) | None => *id != our_id,
                 _ => false,
             })
             .cloned()
             .collect();
         let msg = Target::Nodes(recipients).message(can_decode_msg);
         step.messages.push(msg);
-        let our_id = &self.our_id().clone();
         Ok(step.join(self.handle_can_decode(our_id, hash)?))
     }
 


### PR DESCRIPTION
This guarantees that the sender's own ID is never included in the `Target`: neither in `Nodes`, nor in the exclusions in `AllExcept`. Messages are never meant to be handled by the sender.