### PR TITLE
Added accessor to "our_id" for SyncKeyGen

### DIFF
--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -425,6 +425,11 @@ impl<N: NodeIdT, PK: PublicKey> SyncKeyGen<N, PK> {
         Ok((key_gen, Some(Part(commit, rows))))
     }
 
+    /// Returns the id of this node.
+    pub fn our_id(&self) -> &N {
+        &self.our_id
+    }
+
     /// Returns the map of participating nodes and their public keys.
     pub fn public_keys(&self) -> &PubKeyMap<N, PK> {
         &self.pub_keys


### PR DESCRIPTION
When gathering Part and Ack messages I repeatedly ran into the situation where I needed to access the "sender" with the messages returned by `handle_part()` and `handle_ack()`. 
Without the ability to query the "our_id" member of SyncKeyGen directly that information had to be tediously tracked along with the collection of SyncKeyGen instances, complicating the code unnecessarily.