### PR TITLE
Fix QHB loop with 1 validator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.36.0
+    - 1.42.0
 cache:
   cargo: true
   timeout: 2400

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ travis-ci = { repository = "poanetwork/hbbft" }
 [dependencies]
 bincode = "1.2.0"
 byteorder = "1.3.2"
-derivative = "1.0.3"
+derivative = "2.0.2"
 env_logger = "0.7.1"
 failure = "0.1.6"
 hex_fmt = "0.3"
@@ -31,7 +31,7 @@ init_with = "1.1.0"
 log = "0.4.8"
 rand = "0.6.5"
 rand_derive = "0.5.0"
-reed-solomon-erasure = "3.1.1"
+reed-solomon-erasure = "4.0.1"
 serde = { version = "1.0.102", features = ["derive", "rc"] }
 threshold_crypto = { rev = "624eeee", git = "https://github.com/poanetwork/threshold_crypto" }
 tiny-keccak = { version = "2.0.1", features = ["sha3"]}
@@ -42,8 +42,8 @@ crossbeam = "0.7.3"
 crossbeam-channel = "0.4.0"
 docopt = "1.1.0"
 hbbft_testing = { path = "hbbft_testing", features = ["use-insecure-test-only-mock-crypto"] }
-itertools = "0.8.1"
-signifix = "0.10.0"
+itertools = "0.9.0"
+number_prefix = "0.3.0"
 proptest = "0.9.4"
 
 [[example]]
@@ -60,6 +60,4 @@ overflow-checks = true
 
 [features]
 use-insecure-test-only-mock-crypto = ["threshold_crypto/use-insecure-test-only-mock-crypto"]
-# TODO: Remove this feature once https://github.com/darrenldl/reed-solomon-erasure/issues/28 is
-#       resolved.
-no-simd = ["reed-solomon-erasure/pure-rust"]
+simd-accel = ["reed-solomon-erasure/simd-accel"]

--- a/examples/network/node.rs
+++ b/examples/network/node.rs
@@ -9,21 +9,18 @@
 //! use std::net::SocketAddr;
 //! use std::vec::Vec;
 //!
-//! fn main() {
-//!     let bind_address = "127.0.0.1:10001".parse().unwrap();
-//!     let remote_addresses = vec!["192.168.1.2:10002",
-//!                                 "192.168.1.3:10003",
-//!                                 "192.168.1.4:10004"]
-//!         .iter()
-//!         .map(|s| s.parse().unwrap())
-//!         .collect();
+//! let bind_address = "127.0.0.1:10001".parse().unwrap();
+//! let remote_addresses = vec!["192.168.1.2:10002",
+//!                             "192.168.1.3:10003",
+//!                             "192.168.1.4:10004"]
+//!     .iter()
+//!     .map(|s| s.parse().unwrap())
+//!     .collect();
 //!
-//!     let value = "Value #1".as_bytes().to_vec();
+//! let value = "Value #1".as_bytes().to_vec();
 //!
-//!     let result = Node::new(bind_address, remote_addresses, Some(value))
-//!         .run();
-//!     println!("Consensus result {:?}", result);
-//! }
+//! let result = Node::new(bind_address, remote_addresses, Some(value)).run();
+//! println!("Consensus result {:?}", result);
 //! ```
 //!
 //! Similar code shall then run on hosts 192.168.1.2, 192.168.1.3 and

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -1,15 +1,14 @@
 use std::collections::{BTreeMap, VecDeque};
-use std::convert::TryFrom;
 use std::time::{Duration, Instant};
 use std::{cmp, u64};
 
 use colored::*;
 use docopt::Docopt;
 use itertools::Itertools;
+use number_prefix::{NumberPrefix, Prefixed, Standalone};
 use rand::{distributions::Standard, rngs::OsRng, seq::SliceRandom, Rng};
 use rand_derive::Rand;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use signifix::metric;
 
 use hbbft::crypto::SecretKey;
 use hbbft::dynamic_honey_badger::DynamicHoneyBadger;
@@ -362,8 +361,11 @@ impl EpochInfo {
             max_t.as_secs() * 1000 + u64::from(max_t.subsec_nanos()) / 1_000_000,
             txs,
             network.message_count() / network.nodes.len(),
-            metric::Signifix::try_from(network.message_size() / network.nodes.len() as u64)
-                .unwrap(),
+            match NumberPrefix::decimal(network.message_size() as f64 / network.nodes.len() as f64)
+            {
+                Standalone(bytes) => format!("{:3.0}  ", bytes),
+                Prefixed(prefix, n) => format!("{:3.0} {}", n, prefix),
+            }
         );
     }
 }

--- a/hbbft_testing/src/proptest.rs
+++ b/hbbft_testing/src/proptest.rs
@@ -151,7 +151,7 @@ impl ValueTree for NetworkDimensionTree {
         self.high = self.current;
         self.current = (self.low + self.high) / 2;
 
-        (prev.high != self.high || prev.current != self.current)
+        prev.high != self.high || prev.current != self.current
     }
 
     fn complicate(&mut self) -> bool {
@@ -164,7 +164,7 @@ impl ValueTree for NetworkDimensionTree {
         self.low = self.current + 1;
         self.current = (self.low + self.high) / 2;
 
-        (prev.current != self.current || prev.low != self.low)
+        prev.current != self.current || prev.low != self.low
     }
 }
 

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -8,7 +8,7 @@ use hex_fmt::{HexFmt, HexList};
 use log::{debug, warn};
 use rand::Rng;
 use reed_solomon_erasure as rse;
-use reed_solomon_erasure::ReedSolomon;
+use reed_solomon_erasure::{galois_8::Field as Field8, ReedSolomon};
 
 use super::merkle::{Digest, MerkleTree, Proof};
 use super::message::HexProof;
@@ -638,7 +638,7 @@ impl<N: NodeIdT> fmt::Display for Broadcast<N> {
 #[derive(Debug)]
 enum Coding {
     /// A `ReedSolomon` instance with at least one parity shard.
-    ReedSolomon(Box<ReedSolomon>),
+    ReedSolomon(Box<ReedSolomon<Field8>>),
     /// A no-op replacement that doesn't encode or decode anything.
     Trivial(usize),
 }
@@ -681,7 +681,7 @@ impl Coding {
     /// If enough shards are present, reconstructs the missing ones.
     fn reconstruct_shards(&self, shards: &mut [Option<Box<[u8]>>]) -> RseResult<()> {
         match *self {
-            Coding::ReedSolomon(ref rs) => rs.reconstruct_shards(shards),
+            Coding::ReedSolomon(ref rs) => rs.reconstruct(shards),
             Coding::Trivial(_) => {
                 if shards.iter().all(Option::is_some) {
                     Ok(())

--- a/src/queueing_honey_badger/mod.rs
+++ b/src/queueing_honey_badger/mod.rs
@@ -343,11 +343,13 @@ where
         while self.can_propose() {
             let amount = cmp::max(1, self.batch_size / self.dyn_hb.netinfo().num_nodes());
             let proposal = self.queue.choose(rng, amount, self.batch_size);
-            step.extend(
-                self.dyn_hb
-                    .handle_input(Input::User(proposal), rng)
-                    .map_err(Error::Propose)?,
-            );
+            let propose_step = self
+                .dyn_hb
+                .handle_input(Input::User(proposal), rng)
+                .map_err(Error::Propose)?;
+            self.queue
+                .remove_multiple(propose_step.output.iter().flat_map(Batch::iter));
+            step.extend(propose_step);
         }
         Ok(step)
     }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -125,7 +125,7 @@ fn test_broadcast<A: Adversary<Broadcast<NodeId>>>(
             // verify that all other correct nodes have empty output as well.
             let first = net
                 .correct_nodes()
-                .nth(0)
+                .next()
                 .expect("At least one correct node needs to exist");
             assert!(first.outputs().is_empty());
             break;
@@ -136,7 +136,7 @@ fn test_broadcast<A: Adversary<Broadcast<NodeId>>>(
 
     if proposer_is_faulty {
         // If the proposer was faulty it is sufficient for all correct nodes having the same value.
-        let first = net.correct_nodes().nth(0).unwrap().outputs();
+        let first = net.correct_nodes().next().unwrap().outputs();
         assert!(net.nodes().all(|node| node.outputs() == first));
     } else {
         // In the case where the proposer was valid it must be the value it proposed.

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -41,7 +41,7 @@ where
     // Make two copies of all public keys.
     let pub_keys_add = net
         .correct_nodes()
-        .nth(0)
+        .next()
         .expect("At least one correct node needs to exist")
         .algorithm()
         .algo()
@@ -52,7 +52,7 @@ where
     let mut pub_keys_rm = pub_keys_add.clone();
 
     // Get the first correct node id as candidate for removal/re-adding.
-    let first_correct_node = *net.correct_nodes().nth(0).unwrap().id();
+    let first_correct_node = *net.correct_nodes().next().unwrap().id();
 
     // Remove the first correct node, which is to be removed.
     Arc::make_mut(&mut pub_keys_rm).remove(&first_correct_node);

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -251,7 +251,7 @@ fn test_queueing_honey_badger_different_sizes<A, F>(
 
     let mut rng: TestRng = TestRng::from_seed(seed);
 
-    let sizes = vec![3, 5, rng.gen_range(6, 10)];
+    let sizes = vec![2, 3, 5, rng.gen_range(6, 10)];
     for size in sizes {
         // The test is removing one correct node, so we allow fewer faulty ones.
         let num_adv_nodes = util::max_faulty(size - 1);

--- a/tests/subset.rs
+++ b/tests/subset.rs
@@ -40,7 +40,7 @@ fn test_subset<A>(
     //       or drop this TODO if we decide to abandon that concept.
     let expected_value: BTreeSet<_> = net
         .correct_nodes()
-        .nth(0)
+        .next()
         .unwrap()
         .outputs()
         .iter()

--- a/tests/threshold_sign.rs
+++ b/tests/threshold_sign.rs
@@ -66,7 +66,7 @@ where
         while !net.nodes().all(|node| node.algorithm().terminated()) {
             let _ = net.crank_expect(&mut rng);
         }
-        let node0 = net.correct_nodes().nth(0).unwrap();
+        let node0 = net.correct_nodes().next().unwrap();
         // Verify that all instances output the same value.
         assert_eq!(1, node0.outputs().len());
         assert!(net.nodes().all(|node| node.outputs() == node0.outputs()));
@@ -136,7 +136,7 @@ where
             while !net.nodes().all(|node| node.algorithm().terminated()) {
                 let _ = net.crank_expect(&mut rng);
             }
-            let node0 = net.correct_nodes().nth(0).unwrap();
+            let node0 = net.correct_nodes().next().unwrap();
             // Verify that all instances output the same value.
             assert_eq!(1, node0.outputs().len());
             assert!(net.nodes().all(|node| node.outputs() == node0.outputs()));


### PR DESCRIPTION
QHB needs to remove the output from the queue, even if it's during a `propose` call. In the case of a single validator, the `propose` call always immediately outputs, so forgetting about this caused an infinite loop.

The QHB test is extended to the case of 2 validators, which also tests a single one, since the QHB test removes and re-adds one of its validators.

Closes #432 